### PR TITLE
ci: Make bors work with Buildkite.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-  "ci/hydra:hackworthltd:primer%:required"
+  "buildkite/primer/required"
 ]
 timeout_sec = 3600
 # Disabled for now.


### PR DESCRIPTION
We change the GitHub status of the "required" job to match what
Buildkite reports, so that Bors will trigger merges once that job
successfully completes.