### PR TITLE
Add a custom prelude for `primer`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,11 @@
                   doHoogle = true;
                 }
                 {
+                  # mtl-compat doesn't generate HIE files.
+                  # https://github.com/input-output-hk/haskell.nix/issues/1242
+                  packages.mtl-compat.writeHieFiles = false;
+                }
+                {
                   #TODO This shouldn't be necessary - see the commented-out `build-tool-depends` in primer.cabal.
                   packages.primer.components.tests.primer-test.build-tools = [ final.haskell-nix.haskellPackages.tasty-discover ];
                 }

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -13,6 +13,7 @@ category:      Editor
 library
   exposed-modules:
     Control.Monad.Fresh
+    Foreword
     Primer.Action
     Primer.API
     Primer.App
@@ -39,6 +40,7 @@ library
 
   default-language:   Haskell2010
   default-extensions:
+    NoImplicitPrelude
     DataKinds
     DeriveDataTypeable
     DeriveGeneric
@@ -68,6 +70,7 @@ library
     , megaparsec         >=8.0.0    && <=9.2
     , mtl                >=2.2.2    && <=2.3
     , optics             >=0.4      && <=0.5
+    , protolude          ^>=0.3
     , recursion-schemes  >=5.1.3    && <=5.3
     , semigroups         >=0.19.1   && <=0.20
     , stm                >=2.5      && <=2.6
@@ -106,6 +109,7 @@ test-suite primer-test
 
   default-language:   Haskell2010
   default-extensions:
+    NoImplicitPrelude
     DataKinds
     DeriveDataTypeable
     DeriveGeneric
@@ -144,6 +148,7 @@ test-suite primer-test
       , mtl
       , optics
       , primer
+      , protolude
       , tasty              ^>=1.4.1
       , tasty-discover     ^>=4.2.2
       , tasty-golden       ^>=2.3.4

--- a/primer/src/Control/Monad/Fresh.hs
+++ b/primer/src/Control/Monad/Fresh.hs
@@ -2,11 +2,7 @@
 
 module Control.Monad.Fresh (MonadFresh (..)) where
 
-import Control.Monad.Except (ExceptT)
-import Control.Monad.Reader (ReaderT)
-import Control.Monad.State (StateT)
-import Control.Monad.Trans (lift)
-import Data.Monoid (Ap (Ap))
+import Foreword
 
 -- | This class gives access to a method @fresh@ which generates a new, unique
 --  value of type i.

--- a/primer/src/Control/Monad/NestedError.hs
+++ b/primer/src/Control/Monad/NestedError.hs
@@ -46,7 +46,8 @@
 --           throwError' SpecificError :: MonadError Bool m => m a
 module Control.Monad.NestedError where
 
-import Control.Monad.Except
+import Foreword
+
 import Data.Generics.Sum.Typed
 
 -- | This class is like MonadError but is parameterised by two error

--- a/primer/src/Foreword.hs
+++ b/primer/src/Foreword.hs
@@ -1,0 +1,45 @@
+module Foreword (
+  module Protolude,
+  module Unsafe,
+) where
+
+-- In general, we should defer to "Protolude"'s exports and avoid name
+-- clashes, but if there's a name that we really want to use and it's
+-- unlikely we'll need the "Protolude" version much, we hide the
+-- "Protolude" export. When we do hide a "Protolude" export, we try to
+-- hide related functions & types, as well, under the assumption that
+-- if you ever do need it, you can just import the original module
+-- qualified. Examples are "Control.Monad.STM", 'GHC.Generics.from',
+-- and 'GHC.Generics.to'.
+import Protolude hiding (
+  Meta,
+  OnDecodeError,
+  OnError,
+  STM,
+  Type,
+  TypeError,
+  TypeRep,
+  UnicodeException,
+  atomically,
+  cast,
+  catchSTM,
+  check,
+  eqT,
+  from,
+  gcast,
+  ignore,
+  lenientDecode,
+  orElse,
+  replace,
+  retry,
+  strictDecode,
+  throwSTM,
+  to,
+  typeOf,
+  typeRep,
+  (%),
+ )
+
+-- We should remove all uses of `unsafeHead`. See:
+-- https://github.com/hackworthltd/primer/issues/147
+import Protolude.Unsafe as Unsafe (unsafeHead)

