### PR TITLE
fix: allTypes should look in imports

### DIFF
--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -208,7 +208,7 @@ importModules ms = do
 
 -- | Get all type definitions from all modules (including imports)
 allTypes :: Prog -> [TypeDef]
-allTypes = moduleTypes . progModule
+allTypes p = foldMap moduleTypes $ progModule p : progImports p
 
 -- | Get all definitions from all modules (including imports)
 allDefs :: Prog -> Map ID Def


### PR DESCRIPTION
This was a mistake in the initial implementation. The
documentation was correct, that it should look inside imports,
and the implementation was wrong.

Also adds some tests that would have caught this oversight.
Note that the Eval one is only for consistency -- it would not have
caught the bug since Eval does not ever look at type definitions.