### PR TITLE
feat: Remove the `Version` argument from `querySessionId`.

### DIFF
--- a/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
+++ b/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
@@ -206,10 +206,7 @@ instance (MonadThrow m, MonadIO m) => MonadDb (Rel8DbT m) where
       -- session names loaded from the database.
       safeMkSession (s, n) = Session s (safeMkSessionName n)
 
-  -- Note: we ignore the stored Primer version for now.
-  --
-  -- See https://github.com/hackworthltd/primer/issues/268
-  querySessionId _ sid = do
+  querySessionId sid = do
     result <- runStatement (LoadSessionError sid) $ select $ sessionById sid
     case result of
       [] -> return $ Left $ SessionIdNotFound sid

--- a/primer-rel8/test/Tests/InsertSession.hs
+++ b/primer-rel8/test/Tests/InsertSession.hs
@@ -43,7 +43,7 @@ test_insertSession_roundtrip = testCaseSteps "insertSession database round-tripp
       sessionId <- liftIO newSessionId
       insertSession version sessionId newApp name
       step "Retrieve it"
-      result <- querySessionId version sessionId
+      result <- querySessionId sessionId
       result @?= Right (SessionData newApp name)
 
 test_insertSession_failure :: TestTree

--- a/primer-rel8/test/Tests/QuerySessionId.hs
+++ b/primer-rel8/test/Tests/QuerySessionId.hs
@@ -66,7 +66,7 @@ test_querySessionId = testCaseSteps "querySessionId corner cases" $ \step' ->
 
       step "Attempt to look up a session that doesn't exist"
       nonexistentSessionId <- liftIO newSessionId
-      r1 <- querySessionId version nonexistentSessionId
+      r1 <- querySessionId nonexistentSessionId
       r1 @?= Left (SessionIdNotFound nonexistentSessionId)
 
       step "Attempt to fetch a session whose program is invalid"
@@ -81,7 +81,7 @@ test_querySessionId = testCaseSteps "querySessionId corner cases" $ \step' ->
                 , Schema.name = fromSessionName invalidProgramName
                 }
       liftIO $ insertSessionRow invalidProgramRow conn
-      assertException "querySessionId" (expectedError invalidProgramSessionId) $ querySessionId version invalidProgramSessionId
+      assertException "querySessionId" (expectedError invalidProgramSessionId) $ querySessionId invalidProgramSessionId
 
       step "Attempt to fetch a session whose name is invalid"
       invalidNameSessionId <- liftIO newSessionId
@@ -95,7 +95,7 @@ test_querySessionId = testCaseSteps "querySessionId corner cases" $ \step' ->
                 , Schema.name = invalidName
                 }
       liftIO $ insertSessionRow invalidNameRow conn
-      r3 <- querySessionId version invalidNameSessionId
+      r3 <- querySessionId invalidNameSessionId
       -- In this scenario, we should get the program back with the
       -- default session name, rather than the invalid name we used to
       -- store it in the database.

--- a/primer-rel8/test/Tests/UpdateSessionApp.hs
+++ b/primer-rel8/test/Tests/UpdateSessionApp.hs
@@ -47,29 +47,19 @@ test_updateSessionApp_roundtrip = testCaseSteps "updateSessionApp database round
 
       step "Update it with the same version and app"
       updateSessionApp version sessionId newEmptyApp
-      r1 <- querySessionId version sessionId
+      r1 <- querySessionId sessionId
       r1 @?= Right (SessionData newEmptyApp name)
 
       step "Update it with a new version, but the same app"
       let newVersion = "new-" <> version
       updateSessionApp newVersion sessionId newEmptyApp
-      r2 <- querySessionId newVersion sessionId
+      r2 <- querySessionId sessionId
       r2 @?= Right (SessionData newEmptyApp name)
 
       step "Update it with a new app"
       updateSessionApp newVersion sessionId newApp
-      r3 <- querySessionId newVersion sessionId
+      r3 <- querySessionId sessionId
       r3 @?= Right (SessionData newApp name)
-
-      -- Note: at the moment, we ignore the stored Primer version when
-      -- we query the database. This is a bit odd, but it's not yet
-      -- clear whether it'll be useful to include the version in the
-      -- query.
-      --
-      -- See https://github.com/hackworthltd/primer/issues/268
-      step "We can still query the program using the old version"
-      r4 <- querySessionId version sessionId
-      r4 @?= Right (SessionData newApp name)
 
 test_updateSessionApp_failure :: TestTree
 test_updateSessionApp_failure = testCaseSteps "updateSessionApp failure modes" $ \step' ->

--- a/primer-rel8/test/Tests/UpdateSessionName.hs
+++ b/primer-rel8/test/Tests/UpdateSessionName.hs
@@ -46,30 +46,20 @@ test_updateSessionName_roundtrip = testCaseSteps "updateSessionName database rou
 
       step "Update it with the same version and name"
       updateSessionName version sessionId name
-      r1 <- querySessionId version sessionId
+      r1 <- querySessionId sessionId
       r1 @?= Right (SessionData newEmptyApp name)
 
       step "Update it with a new version, but the same name"
       let newVersion = "new-" <> version
       updateSessionName newVersion sessionId name
-      r2 <- querySessionId newVersion sessionId
+      r2 <- querySessionId sessionId
       r2 @?= Right (SessionData newEmptyApp name)
 
       step "Update it with a new name"
       let newName = safeMkSessionName "new new app"
       updateSessionName newVersion sessionId newName
-      r3 <- querySessionId newVersion sessionId
+      r3 <- querySessionId sessionId
       r3 @?= Right (SessionData newEmptyApp newName)
-
-      -- Note: at the moment, we ignore the stored Primer version when
-      -- we query the database. This is a bit odd, but it's not yet
-      -- clear whether it'll be useful to include the version in the
-      -- query.
-      --
-      -- See https://github.com/hackworthltd/primer/issues/268
-      step "We can still query the program using the old version"
-      r4 <- querySessionId version sessionId
-      r4 @?= Right (SessionData newEmptyApp newName)
 
 test_updateSessionName_failure :: TestTree
 test_updateSessionName_failure = testCaseSteps "updateSessionName failure modes" $ \step' ->


### PR DESCRIPTION
We aren't using it, and it should not factor into a query by session
ID, anyway, because the session ID alone is sufficient to choose a
unique session in our schema.

Closes https://github.com/hackworthltd/primer/issues/268