### PR TITLE
DNM: Testing CI + golden tests: accepts non-existent golden files?

### DIFF
--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -193,5 +193,7 @@ fixtures =
           )
       , mkFixture "prim_char" $ PrimCon @() @() () $ PrimChar 'a'
       , mkFixture "prim_int" $ PrimCon @() @() () $ PrimInt 42
-      , mkFixture "golden_file_not_checked_in" ()
       ]
+
+test_no_golden_file :: TestTree
+test_no_golden_file = goldenVsString "no golden file" "test/outputs/serialization/nonexistent.json" (pure mempty)


### PR DESCRIPTION
We add a golden test fixture but do not check in its output file.
Running locally, I see
  $ cabal run primer-test -- -p 'golden'
  Tests
    Serialization
      encode
        golden_file_not_checked_in: OK
          Golden file did not exist; created
      decode
        golden_file_not_checked_in: FAIL
          Exception: test/outputs/serialization/golden_file_not_checked_in.json: openBinaryFile: does not exist (No such file or directory)
          Use -p '/golden/&&/decode.golden_file_not_checked_in/' to rerun this test only.
i.e. the testsuite only fails because of the decode test.
The encode test (using tasty-golden) passes, even though the golden file
did not exist.

I am worried that this could lead to situations where we forget to check
in a golden file, and this is not caught by CI. However, in our current
testsuite, I think we are saved by the fact the only golden tests we do
are via Fixtures, which include this decode component which will fail.