### PR TITLE
ci: Add a Mergify config.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,10 @@
+pull_request_rules:
+  - name: Automerge
+    conditions:
+      - base=main
+      - label="Ready to merge"
+      - "#review-threads-unresolved=0"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
Starter config for Mergify. This will automatically merge a PR to main
once the "Ready to merge" label is applied to the PR and there are no
unresolved threads or changes requested by reviewers.

We don't (yet) require approved reviews.