### PR TITLE
fix: handle recursive functions in RenameDef

### DIFF
--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -450,15 +450,17 @@ applyProgAction prog mdefName = \case
       if Map.member name defs
         then throwError $ DefAlreadyExists name
         else do
+          let def' = DefAST def{astDefName = name}
           defs' <-
             maybe (throwError $ ActionError NameCapture) pure $
-              traverse (traverseOf (#_DefAST % #astDefExpr) $ renameVar d name) (Map.delete d defs)
-          let def' = def{astDefName = name}
-              prog' =
+              traverse
+                (traverseOf (#_DefAST % #astDefExpr) $ renameVar d name)
+                (Map.insert name def' $ Map.delete d defs)
+          let prog' =
                 prog
-                  & #progSelection ?~ Selection (astDefName def') Nothing
+                  & #progSelection ?~ Selection (defName def') Nothing
                   & #progModule % #moduleDefs .~ defs'
-          pure (addDef def' prog', mdefName)
+          pure (prog', mdefName)
   CreateDef n -> do
     let defs = moduleDefs $ progModule prog
     name <- case n of

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -146,6 +146,19 @@ unit_rename_def_referenced =
       fmap defName (Map.lookup "main" (moduleDefs $ progModule prog')) @?= Just "main"
       fmap (set _exprMeta () . astDefExpr) (defAST =<< Map.lookup "main" (moduleDefs $ progModule prog')) @?= Just (Var () $ GlobalVarRef "foo")
 
+unit_rename_def_recursive :: Assertion
+unit_rename_def_recursive =
+  progActionTest
+    defaultEmptyProg
+    [ MoveToDef "main"
+    , BodyAction [ConstructVar $ GlobalVarRef "main"]
+    , RenameDef "main" "foo"
+    ]
+    $ expectSuccess $ \_ prog' -> do
+      fmap defName (Map.lookup "main" (moduleDefs $ progModule prog')) @?= Nothing
+      fmap defName (Map.lookup "foo" (moduleDefs $ progModule prog')) @?= Just "foo"
+      fmap (set _exprMeta () . astDefExpr) (defAST =<< Map.lookup "foo" (moduleDefs $ progModule prog')) @?= Just (Var () $ GlobalVarRef "foo")
+
 unit_delete_def :: Assertion
 unit_delete_def =
   progActionTest defaultEmptyProg [DeleteDef "other"] $


### PR DESCRIPTION
We need to rename recursive references. Prior to this commit we would
only rename references appearing in /other/ definitions.