### PR TITLE
fix: don't build `ghcjsPrimerFlake.apps` attribute.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -311,7 +311,6 @@
       apps = {
         inherit (pkgs) run-primer run-primer-local-pgsql create-local-pgsql-db;
       }
-      // ghcjsPrimerFlake.apps
       // primerFlake.apps;
 
       defaultApp = self.apps.${system}.run-primer;


### PR DESCRIPTION
This was leftover from when I removed our `ghcjs` targets, due to its
not working on `aarch64-darwin`.