### PR TITLE
refactor: Don't expose MonadState internals of MonadFresh instances

### DIFF
--- a/primer/src/Primer/Core/DSL.hs
+++ b/primer/src/Primer/Core/DSL.hs
@@ -52,10 +52,10 @@ import Primer.Core (
 import Primer.Name (Name)
 
 newtype S a = S {unS :: State ID a}
-  deriving newtype (Functor, Applicative, Monad, MonadState ID)
+  deriving newtype (Functor, Applicative, Monad)
 
 instance MonadFresh ID S where
-  fresh = do
+  fresh = S $ do
     i <- get
     put (i + 1)
     pure i

--- a/primer/test/Gen/Core/Typed.hs
+++ b/primer/test/Gen/Core/Typed.hs
@@ -104,7 +104,6 @@ newtype WT a = WT {unWT :: ReaderT Cxt TestM a}
     , Applicative
     , Monad
     , MonadReader Cxt
-    , MonadState Int
     , MonadFresh NameCounter
     , MonadFresh ID
     )

--- a/primer/test/TestM.hs
+++ b/primer/test/TestM.hs
@@ -10,13 +10,13 @@ import Primer.Name (NameCounter)
 -- This monad is responsible for generating fresh IDs and names in tests.
 -- If we need other abilities, this will be the base monad.
 newtype TestM a = TestM {unTestM :: State Int a}
-  deriving newtype (Functor, Applicative, Monad, MonadState Int)
+  deriving newtype (Functor, Applicative, Monad)
 
 -- | Run an action and ignore any effect on the fresh name/id state
 isolateTestM :: TestM a -> TestM a
-isolateTestM m = do
+isolateTestM m = TestM $ do
   st <- get
-  x <- m
+  x <- unTestM m
   put st
   pure x
 
@@ -24,13 +24,13 @@ evalTestM :: ID -> TestM a -> a
 evalTestM (ID id_) = fst . flip runState id_ . unTestM
 
 instance MonadFresh ID TestM where
-  fresh = do
+  fresh = TestM $ do
     i <- get
     put $ i + 1
     pure $ ID i
 
 instance MonadFresh NameCounter TestM where
-  fresh = do
+  fresh = TestM $ do
     i <- get
     put $ i + 1
     -- A bit of a hack: make the names generated a,a1,a2,... as the testsuite


### PR DESCRIPTION
There is no use of these instances in the codebase. I know of no reason
one would want to monkey about in these internals, so let's remove the
foot-gun. Further, since MonadState has a fundep and lifts through many
common monad transformers, this useless instances removes the
possibility of having a more useful MonadState instance on a wrapped
type in the future.