### PR TITLE
test: Add database unit/integration tests.

### DIFF
--- a/.buildkite/pipeline.db-tests.yaml
+++ b/.buildkite/pipeline.db-tests.yaml
@@ -1,0 +1,25 @@
+agents:
+  docker: "true"
+
+env:
+  # No, this is not a secret. This is just a tear-up/tear-down
+  # test database.
+  POSTGRES_PASSWORD: "primer-dev"
+  LOCAL_POSTGRES_PORT: 5432
+
+steps:
+  - label: ":postgres: Initialize database"
+    plugins:
+      - hackworthltd/docker-service#feat/configurable_lockdir:
+          lockfile-dir: "$HOME"
+          container: postgres:13
+          flags:
+            - --env=POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
+
+          # Note: make sure that the PostgreSQL port isn't exposed to
+          # the outside world, as using the "host" Docker network will
+          # make the Docker PostgreSQL service listen on the host's
+          # external IP address.
+          network: host
+    command: |
+      nix run .#primer-init-db-test

--- a/flake.nix
+++ b/flake.nix
@@ -176,9 +176,26 @@
 
             inherit primer-openapi-spec;
 
-            inherit primer-scripts;
-            inherit (primer-scripts) deploy-postgresql-container start-postgresql-container stop-postgresql-container;
-            inherit (primer-scripts) run-primer create-local-db deploy-local-db verify-local-db revert-local-db status-local-db log-local-db delete-local-db dump-local-db restore-local-db primer-sqitch;
+            inherit (primer-scripts)
+              deploy-postgresql-container
+              start-postgresql-container
+              stop-postgresql-container;
+
+            inherit (primer-scripts)
+              run-primer
+              create-local-db
+              deploy-local-db
+              verify-local-db
+              revert-local-db
+              status-local-db
+              log-local-db
+              delete-local-db
+              dump-local-db
+              restore-local-db
+              primer-sqitch;
+
+            inherit (primer-scripts)
+              primer-init-db-test;
           }
         )
       ];
@@ -199,71 +216,176 @@
       inherit overlay;
     }
 
