### PR TITLE
ci: Temporarily remove macOS checks from required job.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -489,12 +489,14 @@
           pkgs.releaseTools.aggregate {
             name = "required";
             constituents = builtins.map builtins.attrValues (with self.hydraJobs; [
+              # Temporarily disable macOS checks.
+
               packages.x86_64-linux
-              packages.aarch64-darwin
+              #packages.aarch64-darwin
               checks.x86_64-linux
-              checks.aarch64-darwin
+              #checks.aarch64-darwin
               tests.x86_64-linux
-              devShell
+              #devShell
             ]);
             meta.description = "Required CI builds";
           };


### PR DESCRIPTION
Our macOS remote builders will be down for approximately the next
week.