### PR TITLE
refactor: only ignore hlint hints in specific definitions

### DIFF
--- a/primer-service/exe-server/Main.hs
+++ b/primer-service/exe-server/Main.hs
@@ -43,12 +43,12 @@ import qualified StmContainers.Map as StmMap
 import System.Directory (withCurrentDirectory)
 import System.Environment (lookupEnv)
 
-{- HLINT ignore "Use newtype instead of data" -}
+{- HLINT ignore GlobalOptions "Use newtype instead of data" -}
 data GlobalOptions = GlobalOptions
   { cmd :: !Command
   }
 
-data Database = PostgreSQL BS.ByteString
+newtype Database = PostgreSQL BS.ByteString
 
 parseDatabase :: Parser Database
 parseDatabase = PostgreSQL <$> option auto (long "pgsql-url")

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -130,7 +130,7 @@ data Env = Env
 
 type PrimerM m = ReaderT Env m
 
-{- HLINT ignore "Use newtype instead of data" -}
+{- HLINT ignore PrimerErr "Use newtype instead of data" -}
 
 -- | Primer exception class.
 data PrimerErr = DatabaseErr Text deriving (Show)

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -377,7 +377,7 @@ lookupConstructor tyDefs c =
         pure (vc, td)
    in find ((== c) . valConName . fst) allCons
 
-{- HLINT ignore "Avoid lambda using `infix`" -}
+{- HLINT ignore synth "Avoid lambda using `infix`" -}
 -- Note [Let expressions]
 -- Let expressions are typechecked flexibly in order to minimise the instances
 -- where an annotation must be added. Hence we can both synthesise and check

--- a/primer/src/Primer/Zipper.hs
+++ b/primer/src/Primer/Zipper.hs
@@ -178,7 +178,7 @@ instance HasID Loc where
 -- | A location of a binding.
 -- This only covers bindings in case branches for now.
 
-{- HLINT ignore "Use newtype instead of data" -}
+{- HLINT ignore BindLoc "Use newtype instead of data" -}
 data BindLoc
   = BindCase CaseBindZ
   deriving (Generic)


### PR DESCRIPTION
Previously we ignored the specified hint in the entire file, not just in
the one intended definition.