-    // forAllSupportedSystems (system:
-    let
-      pkgs = pkgsFor system;
+    // forAllSupportedSystems
+      (system:
+      let
+        pkgs = pkgsFor system;
 
-      # haskell.nix does a lot of heavy lifiting for us and gives us a
-      # flake for our Cabal project with the following attributes:
-      # `checks`, `apps`, and `packages`.
-      #
-      # When merging package sets, make sure to put the
-      # ghcjsPrimerFlake first, so that the primerFlake will
-      # override any commonly-named attributes. We only want the ghcjs
-      # parts of the `ghcjsPrimerFlake` flake.
+        # haskell.nix does a lot of heavy lifiting for us and gives us a
+        # flake for our Cabal project with the following attributes:
+        # `checks`, `apps`, and `packages`.
+        #
+        # When merging package sets, make sure to put the
+        # ghcjsPrimerFlake first, so that the primerFlake will
+        # override any commonly-named attributes. We only want the ghcjs
+        # parts of the `ghcjsPrimerFlake` flake.
 
-      ghcjsPrimerFlake = pkgs.ghcjsPrimer.flake {
-        crossPlatforms = p: [ p.ghcjs ];
-      };
+        ghcjsPrimerFlake = pkgs.ghcjsPrimer.flake {
+          crossPlatforms = p: [ p.ghcjs ];
+        };
 
-      primerFlake = pkgs.primer.flake { };
+        primerFlake = pkgs.primer.flake { };
 
-      weeder =
-        let
-          weederTool = pkgs.haskell-nix.tool ghcVersion "weeder" weederVersion;
-          getLibHIE = package:
-            pkgs.lib.optional (package.components ? library)
-              { name = "${package.identifier.name}-library"; path = package.components.library.hie; };
-          getHIE = package: component: pkgs.lib.lists.map
-            (cn: {
-              name = "${package.identifier.name}-${component}-${cn}";
-              path = package.components.${component}.${cn}.hie;
-            })
-            (builtins.attrNames package.components.${component});
-          getHIEs = package:
-            getLibHIE package
-            ++ pkgs.lib.concatMap (getHIE package)
-              [ "benchmarks" "exes" "sublibs" "tests" ];
-          primer-packages = pkgs.haskell-nix.haskellLib.selectProjectPackages pkgs.primer;
-        in
-        pkgs.runCommand "weeder"
-          {
-            weederConfig = ./weeder.dhall;
-            allHieFiles = pkgs.linkFarm
-              "primer-hie-files"
-              (pkgs.lib.concatMap getHIEs (builtins.attrValues primer-packages));
-          }
+        weeder =
+          let
+            weederTool = pkgs.haskell-nix.tool ghcVersion "weeder" weederVersion;
+            getLibHIE = package:
+              pkgs.lib.optional (package.components ? library)
+                { name = "${package.identifier.name}-library"; path = package.components.library.hie; };
+            getHIE = package: component: pkgs.lib.lists.map
+              (cn: {
+                name = "${package.identifier.name}-${component}-${cn}";
+                path = package.components.${component}.${cn}.hie;
+              })
+              (builtins.attrNames package.components.${component});
+            getHIEs = package:
+              getLibHIE package
+              ++ pkgs.lib.concatMap (getHIE package)
+                [ "benchmarks" "exes" "sublibs" "tests" ];
+            primer-packages = pkgs.haskell-nix.haskellLib.selectProjectPackages pkgs.primer;
+          in
+          pkgs.runCommand "weeder"
+            {
+              weederConfig = ./weeder.dhall;
+              allHieFiles = pkgs.linkFarm
+                "primer-hie-files"
+                (pkgs.lib.concatMap getHIEs (builtins.attrValues primer-packages));
+            }
+            ''
+              export XDG_CACHE_HOME=$(mktemp -d)
+              ${weederTool}/bin/weeder --config $weederConfig --hie-directory $allHieFiles
+              echo "No issues found."
+              touch $out
+            '';
+
+        openapi-validate = pkgs.runCommand "openapi-validate" { }
           ''
-            export XDG_CACHE_HOME=$(mktemp -d)
-            ${weederTool}/bin/weeder --config $weederConfig --hie-directory $allHieFiles
+            ${pkgs.openapi-generator-cli}/bin/openapi-generator-cli validate --recommend -i ${pkgs.primer-openapi-spec}
             echo "No issues found."
             touch $out
           '';
 
-      openapi-validate = pkgs.runCommand "openapi-validate" { }
-        ''
-          ${pkgs.openapi-generator-cli}/bin/openapi-generator-cli validate --recommend -i ${pkgs.primer-openapi-spec}
-          echo "No issues found."
-          touch $out
-        '';
+        pre-commit-hooks =
+          let
+            # Override the default nix-pre-commit-hooks tools with the version
+            # we're using.
+            haskellNixTools = pkgs.haskell-nix.tools ghcVersion {
+              hlint = "latest";
+              cabal-fmt = "latest";
 
-      pre-commit-hooks =
-        let
-          # Override the default nix-pre-commit-hooks tools with the version
-          # we're using.
-          haskellNixTools = pkgs.haskell-nix.tools ghcVersion {
+              # https://github.com/input-output-hk/haskell.nix/issues/1337
+              fourmolu = {
+                version = "latest";
+                modules = [
+                  ({ lib, ... }: {
+                    options.nonReinstallablePkgs = lib.mkOption { apply = lib.remove "Cabal"; };
+                  })
+                ];
+              };
+            };
+          in
+          pre-commit-hooks-nix.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              hlint.enable = true;
+              fourmolu.enable = true;
+              cabal-fmt.enable = true;
+              nixpkgs-fmt.enable = true;
+            };
+
+            # Override the default nix-pre-commit-hooks tools with the version
+            # we're using.
+            tools = {
+              inherit (pkgs) nixpkgs-fmt;
+            } // haskellNixTools;
+
+            excludes = [
+              "primer/test/outputs"
+            ];
+          };
+      in
+      {
+        packages =
+          {
+            inherit (pkgs) primer-service primer-openapi-spec;
+
+            inherit (pkgs)
+              deploy-postgresql-container
+              start-postgresql-container
+              stop-postgresql-container;
+
+            inherit (pkgs)
+              run-primer
+              create-local-db
+              deploy-local-db
+              verify-local-db
+              revert-local-db
+              status-local-db
+              log-local-db
+              delete-local-db
+              dump-local-db
+              restore-local-db
+              primer-sqitch;
+
+            inherit (pkgs)
+              primer-init-db-test;
+          }
+          // primerFlake.packages;
+
+        # Notes:
+        #
+        # - Don't include the `ghcjsPrimerFlake` checks, as they don't
+        #   actually work since they won't be run in a browser.
+        checks =
+          {
+            source-code-checks = pre-commit-hooks;
+            inherit weeder openapi-validate;
+          }
+          // primerFlake.checks;
+
+        apps = {
+          inherit (pkgs) run-primer primer-openapi-spec;
+
+          inherit (pkgs)
+            create-local-db
+            deploy-local-db
+            verify-local-db
+            revert-local-db
+            status-local-db
+            log-local-db
+            delete-local-db
+            dump-local-db
+            restore-local-db
+            primer-sqitch;
+
+          inherit (pkgs)
+            deploy-postgresql-container
+            start-postgresql-container
+            stop-postgresql-container;
+
+          inherit (pkgs)
+            primer-init-db-test;
+        }
+        // primerFlake.apps;
+
+        defaultApp = self.apps.${system}.run-primer;
+
+        devShell = pkgs.primer.shellFor {
+          tools = {
+            ghcid = "latest";
+            haskell-language-server = "latest";
+            cabal = "latest";
             hlint = "latest";
-            cabal-fmt = "latest";
 
             # https://github.com/input-output-hk/haskell.nix/issues/1337
             fourmolu = {
@@ -274,118 +396,52 @@
                 })
               ];
             };
