### PR TITLE
fix: Evalfull tests: add some pre-defined globals

### DIFF
--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -50,6 +50,7 @@ module Primer.Typecheck (
   extendLocalCxtTys,
   extendLocalCxt,
   extendLocalCxts,
+  extendGlobalCxt,
   localTmVars,
   localTyVars,
 ) where


### PR DESCRIPTION
Previously they would not have any globals at all. Now they at least
have one AST global, and one primitive global in scope for the resume
and type preservation tests.

This was motivated by a previously-fixed bug where reduction of an
annotated primitive function application could break type preservation,
if the annotation contained holes and acted as a type-changing cast. It
was noticed that our property tests would never pick this up, since they
did not contain any primitives. This commit ensures we have some chance
to detect similar problems in the future.

Unfortunately, since generating well-typed terms is a hard problem, we
are very unlikely to actually detect it in a reasonable time! As a test,
I ran the following property test
```
  hprop_tmp_classify :: Property
  hprop_tmp_classify =
    propertyWT (buildTypingContext defaultTypeDefs mempty NoSmartHoles) $
    withGlobals testGlobals $ \fixedGlobs -> do
      (dir, t, _, _) <- genDirTmGlobs fixedGlobs
      collect dir
      let primIds = mapMaybe (fmap primDefID . defPrim) fixedGlobs
      label $ foo primIds t
   where
     foo primIds = \case
        App _ (Ann _ (GlobalVar _ i) _) (PrimCon _ _) | i `elem` primIds -> "1. (primfun :: _) primcon"
                                                      | otherwise -> "2.  (global :: _) primcon"
        App _ (Ann _ (GlobalVar _ i) _) _ | i `elem` primIds -> "3.  (primfun :: _) _"
                                          | otherwise -> "4. (global :: _) _"
        Ann _ (GlobalVar _ i) _ | i `elem` primIds -> "5. primfun :: _"
                                | otherwise -> "6. global :: _"
        GlobalVar _ i | i `elem` primIds -> "7. primfun"
                      | otherwise -> "8. global"
        PrimCon _ _ -> "9. primcon"
        _ -> "10. other"
```
for 100000 tests and obtained the following distribution
```
  ✓ tmp classify passed 100000 tests.
              Chk                 45% █████████···········
              Syn                 55% ██████████▉·········
              10. other           98% ███████████████████▌
              3. (primfun :: _) _  0% ····················
              4. (global :: _) _   0% ····················
              5. primfun :: _      0% ····················
              6. global :: _       0% ····················
              7. primfun           1% ▏···················
              8. global            1% ▏···················
```
Note that this implies that cases 1 and 2 never happened even once!