### PR TITLE
Remove unnecessary `Result` type, replacing with isomorphic `Either`

### DIFF
--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -64,7 +64,6 @@ import Primer.App (
   Prog,
   ProgAction (BodyAction, MoveToDef),
   ProgError (NoDefSelected),
-  Result (..),
   newProg,
  )
 import Primer.Core (
@@ -204,7 +203,6 @@ type SOpenAPI = (
     "program" :> Get '[JSON] API.Prog
   )
 
-
 -- | The session-specific bits of the api
 -- (legacy version)
 type SAPI = (
@@ -220,7 +218,7 @@ type SAPI = (
 
     -- POST /api/edit
     --   Submit an action, returning an updated program state
-  :<|> "edit" :> ReqBody '[JSON] MutationRequest :> Post '[JSON] (Result ProgError Prog)
+  :<|> "edit" :> ReqBody '[JSON] MutationRequest :> Post '[JSON] (Either ProgError Prog)
 
     -- POST /question
     --   Submit a qestion, returning the answer or an error.
@@ -233,7 +231,7 @@ type SAPI = (
     --   Ask what variables are in scope for the given node ID
     "variables-in-scope"
       :> ReqBody '[JSON] (ID, ID)
-      :> Post '[JSON] (Result ProgError (([(Name, Kind)], [(Name, Type' ())]), [(ID, Name, Type' ())]))
+      :> Post '[JSON] (Either ProgError (([(Name, Kind)], [(Name, Type' ())]), [(ID, Name, Type' ())]))
 
     -- POST /question/generate-names
     --   Ask for a list of possible names for a binding at the given location.
@@ -241,16 +239,16 @@ type SAPI = (
     -- body, which isn't well supported for GET requests.
     :<|> "generate-names"
       :> ReqBody '[JSON] ((ID, ID), Either (Maybe (Type' ())) (Maybe Kind))
-      :> Post '[JSON] (Result ProgError [Name])
+      :> Post '[JSON] (Either ProgError [Name])
     )
 
     -- POST /eval-step
     --   Perform one step of evaluation on the given expression.
-  :<|> "eval-step" :> ReqBody '[JSON] EvalReq :> Post '[JSON] (Result ProgError EvalResp)
+  :<|> "eval-step" :> ReqBody '[JSON] EvalReq :> Post '[JSON] (Either ProgError EvalResp)
 
     -- POST /eval
     --   Evaluate the given expression to normal form (or time out).
