### PR TITLE
fix: Tests.Action.Prog: defaultPrimsProg clobbers 'main'

### DIFF
--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -112,7 +112,7 @@ unit_rename_def_to_same_name_as_existing_def =
 unit_rename_def_to_same_name_as_existing_def_prim :: Assertion
 unit_rename_def_to_same_name_as_existing_def_prim =
   progActionTest defaultPrimsProg [RenameDef 2 "toUpper"] $
-    expectError (@?= DefAlreadyExists "toUpper" 114)
+    expectError (@?= DefAlreadyExists "toUpper" 118)
 
 unit_delete_def :: Assertion
 unit_delete_def =
@@ -162,7 +162,7 @@ unit_create_def = progActionTest defaultEmptyProg [CreateDef $ Just "newDef"] $
 unit_create_def_clash_prim :: Assertion
 unit_create_def_clash_prim =
   progActionTest defaultPrimsProg [CreateDef $ Just "toUpper"] $
-    expectError (@?= DefAlreadyExists "toUpper" 114)
+    expectError (@?= DefAlreadyExists "toUpper" 118)
 
 unit_create_typedef :: Assertion
 unit_create_typedef =
@@ -606,10 +606,13 @@ defaultEmptyProg = do
 
 -- `defaultEmptyProg`, plus all primitive definitions (types and terms)
 defaultPrimsProg :: MonadFresh ID m => m Prog
-defaultPrimsProg = withPrimDefs $ \_ m ->
-  over #progTypes ((TypeDefPrim <$> toList allPrimTypeDefs) <>)
-    . over #progDefs ((DefPrim <$> m) <>)
-    <$> defaultEmptyProg
+defaultPrimsProg = do
+  p <- defaultEmptyProg
+  withPrimDefs $ \_ m ->
+    pure $
+      over #progTypes ((TypeDefPrim <$> toList allPrimTypeDefs) <>)
+        . over #progDefs ((DefPrim <$> m) <>)
+        $ p
 
 _defIDs :: Traversal' ASTDef ID
 _defIDs = #astDefID `adjoin` #astDefExpr % (_exprMeta % _id `adjoin` _exprTypeMeta % _id) `adjoin` #astDefType % _typeMeta % _id


### PR DESCRIPTION
The definition of defaultEmptyProg is a hack, hardcoding an ID of 0 for
'main' and 2 for 'other', regardless of whether they are fresh or not.
This leads to two different defs having ID 0 in defaultPrimsProg as
normally used in progActionTest, and it turns out that 'main' is
overwritten with a primitive definition. Thus one cannot do any edits to
ID 0 in tests.

Note that whilst we have worked around this symptom, the implementation
of defaultEmptyProg is still wrong: these IDs will clash with some node
IDs in the current usage.