--- a/primer/src/Primer/Core.hs
+++ b/primer/src/Primer/Core.hs
@@ -40,13 +40,13 @@ module Primer.Core (
   bindName,
 ) where
 
+import Foreword
+
 import Data.Aeson (Value)
 import Data.Data (Data)
 import Data.Generics.Product
 import Data.Generics.Uniplate.Data ()
 import Data.Generics.Uniplate.Zipper (Zipper, hole, replaceHole)
-import Data.List (foldl')
-import GHC.Generics hiding (Meta)
 import Optics (Lens', Traversal, lens, set, view, (%))
 import Primer.JSON
 import Primer.Name (Name)

--- a/primer/src/Primer/Core/DSL.hs
+++ b/primer/src/Primer/Core/DSL.hs
@@ -30,8 +30,9 @@ module Primer.Core.DSL (
   S,
 ) where
 
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh, fresh)
-import Control.Monad.State (MonadState, State, get, put, runState)
 import Optics (set)
 import Primer.Core (
   Bind' (..),

--- a/primer/src/Primer/Core/Transform.hs
+++ b/primer/src/Primer/Core/Transform.hs
@@ -7,7 +7,8 @@ module Primer.Core.Transform (
   removeAnn,
 ) where
 
-import Data.Bifunctor (second)
+import Foreword
+
 import Data.Data (Data)
 import Data.Generics.Uniplate.Data (descendM)
 import Primer.Core (CaseBranch' (..), Expr' (..), Type' (..), bindName)

--- a/primer/src/Primer/Core/Utils.hs
+++ b/primer/src/Primer/Core/Utils.hs
@@ -6,7 +6,8 @@ module Primer.Core.Utils (
   noHoles,
 ) where
 
-import Control.Monad ((<=<))
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh)
 import Data.Data (Data)
 import Data.Generics.Uniplate.Data (universe)

--- a/primer/src/Primer/Database.hs
+++ b/primer/src/Primer/Database.hs
@@ -19,28 +19,21 @@ module Primer.Database (
   serve,
 ) where
 
-import Control.Applicative (Alternative)
+import Foreword
+
 import Control.Concurrent.STM (
   TBQueue,
   TMVar,
-  atomically,
   putTMVar,
   readTBQueue,
  )
-import Control.Monad (MonadPlus, forever)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Cont (MonadCont)
-import Control.Monad.Except (MonadError)
 import Control.Monad.Fix (MonadFix)
-import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Reader (MonadReader, ReaderT, ask)
-import Control.Monad.State (MonadState)
+import Control.Monad.STM (atomically)
 import Control.Monad.Trans (MonadTrans)
 import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Zip (MonadZip)
-import Data.Bifunctor (second)
-import Data.Maybe (fromMaybe)
-import Data.Text (Text)
 import qualified Data.Text as Text (
   strip,
   take,
@@ -49,7 +42,6 @@ import qualified Data.Text as Text (
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID (toText)
 import Data.UUID.V4 (nextRandom)
-import GHC.Generics (Generic)
 import qualified ListT (toList)
 import Primer.App (App (..))
 import qualified StmContainers.Map as StmMap

--- a/primer/src/Primer/JSON.hs
+++ b/primer/src/Primer/JSON.hs
@@ -3,12 +3,11 @@
 
 module Primer.JSON (CustomJSON (..), VJSON, VJSONPrefix, ToJSON, FromJSON, ToJSONKey, FromJSONKey) where
 
+import Foreword
+
 import Data.Aeson (FromJSONKey, ToJSONKey)
-import Data.Char (toLower)
 import Data.List (stripPrefix)
-import Data.Proxy (Proxy (Proxy))
 import Deriving.Aeson
-import GHC.TypeLits (KnownSymbol, symbolVal)
 
 -- | A type for 'Primer' style JSON encoding.
 -- All our types use this, so we generate consistent encodings for the whole

--- a/primer/src/Primer/Name.hs
+++ b/primer/src/Primer/Name.hs
@@ -6,13 +6,13 @@ module Primer.Name (
   unsafeMkName,
 ) where
 
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh, fresh)
 import qualified Data.Char as C
 import Data.Data (Data)
 import qualified Data.Set as S
-import Data.String (IsString)
-import Data.Text (Text, pack)
-import GHC.Generics (Generic)
+import Data.String (String)
 import Numeric.Natural (Natural)
 import Primer.JSON
 
@@ -43,7 +43,7 @@ freshName avoid = go
   where
     go = do
       NC n <- fresh
-      let s = Name $ pack $ genAlpha n
+      let s = Name $ toS $ genAlpha n
       if s `S.member` avoid
         then go
         else pure s
@@ -53,6 +53,9 @@ freshName avoid = go
 --
 -- >>> map genAlpha [0, 1, 30, 31]
 -- ["a", "b", "e1", "f1"]
+--
+-- Note: replace this use of `String`. See:
+-- https://github.com/hackworthltd/primer/issues/149
 genAlpha :: Natural -> String
 genAlpha n =
   let c = C.chr $ fromInteger $ toInteger (97 + (n `mod` 26))

--- a/primer/src/Primer/Questions.hs
+++ b/primer/src/Primer/Questions.hs
@@ -9,12 +9,10 @@ module Primer.Questions (
   generateNameTy,
 ) where
 
-import Control.Monad.Reader (MonadReader, asks)
-import Data.List (sort)
-import Data.Map.Strict (Map)
+import Foreword
+
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Data.Text (pack)
 import Primer.Action (mkAvoidForFreshName, mkAvoidForFreshNameTy)
 import Primer.Core (
   Def (..),
@@ -111,8 +109,10 @@ getAvoidSetTy z = do
 uniquify :: Set.Set Name -> [Name] -> [Name]
 uniquify avoid ns = map snd $ sort $ map go ns
   where
-    go n = head [(i, f n i) | i <- [0 ..], f n i `Set.notMember` avoid]
+    -- Replace use of `unsafeHead` here. See:
+    -- https://github.com/hackworthltd/primer/issues/147
+    go n = unsafeHead [(i, f n i) | i <- [0 ..], f n i `Set.notMember` avoid]
     f :: Name -> Integer -> Name
     f n = \case
       0 -> n
-      i -> unsafeMkName $ unName n <> pack (show i)
+      i -> unsafeMkName $ unName n <> show i

--- a/primer/src/Primer/Refine.hs
+++ b/primer/src/Primer/Refine.hs
@@ -1,8 +1,8 @@
 module Primer.Refine (refine, Inst (..)) where
 
-import Control.Monad.Except (MonadError)
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh)
-import Data.Either (rights)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Primer.Core (Type' (TForall, TFun, TVar))

--- a/primer/src/Primer/Subst.hs
+++ b/primer/src/Primer/Subst.hs
@@ -10,11 +10,10 @@ module Primer.Subst (
   substTys,
 ) where
 
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh)
-import Data.Bifunctor (first)
-import Data.Foldable (foldrM)
 import qualified Data.Map.Strict as M
-import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Set.Optics (setOf)
 import Optics (Fold, Traversal, getting, summing, to, traversalVL, (%), _2)

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -55,23 +55,16 @@ module Primer.Typecheck (
   localTyVars,
 ) where
 
-import Control.Applicative (liftA2)
-import Control.Monad (unless, zipWithM, (<=<))
-import Control.Monad.Except (catchError)
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh (..))
 import Control.Monad.NestedError (MonadNestedError (..))
-import Control.Monad.Reader (MonadReader, ReaderT, asks, local, reader, runReaderT)
-import Data.Bifunctor (first, second)
-import Data.Foldable (foldrM)
 import Data.Functor.Compose (Compose (Compose), getCompose)
 import Data.Generics.Product (HasType, position, typed)
-import Data.List (find, foldl')
 import qualified Data.Map as M
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust)
 import qualified Data.Set as S
-import GHC.Generics (Generic)
+import Data.String (String)
 import Optics (Lens', over, set, view, (%))
 import Primer.Core (
   Bind' (..),
@@ -119,6 +112,8 @@ type ExprT = Expr' (Meta TypeCache) (Meta Kind)
 
 type TypeT = Type' (Meta Kind)
 
+-- We should replace this use of `String`. See:
+-- https://github.com/hackworthltd/primer/issues/149
 data TypeError
   = InternalError String
   | UnknownVariable Name

--- a/primer/src/Primer/Zipper.hs
+++ b/primer/src/Primer/Zipper.hs
@@ -44,10 +44,9 @@ module Primer.Zipper (
   bindersBelowTy,
 ) where
 
-import Control.Applicative ((<|>))
+import Foreword
+
 import Data.Data (Data)
-import Data.Function ((&))
-import Data.Functor ((<&>))
 import Data.Generics.Product (field, position)
 import Data.Generics.Sum (_Ctor)
 import Data.Generics.Uniplate.Data ()
@@ -60,7 +59,6 @@ import Data.Generics.Uniplate.Zipper (
 import qualified Data.Generics.Uniplate.Zipper as Z
 import Data.List as List (delete)
 import qualified Data.Set as S
-import GHC.Generics (Generic)
 import Optics (
   filteredBy,
   ifolded,
@@ -372,11 +370,6 @@ foldBelow :: (IsZipper za a, Monoid m) => (a -> m) -> za -> m
 foldBelow f z = f (target z) <> maybe mempty go (farthest left <$> down z)
   where
     go z' = f (target z') <> maybe mempty go (farthest left <$> down z') <> maybe mempty go (right z')
-
--- | @guarded f x@ returns @Just x@ if @f x@ is @True@.
-guarded :: (a -> Bool) -> a -> Maybe a
-guarded f x | f x = Just x
-guarded _ _ = Nothing
 
 -- Gets all binders that scope over the focussed subtree
 bindersAbove :: ExprZ -> S.Set Name

--- a/primer/src/Primer/ZipperCxt.hs
+++ b/primer/src/Primer/ZipperCxt.hs
@@ -10,8 +10,9 @@ module Primer.ZipperCxt (
   forgetMetadata,
 ) where
 
+import Foreword
+
 import Data.Generics.Product (Param (..), param, position)
-import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Optics (set, view, (^.))
 import Primer.Core (

--- a/primer/test/Gen/Core/Raw.hs
+++ b/primer/test/Gen/Core/Raw.hs
@@ -1,6 +1,7 @@
 module Gen.Core.Raw where
 
-import Control.Monad.State (StateT, evalStateT, get, put, runStateT)
+import Foreword
+
 import Hedgehog hiding (Var, check)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range

--- a/primer/test/Gen/Core/Typed.hs
+++ b/primer/test/Gen/Core/Typed.hs
@@ -18,17 +18,11 @@ module Gen.Core.Typed (
   freshNameForCxt,
 ) where
 
-import Control.Monad (replicateM)
-import Control.Monad.Except (runExceptT)
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh, fresh)
-import Control.Monad.Morph (hoist, lift)
-import Control.Monad.Reader (MonadReader, ReaderT, ask, asks, local, runReaderT)
-import Control.Monad.State (MonadState)
-import Data.Bifunctor (first, second)
-import Data.Functor ((<&>))
+import Control.Monad.Morph (hoist)
 import qualified Data.Map as M
-import Data.Maybe (catMaybes)
-import Data.Traversable (for)
 import Hedgehog (
   GenT,
   MonadGen,
@@ -159,7 +153,7 @@ genSyns ty = do
             cxt <- ask
             runExceptT (refine cxt ty hT) >>= \case
               -- This error case indicates a bug. Crash and fail loudly!
-              Left err -> error $ "Internal refine/unify error: " ++ show err
+              Left err -> panic $ "Internal refine/unify error: " <> show err
               Right Nothing -> pure Nothing
               Right (Just (inst, instTy)) -> do
                 (sb, is) <- genInstApp inst

--- a/primer/test/TestM.hs
+++ b/primer/test/TestM.hs
@@ -1,8 +1,9 @@
 -- A test monad for generating names and IDs and typechecking
 module TestM (TestM, evalTestM) where
 
+import Foreword
+
 import Control.Monad.Fresh
-import Control.Monad.State (MonadState, State, get, put, runState)
 import Primer.Core (ID (..))
 import Primer.Name (NameCounter)
 

--- a/primer/test/Tests/Action.hs
+++ b/primer/test/Tests/Action.hs
@@ -1,6 +1,8 @@
 -- | Tests for action application.
 module Tests.Action where
 
+import Foreword
+
 import Data.Generics.Uniplate.Data (universe)
 import Gen.Core.Raw (
   evalExprGen,

--- a/primer/test/Tests/Action/Capture.hs
+++ b/primer/test/Tests/Action/Capture.hs
@@ -1,6 +1,8 @@
 -- | Tests for actions handling variable capture.
 module Tests.Action.Capture where
 
+import Foreword
+
 import Primer.Action (
   Action (..),
   ActionError (NameCapture, NeedEmptyHole),

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -3,9 +3,9 @@
 
 module Tests.Action.Prog where
 
-import Control.Monad.Except (ExceptT, MonadError, runExceptT)
+import Foreword
+
 import Control.Monad.Fresh
-import Control.Monad.State (MonadState, StateT, runStateT)
 import qualified Data.Map.Strict as Map
 import Optics
 import Primer.Action (
@@ -151,7 +151,7 @@ unit_create_def = progActionTest defaultEmptyProg [CreateDef $ Just "newDef"] $
 
 unit_create_typedef :: Assertion
 unit_create_typedef =
-  let list =
+  let lst =
         TypeDef
           { typeDefName = "List"
           , typeDefParameters = [("a", KType)]
@@ -168,12 +168,12 @@ unit_create_typedef =
           , typeDefConstructors = [ValCon "Node" [TVar () "a", TApp () (TCon () "List") (TApp () (TCon () "Tree") (TVar () "a"))]]
           , typeDefNameHints = ["xs", "ys", "zs"]
           }
-   in progActionTest defaultEmptyProg [AddTypeDef list, AddTypeDef tree] $
+   in progActionTest defaultEmptyProg [AddTypeDef lst, AddTypeDef tree] $
         expectSuccess $
           \_ prog' -> do
             case progTypes prog' of
-              [list', tree'] -> do
-                list @=? list'
+              [lst', tree'] -> do
+                lst @=? lst'
                 tree @=? tree'
               _ -> assertFailure $ show $ progTypes prog'
 

--- a/primer/test/Tests/AlphaEquality.hs
+++ b/primer/test/Tests/AlphaEquality.hs
@@ -1,5 +1,7 @@
 module Tests.AlphaEquality where
 
+import Foreword
+
 import Gen.Core.Raw (
   evalExprGen,
   genName,

--- a/primer/test/Tests/Database.hs
+++ b/primer/test/Tests/Database.hs
@@ -1,6 +1,7 @@
 module Tests.Database where
 
-import Data.Text (Text)
+import Foreword
+
 import qualified Data.Text as Text
 import Primer.Database (
   defaultSessionName,
@@ -65,7 +66,7 @@ test_modified =
             "   \nfoo bar baz  \n  "
             "foo bar baz"
         ]
-    , let tooLong = Text.pack . concat $ replicate 7 ['0' .. '9']
+    , let tooLong = toS . concat $ replicate 7 ['0' .. '9']
        in testSessionName
             "truncate at 64"
             tooLong

--- a/primer/test/Tests/Eval.hs
+++ b/primer/test/Tests/Eval.hs
@@ -1,8 +1,8 @@
 module Tests.Eval where
 
-import Control.Monad.Except (runExceptT)
+import Foreword
+
 import qualified Data.Map.Strict as Map
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Optics (over, (^.))
 import Primer.Core (

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -1,13 +1,13 @@
 module Tests.EvalFull where
 
-import Control.Monad (when, zipWithM_)
+import Foreword hiding (unlines)
+
 import Control.Monad.Fresh (fresh)
-import Control.Monad.Reader (asks)
-import Data.Function (on)
 import Data.Generics.Uniplate.Data (universe)
 import Data.List ((\\))
 import qualified Data.Map as M
 import qualified Data.Set as S
+import Data.String (unlines)
 import Gen.Core.Typed (WT, forAllT, genChk, genSyn, genWTType, propertyWT)
 import Hedgehog hiding (test)
 import qualified Hedgehog.Gen as Gen
@@ -142,8 +142,8 @@ unit_8 =
         isEven <- lam "x" $ case_ (var "x") [branch "Zero" [] $ con "True", branch "Succ" [("n", Nothing)] $ global oddID `app` var "n"]
         isOdd <- lam "x" $ case_ (var "x") [branch "Zero" [] $ con "False", branch "Succ" [("n", Nothing)] $ global evenID `app` var "n"]
         let mkList t = foldr (\x xs -> con "Cons" `aPP` t `app` x `app` xs) (con "Nil" `aPP` t)
-        let list = mkList (tcon "Nat") $ take n $ iterate (con "Succ" `app`) (con "Zero")
-        expr <- global mapID `aPP` tcon "Nat" `aPP` tcon "Bool" `app` global evenID `app` list
+        let lst = mkList (tcon "Nat") $ take n $ iterate (con "Succ" `app`) (con "Zero")
+        expr <- global mapID `aPP` tcon "Nat" `aPP` tcon "Bool" `app` global evenID `app` lst
         let mapDef = Def mapID "map" map_ mapTy
         let evenDef = Def evenID "even" isEven evenTy
         let oddDef = Def oddID "odd" isOdd oddTy
@@ -182,8 +182,8 @@ unit_9 =
         isEven <- lam "x" $ case_ (var "x") [branch "Zero" [] $ con "True", branch "Succ" [("n", Nothing)] $ global oddID `app` var "n"]
         isOdd <- lam "x" $ case_ (var "x") [branch "Zero" [] $ con "False", branch "Succ" [("n", Nothing)] $ global evenID `app` var "n"]
         let mkList t = foldr (\x xs -> con "Cons" `aPP` t `app` x `app` xs) (con "Nil" `aPP` t)
-        let list = mkList (tcon "Nat") $ take n $ iterate (con "Succ" `app`) (con "Zero")
-        expr <- global mapID `aPP` tcon "Nat" `aPP` tcon "Bool" `app` global evenID `app` list
+        let lst = mkList (tcon "Nat") $ take n $ iterate (con "Succ" `app`) (con "Zero")
+        expr <- global mapID `aPP` tcon "Nat" `aPP` tcon "Bool" `app` global evenID `app` lst
         let mapDef = Def mapID "map" map_ mapTy
         let evenDef = Def evenID "even" isEven evenTy
         let oddDef = Def oddID "odd" isOdd oddTy

--- a/primer/test/Tests/FreeVars.hs
+++ b/primer/test/Tests/FreeVars.hs
@@ -1,5 +1,7 @@
 module Tests.FreeVars where
 
+import Foreword
+
 import qualified Data.Set as Set
 import Primer.Core (Kind (KType))
 import Primer.Core.DSL

--- a/primer/test/Tests/Gen/Core/Typed.hs
+++ b/primer/test/Tests/Gen/Core/Typed.hs
@@ -5,11 +5,9 @@
 -- generate well-typed terms
 module Tests.Gen.Core.Typed where
 
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Morph (lift)
-import Control.Monad.Reader (ask, local)
+import Foreword hiding (diff)
+
 import qualified Data.Map as M
-import GHC.Stack (HasCallStack, withFrozenCallStack)
 import Gen.Core.Typed (
   WT,
   genChk,

--- a/primer/test/Tests/Question.hs
+++ b/primer/test/Tests/Question.hs
@@ -1,10 +1,9 @@
 -- | Tests for Question logic
 module Tests.Question where
 
-import Control.Monad ((>=>))
-import Control.Monad.Reader (runReader)
-import Data.Function (on)
-import Data.List (nub, nubBy, sort)
+import Foreword hiding (diff)
+
+import Data.List (nub, nubBy)
 import Gen.Core.Raw (evalExprGen, genID, genKind, genName, genType)
 import Hedgehog hiding (check)
 import Hedgehog.Classes

--- a/primer/test/Tests/Serialisation.hs
+++ b/primer/test/Tests/Serialisation.hs
@@ -2,10 +2,12 @@
 
 module Tests.Serialisation where
 
+import Foreword hiding (log)
+
 import Data.Aeson hiding (Error, Result, Success)
 import Data.Aeson.Encode.Pretty (encodePretty)
-import Data.Functor
 import qualified Data.Map.Strict as Map
+import Data.String (String)
 import Primer.Action (Action (Move, SetCursor), ActionError (IDNotFound), Movement (Child1))
 import Primer.App (
   Log (..),
@@ -38,7 +40,6 @@ import System.FilePath (takeBaseName)
 import Test.Tasty
 import Test.Tasty.Golden
 import Test.Tasty.HUnit
-import Prelude hiding (log)
 
 -- | Check that encoding the value produces the file.
 test_encode :: TestTree

--- a/primer/test/Tests/Subst.hs
+++ b/primer/test/Tests/Subst.hs
@@ -1,5 +1,7 @@
 module Tests.Subst where
 
+import Foreword
+
 import Optics (set)
 import Primer.Core (
   Kind (KType),

--- a/primer/test/Tests/Transform.hs
+++ b/primer/test/Tests/Transform.hs
@@ -1,6 +1,7 @@
 module Tests.Transform where
 
-import Data.Function (on)
+import Foreword
+
 import Optics (over, view)
 import Primer.Core
 import Primer.Core.DSL

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -1,11 +1,9 @@
 -- | Tests for the typechecker
 module Tests.Typecheck where
 
-import Control.Applicative (liftA2)
-import Control.Monad.Except (ExceptT, MonadError, runExceptT)
+import Foreword
+
 import Control.Monad.Fresh (MonadFresh)
-import Control.Monad.Reader (MonadReader, ReaderT, runReaderT)
-import Data.Function (on)
 import Gen.Core.Raw (
   evalExprGen,
   genName,

--- a/primer/test/Tests/Zipper.hs
+++ b/primer/test/Tests/Zipper.hs
@@ -1,7 +1,8 @@
 -- | Tests for Primer.Zipper
 module Tests.Zipper where
 
-import Control.Monad (forM_)
+import Foreword
+
 import Data.Generics.Uniplate.Data (para)
 import Gen.Core.Raw (
   evalExprGen,

--- a/primer/test/Tests/Zipper/BindersAbove.hs
+++ b/primer/test/Tests/Zipper/BindersAbove.hs
@@ -1,9 +1,8 @@
 -- | Tests for 'Primer.Zipper.bindersAbove'.
 module Tests.Zipper.BindersAbove where
 
-import Control.Monad (foldM)
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Reader (runReaderT)
+import Foreword
+
 import qualified Data.Set as S
 import Primer.Action (
   Movement (..),


### PR DESCRIPTION
This custom prelude, named Foreword, is based on Protolude. In this
initial version, we re-export most of Protolude, but we elide a few
types and functions whose names clash with types and functions we use
in Primer. We're unlikely to use these particular elided types &
functions very often, so this seems like the right trade-off. (In a
few cases, I've renamed our own functions or local variables to avoid
clashes, when the Protolude versions seemed generally more useful
and/or conventional.)

When we do elide a function, we also elide related functions. For
example, Primer exports a function named `check`, and we use it
extensively. This name conflicts with `Control.Monad.STM.check`, which
is exported unqualified from Protolude, and therefore we elide `check`
from Protolude's exports. But as a user of Foreword, it might be
confusing if you could use, say, `atomically`, also from STM, but not
`check`. Therefore, we do not re-export *any* STM functions from
Protolude. You would therefore need to import
`Control.Monad.STM` (possibly qualified) if you wanted to use any STM
functions.

Note that there is still a bit of work to do before we're taking full
advantage of Protolude. Specifically, we make use of `error` and
`head` in a few places in library code, and we should not be doing
that. (We never want Primer to crash or throw a generic exception,
even if those cases should "never happen.") In this commit, I've
renamed the uses of `head` to `unsafeHead`. Protolude does re-export
`error`, but it does so with a warning, which, while normally helpful,
in our case would cause CI to fail, so we don't take advantage of
this, and `error` is now imported from `GHC.Err`, for the moment.

Other notes:

* There are certainly other things we might want to add to our custom
prelude, but one step at a time. (`Optics` seems like an obvious
candidate to add next.)

* I believe that, for the most part, no types have changed in this
commit, and I've not significantly rewritten any code, so these
changes should be more or less semantically neutral.

* Protolude famously does not export `String`, and in a few places
I've had to import it from `Data.String`. We should probably replace
those uses with `Text` for better performance & consistency with the
rest of the code base.

* `writeHieFiles` in our Nix config breaks on `mtl-compat-0.2.2`,
which is pulled in by `protolude`. For now, I've disabled that option
just for this package. `mtl-compat` probably doesn't generate HIE
files, anyway. See:

https://github.com/input-output-hk/haskell.nix/issues/1242