-   :<|> "eval" :> ReqBody '[JSON] EvalFullReq :> Post '[JSON] (Result ProgError EvalFullResp)
+   :<|> "eval" :> ReqBody '[JSON] EvalFullReq :> Post '[JSON] (Either ProgError EvalFullResp)
 
     -- GET /api/test/<type>
     --   Get an arbitrary value of that type

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -64,7 +64,6 @@ import Primer.App (
   ProgError,
   QueryAppM,
   Question (..),
-  Result (..),
   handleEvalFullRequest,
   handleEvalRequest,
   handleGetProgramRequest,
@@ -269,12 +268,12 @@ renameSession sid n = withSession' sid $ RenameSession n
 
 -- Run an 'EditAppM' action, using the given session ID to look up and
 -- pass in the app state for that session.
-liftEditAppM :: (MonadIO m, MonadThrow m) => EditAppM a -> SessionId -> PrimerM m (Result ProgError a)
+liftEditAppM :: (MonadIO m, MonadThrow m) => EditAppM a -> SessionId -> PrimerM m (Either ProgError a)
 liftEditAppM h sid = withSession' sid (EditApp $ runEditAppM h)
 
 -- Run a 'QueryAppM' action, using the given session ID to look up and
 -- pass in the app state for that session.
-liftQueryAppM :: (MonadIO m, MonadThrow m) => QueryAppM a -> SessionId -> PrimerM m (Result ProgError a)
+liftQueryAppM :: (MonadIO m, MonadThrow m) => QueryAppM a -> SessionId -> PrimerM m (Either ProgError a)
 liftQueryAppM h sid = withSession' sid (QueryApp $ runQueryAppM h)
 
 getProgram :: (MonadIO m, MonadThrow m) => SessionId -> PrimerM m Prog
@@ -367,22 +366,22 @@ viewTreeType = U.para $ \e allChildren ->
         _ -> unwords $ c : map unName (U.childrenBi e)
    in Tree (getID e) n allChildren
 
-edit :: (MonadIO m, MonadThrow m) => SessionId -> MutationRequest -> PrimerM m (Result ProgError App.Prog)
+edit :: (MonadIO m, MonadThrow m) => SessionId -> MutationRequest -> PrimerM m (Either ProgError App.Prog)
 edit sid req = liftEditAppM (handleMutationRequest req) sid
 
-variablesInScope :: (MonadIO m, MonadThrow m) => SessionId -> (ID, ID) -> PrimerM m (Result ProgError (([(Name, Kind)], [(Name, Type' ())]), [(ID, Name, Type' ())]))
+variablesInScope :: (MonadIO m, MonadThrow m) => SessionId -> (ID, ID) -> PrimerM m (Either ProgError (([(Name, Kind)], [(Name, Type' ())]), [(ID, Name, Type' ())]))
 variablesInScope sid (defid, exprid) =
   liftQueryAppM (handleQuestion (VariablesInScope defid exprid)) sid
 
-generateNames :: (MonadIO m, MonadThrow m) => SessionId -> ((ID, ID), Either (Maybe (Type' ())) (Maybe Kind)) -> PrimerM m (Result ProgError [Name])
+generateNames :: (MonadIO m, MonadThrow m) => SessionId -> ((ID, ID), Either (Maybe (Type' ())) (Maybe Kind)) -> PrimerM m (Either ProgError [Name])
 generateNames sid ((defid, exprid), tk) =
   liftQueryAppM (handleQuestion $ GenerateName defid exprid tk) sid
 
-evalStep :: (MonadIO m, MonadThrow m) => SessionId -> EvalReq -> PrimerM m (Result ProgError EvalResp)
+evalStep :: (MonadIO m, MonadThrow m) => SessionId -> EvalReq -> PrimerM m (Either ProgError EvalResp)
 evalStep sid req =
   liftEditAppM (handleEvalRequest req) sid
 
-evalFull :: (MonadIO m, MonadThrow m) => SessionId -> EvalFullReq -> PrimerM m (Result ProgError EvalFullResp)
+evalFull :: (MonadIO m, MonadThrow m) => SessionId -> EvalFullReq -> PrimerM m (Either ProgError EvalFullResp)
 evalFull sid req =
   liftEditAppM (handleEvalFullRequest req) sid
 

--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -4,7 +4,7 @@ module Tests.Serialization where
 
 import Foreword hiding (log)
 
-import Data.Aeson hiding (Error, Result, Success)
+import Data.Aeson hiding (Error, Success)
 import Data.Aeson.Encode.Pretty (
   Config (confCompare),
   defConfig,
@@ -21,7 +21,6 @@ import Primer.App (
   Prog (..),
   ProgAction (BodyAction, MoveToDef),
   ProgError (NoDefSelected),
-  Result (..),
   Selection (..),
  )
 import Primer.Core (
@@ -138,6 +137,6 @@ fixtures =
       , mkFixture "selection" selection
       , mkFixture
           "edit_response_1"
-          (Error actionError :: Result ActionError Prog)
-      , mkFixture "edit_response_2" (Success prog :: Result ActionError Prog)
+          (Left actionError :: Either ActionError Prog)
+      , mkFixture "edit_response_2" (Right prog :: Either ActionError Prog)
       ]

--- a/primer/test/outputs/serialization/edit_response_1.json
+++ b/primer/test/outputs/serialization/edit_response_1.json
@@ -1,7 +1,6 @@
 {
-    "contents": {
+    "Left": {
         "contents": 0,
         "tag": "IDNotFound"
-    },
-    "tag": "Error"
+    }
 }

--- a/primer/test/outputs/serialization/edit_response_2.json
+++ b/primer/test/outputs/serialization/edit_response_2.json
@@ -1,5 +1,5 @@
 {
-    "contents": {
+    "Right": {
         "progDefs": {
             "1": {
                 "defExpr": {
@@ -161,6 +161,5 @@
                 ]
             }
         ]
-    },
-    "tag": "Success"
+    }
 }


### PR DESCRIPTION
This is effectively a follow-up to https://github.com/hackworthltd/vonnegut/pull/775. It wasn't noticed back then that somehow we had two workarounds for `Either` serialisation - `Data.Sum` *and* `App.Result`.

There is a slight change to our encodings, since we were using `aeson`'s `defaultTaggedObject` sum encoding, whereas `Either`'s instance uses the more concise `ObjectWithSingleField`. See the changes to test fixtures.