### PR TITLE
Restore macOS required checks and don't build `x86_64-darwin`.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,6 @@
 
       forAllSupportedSystems = flake-utils.lib.eachSystem [
         "x86_64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 


### PR DESCRIPTION
Our Intel Mac remote builders are gone and aren't coming back, so we simply remove support for this architecture. We can add it back later if there's enough demand from the community. To be clear, I don't expect that there will be any issues getting Primer to compile on Intel Macs; it's just that we won't provide Nix packages for it in our community binary cache.

Fixes PRIM-22.