### PR TITLE
ci: New Mergify rules.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,10 +1,35 @@
 pull_request_rules:
-  - name: Automerge
+
+  - name: Merge via the default merge queue
     conditions:
       - base=main
       - label="Ready to merge"
       - "#review-threads-unresolved=0"
       - "#changes-requested-reviews-by=0"
+      - check-success="buildkite/primer/pr/required"
     actions:
-      merge:
+      queue:
+        name: default
         method: merge
+        update_method: merge
+
+  - name: Notify author on queue failure
+    conditions:
+      - 'check-failure=Queue: Embarked in merge train'
+    actions:
+      comment:
+        message: >
+          Hey @{{ author }}, this pull request failed to merge and has been
+          dequeued from the merge train.  If you believe your PR failed in
+          the merge train because of a flaky test, requeue it by commenting
+          with `@mergifyio refresh`.
+
+          More details can be found on the `Queue: Embarked in merge train`
+          check-run.
+
+queue_rules:
+  - name: default
+    allow_inplace_checks: false
+    conditions:
+      - base=main
+      - check-success="buildkite/primer/pr/required"


### PR DESCRIPTION
Switch to using Mergify's `queue` action, rather than the previous
`merge` action. This makes it act more like Bors. See:

https://docs.mergify.com/actions/queue/

We configure Mergify to create a separate PR for checking merges
against `main`, rather than updating the origin PR in place. Besides
the advantage of keeping the history for the original PR cleaner, when
creating the separate PR, Mergify provides some nice status
information about the status of the build, the state of the merge
queue, etc.

NOTE: this Mergify configuration requires that we remove GitHub's own
required status checks on protected branches. If we don't do this,
then after building the separate PR (see above), Mergify will wait for
a new required status check from Buildkite on the original PR, which
will never arrive since there's nothing new to build. I'm not quite
certain why Mergify thinks a new status update is forthcoming, since
nothing will have changed on the original PR in this scenario, but so
long as we configure our protected branches such that only Mergify can
commit to them, then the end result should be the same as using
GitHub's required status checks.

For posterity, here are some notes on how this Mergify approach
differs from how we've been using Bors up to this point:

- When you ask Bors to merge a PR, Bors will create a new branch that
merges that PR with current `main` and pushes this new branch to
GitHub. However, it doesn't create a new PR. You must configure your
build system (in our case, Buildkite) to automatically build these
branches. With this Mergify configuration, Mergify does the test build
on a new PR, so there's nothing special to configure on the Buildkite
side, assuming Buildkite is already configured to build PRs.

- Bors then waits for the GitHub status on the required Bors jobs. If
it succeeds, Bors commits its branch to `main`. If not, it reports
that the build failed via a comment in the original PR thread. This
Mergify configuration, on the other hand, does *not* commit the
separate PR branch to `main`: it will just merge the original PR into
`main`. However, because everything goes through the Mergify queue,
that merge should successfully build in CI, because it's functionally
equivalent to the branch it created for the separate PR.

- One drawback to Bors is that, in order to determine why a merge
request failed, you have to go digging around in Buildkite's logs.
Bors doesn't help much here: it has no useful logs of its own, and
because it doesn't create a separate PR, there's no way to easily
retrieve the status of the failed branch via the GitHub UI. Mergify,
on the other hand, creates the separate PR for its merge attempt, and
that PR contains everything you need to know about why the build
failed, easily accessible from GitHub's UI.