### PR TITLE
test(primer-rel8): Add a more robust test app.

### DIFF
--- a/primer-rel8/primer-rel8.cabal
+++ b/primer-rel8/primer-rel8.cabal
@@ -90,6 +90,7 @@ test-suite primer-rel8-test
     build-depends:
       , aeson
       , base
+      , containers
       , exceptions
       , filepath
       , hasql

--- a/primer-rel8/test/Tests/InsertSession.hs
+++ b/primer-rel8/test/Tests/InsertSession.hs
@@ -24,6 +24,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
 import TestUtils (
   assertException,
+  testApp,
   withDbSetup,
   (@?=),
  )
@@ -41,10 +42,10 @@ test_insertSession_roundtrip = testCaseSteps "insertSession database round-tripp
       let version = "git123"
       let name = safeMkSessionName "testNewApp"
       sessionId <- liftIO newSessionId
-      insertSession version sessionId newApp name
+      insertSession version sessionId testApp name
       step "Retrieve it"
       result <- querySessionId sessionId
-      result @?= Right (SessionData newApp name)
+      result @?= Right (SessionData testApp name)
 
 test_insertSession_failure :: TestTree
 test_insertSession_failure = testCaseSteps "insertSession failure modes" $ \step' ->

--- a/primer-rel8/test/Tests/UpdateSessionApp.hs
+++ b/primer-rel8/test/Tests/UpdateSessionApp.hs
@@ -25,6 +25,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
 import TestUtils (
   assertException,
+  testApp,
   withDbSetup,
   (@?=),
  )
@@ -57,9 +58,9 @@ test_updateSessionApp_roundtrip = testCaseSteps "updateSessionApp database round
       r2 @?= Right (SessionData newEmptyApp name)
 
       step "Update it with a new app"
-      updateSessionApp newVersion sessionId newApp
+      updateSessionApp newVersion sessionId testApp
       r3 <- querySessionId sessionId
-      r3 @?= Right (SessionData newApp name)
+      r3 @?= Right (SessionData testApp name)
 
 test_updateSessionApp_failure :: TestTree
 test_updateSessionApp_failure = testCaseSteps "updateSessionApp failure modes" $ \step' ->


### PR DESCRIPTION
This top-level definition in this app contains every construct in the Primer language, so it's a more robust test of our database serialization path.

There's quite a bit of code in here that can be refactored for better re-use, but I'll leave that for subsequent work. See #273.