-          };
-        in
-        pre-commit-hooks-nix.lib.${system}.run {
-          src = ./.;
-          hooks = {
-            hlint.enable = true;
-            fourmolu.enable = true;
-            cabal-fmt.enable = true;
-            nixpkgs-fmt.enable = true;
+
+            cabal-edit = "latest";
+            cabal-fmt = "latest";
+            #TODO Explicitly requiring tasty-discover shouldn't be necessary - see the commented-out `build-tool-depends` in primer.cabal.
+            tasty-discover = "latest";
+            weeder = weederVersion;
           };
 
-          # Override the default nix-pre-commit-hooks tools with the version
-          # we're using.
-          tools = {
-            inherit (pkgs) nixpkgs-fmt;
-          } // haskellNixTools;
+          buildInputs = (with pkgs; [
+            nixpkgs-fmt
+            postgresql
+            openapi-generator-cli
 
-          excludes = [
-            "primer/test/outputs"
-          ];
+            # For Docker support.
+            docker
+            lima
+            colima
+
+            # For Language Server support.
+            nodejs-16_x
+
+            # sqitch
+            nix-generate-from-cpan
+            sqitch
+            primer-sqitch
+
+            # Local database scripts.
+            create-local-db
+            deploy-local-db
+            verify-local-db
+            revert-local-db
+            status-local-db
+            log-local-db
+            delete-local-db
+            dump-local-db
+            restore-local-db
+          ]);
+
+          shellHook = ''
+            export HIE_HOOGLE_DATABASE="$(cat $(${pkgs.which}/bin/which hoogle) | sed -n -e 's|.*--database \(.*\.hoo\).*|\1|p')"
+          '';
+
+          # Make this buildable on Hydra.
+          meta.platforms = pkgs.lib.platforms.unix;
         };
