### PR TITLE
HLint: enforce explicit export lists

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -14,3 +14,13 @@
 - ignore:
     name: "Use let"
     within: Main
+- warn:
+    name: "Use explicit module export list"
+- warn:
+    name: "Use module export list"
+- ignore:
+    name: "Use explicit module export list"
+    within: Tests.**
+- ignore:
+    name: "Use module export list"
+    within: Tests.**

--- a/primer/src/Control/Monad/NestedError.hs
+++ b/primer/src/Control/Monad/NestedError.hs
@@ -44,7 +44,7 @@
 --     • The type Bool does not contain a constructor whose field is of type SpecificError
 --     • In the expression:
 --           throwError' SpecificError :: MonadError Bool m => m a
-module Control.Monad.NestedError where
+module Control.Monad.NestedError (MonadNestedError (..)) where
 
 import Control.Monad.Except
 import Data.Generics.Sum.Typed

--- a/primer/test/Gen/Core/Raw.hs
+++ b/primer/test/Gen/Core/Raw.hs
@@ -1,4 +1,12 @@
-module Gen.Core.Raw where
+module Gen.Core.Raw (
+  runExprGen,
+  evalExprGen,
+  genID,
+  genName,
+  genKind,
+  genType,
+  genExpr,
+) where
 
 import Control.Monad.State (StateT, evalStateT, get, put, runStateT)
 import Hedgehog hiding (Var, check)


### PR DESCRIPTION
Unfortunately, there does not seem to be a hint to use an explicit
export list which will trigger when no export list is given. We instead
have
- if no export list at all, suggest
    primer/test/Gen/Core/Raw.hs:1:1: Warning: Use module export list
    Found:
      module Gen.Core.Raw where
    Perhaps:
      module Gen.Core.Raw (
              module Gen.Core.Raw
          ) where
    Note: an explicit list is usually better
- if a "module" export list is given, suggest
    primer/test/Gen/Core/Raw.hs:1:1: Warning: Use explicit module export list
    Found:
      module Gen.Core.Raw (
              module Gen.Core.Raw
          ) where
    Perhaps:
      module Gen.Core.Raw (
               ...
          ) where

This gets the job done, but is rather unergonomic!