### PR TITLE
feat: Use our new Rel8 adapter in `primer-service`

### DIFF
--- a/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
+++ b/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
@@ -4,6 +4,8 @@
 module Primer.Database.Rel8.Rel8Db (
   Rel8DbT (..),
   Rel8Db,
+  runRel8DbT,
+  runRel8Db,
 ) where
 
 import Foreword hiding (filter)
@@ -81,6 +83,15 @@ newtype Rel8DbT m a = Rel8DbT {unRel8DbT :: ReaderT Connection m a}
 
 -- | The 'Rel8DbT' monad transformer applied to 'IO'.
 type Rel8Db a = Rel8DbT IO a
+
+-- | Run an action in the 'Rel8DbT' monad with the given 'Connection'.
+runRel8DbT :: Rel8DbT m a -> Connection -> m a
+runRel8DbT m = runReaderT (unRel8DbT m)
+
+-- | Run an 'IO' action in the 'Rel8Db' monad with the given
+-- 'Connection'.
+runRel8Db :: Rel8DbT IO a -> Connection -> IO a
+runRel8Db = runRel8DbT
 
 -- | A 'MonadDb' instance for 'Rel8DbT'.
 --

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -48,7 +48,6 @@ library
     , openapi3           >=3.1.0   && <=3.2
     , optics             >=0.4     && <=0.5
     , primer             ^>=0.7
-    , selda              ^>=0.5
     , servant            ^>=0.18
     , servant-openapi3   ^>=2.0.1.2
     , servant-server     ^>=0.18
@@ -89,13 +88,11 @@ executable primer-service
     , base
     , bytestring            >=0.10.8.2 && <=0.11
     , directory             ^>=1.3
+    , hasql                 ^>=1.4.5.3
     , optparse-applicative  ^>=0.15.1.0
     , primer
-    , primer-selda          ^>=0.7
+    , primer-rel8           ^>=0.7
     , primer-service
-    , selda
-    , selda-postgresql      ^>=0.1
-    , selda-sqlite          ^>=0.1
     , stm
     , stm-containers
     , text

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -1,6 +1,16 @@
 let
-    -- TODO remove these once this code (recently ported from old frontend) is exercised
+    -- TODO remove the Primer.Action overrides once this code
+    -- (recently ported from old frontend) is exercised
     tmpRoots =
-      [ "^Primer.Action.Available", "^Primer.Action.Priorities", "^Primer.Database.Rel8" ]
+      [ "^Primer.Action.Available"
+      , "^Primer.Action.Priorities"
+      , "^Primer.Database.Selda.initialize"
+      ]
 
-in  { roots = [ "^Main.main$" ] # tmpRoots, type-class-roots = False }
+let
+    -- Anything specific we want Weeder to ignore goes here. This
+    -- includes things that we export for the convenience of users of
+    -- these packages, but don't actually make use of ourselves.
+    ignoreRoots = [ "^Primer.Database.Rel8.Rel8Db.runRel8Db" ]
+
+in  { roots = [ "^Main.main$" ] # tmpRoots # ignoreRoots, type-class-roots = True }


### PR DESCRIPTION
This change replaces the Selda database adapter with our new Rel8
adapter.

One ramification of this change is that we lose SQLite support, but
that was only ever intended as a local development option, anyway.
Recent changes (esp. Docker scripts to run a local PostgreSQL
instance) have obviated the need for it, in any case.

Error reporting on the command line leaves something to be desired,
but it's not demonstrably worse than what we had before and isn't a
priority at the moment.