-    in
-    {
-      packages =
-        {
-          inherit (pkgs) primer-service;
-          inherit (pkgs) run-primer create-local-db deploy-local-db verify-local-db revert-local-db status-local-db log-local-db delete-local-db dump-local-db restore-local-db primer-sqitch primer-openapi-spec;
-          inherit (pkgs) deploy-postgresql-container start-postgresql-container stop-postgresql-container;
-        }
-        // primerFlake.packages;
-
-      # Notes:
-      #
-      # - Don't include the `ghcjsPrimerFlake` checks, as they don't
-      #   actually work since they won't be run in a browser.
-      checks =
-        {
-          source-code-checks = pre-commit-hooks;
-          inherit weeder openapi-validate;
-        }
-        // primerFlake.checks;
-
-      apps = {
-        inherit (pkgs) run-primer create-local-db deploy-local-db verify-local-db revert-local-db status-local-db log-local-db delete-local-db dump-local-db restore-local-db primer-sqitch primer-openapi-spec;
-        inherit (pkgs) deploy-postgresql-container start-postgresql-container stop-postgresql-container;
-      }
-      // primerFlake.apps;
-
-      defaultApp = self.apps.${system}.run-primer;
-
-      devShell = pkgs.primer.shellFor {
-        tools = {
-          ghcid = "latest";
-          haskell-language-server = "latest";
-          cabal = "latest";
-          hlint = "latest";
-
-          # https://github.com/input-output-hk/haskell.nix/issues/1337
-          fourmolu = {
-            version = "latest";
-            modules = [
-              ({ lib, ... }: {
-                options.nonReinstallablePkgs = lib.mkOption { apply = lib.remove "Cabal"; };
-              })
-            ];
-          };
-
-          cabal-edit = "latest";
-          cabal-fmt = "latest";
-          #TODO Explicitly requiring tasty-discover shouldn't be necessary - see the commented-out `build-tool-depends` in primer.cabal.
-          tasty-discover = "latest";
-          weeder = weederVersion;
-        };
-
-        buildInputs = (with pkgs; [
-          nixpkgs-fmt
-          postgresql
-          openapi-generator-cli
-
-          # For Docker support.
-          docker
-          lima
-          colima
-
-          # For Language Server support.
-          nodejs-16_x
-
-          # sqitch
-          nix-generate-from-cpan
-          sqitch
-          primer-sqitch
-
-          # Local database scripts.
-          create-local-db
-          deploy-local-db
-          verify-local-db
-          revert-local-db
-          status-local-db
-          log-local-db
-          delete-local-db
-          dump-local-db
-          restore-local-db
-        ]);
-
-        shellHook = ''
-          export HIE_HOOGLE_DATABASE="$(cat $(${pkgs.which}/bin/which hoogle) | sed -n -e 's|.*--database \(.*\.hoo\).*|\1|p')"
-        '';
-
-        # Make this buildable on Hydra.
-        meta.platforms = pkgs.lib.platforms.unix;
-      };
-    })
+      })
 
     // {
       hydraJobs = {

--- a/nix/pkgs/primer-scripts/default.nix
+++ b/nix/pkgs/primer-scripts/default.nix
@@ -203,4 +203,19 @@ in
       primer-service serve . ${primerVersion} "$@"
     '';
   };
+
+
+  ## Database unit/integration tests.
+  primer-init-db-test = writeShellApplication
+    {
+      name = "primer-init-db-test";
+      runtimeInputs = [
+        sqitchBundle
+      ];
+      text = ''
+        DATABASE_URL="postgres://postgres:$POSTGRES_PASSWORD@$DOCKER_SERVICE_IP:$LOCAL_POSTGRES_PORT"
+        export DATABASE_URL
+        sqitch deploy --verify db:"$DATABASE_URL"
+      '';
+    };
 }


### PR DESCRIPTION
This PR is an alternate approach to #286. This version uses Docker to run the database unit tests. It works well enough for this initial test, which simply runs Sqitch on a fresh database instance and ensures it was deployed correctly.

However, subsequent tests will need to use the PostgreSQL `pgtap` extension, and that's rather tricky to get working with the official PostgreSQL Docker image. In order to make this work, we'd either have to create our own PostgreSQL Docker image, or run *another* Docker container to build the `pgtap` extension and install it at runtime into the PostgreSQL Docker container. Building our own PostgreSQL Docker image wouldn't be too bad, but we'd need to push that to Docker Hub, or modify the Buildkite plugin we're using to grab the Docker image from the Nix store... and all of this is probably going to go away eventually anyway when we choose our production cloud PostgreSQL service and we can easily launch development/test instances that are exactly like our production instances, which is clearly the preferable test environment in the long run.

I suspect I'll go with #286 since that's expedient and doesn't require any new bespoke build system work, but I'll keep this PR open until I'm certain.