### PR TITLE
fix: make typeDef well formed in Tests/Serialization

### DIFF
--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -35,7 +35,7 @@ import Primer.Core (
   Kind (KFun, KType),
   Meta (..),
   PrimCon (..),
-  Type' (TApp, TCon, TEmptyHole),
+  Type' (TApp, TCon, TEmptyHole, TVar),
   TypeCache (TCSynthed),
   TypeCacheBoth (TCBoth),
   TypeDef (..),
@@ -100,7 +100,7 @@ fixtures =
           ASTTypeDef
             { astTypeDefName = "T"
             , astTypeDefParameters = [("a", KType), ("b", KFun KType KType)]
-            , astTypeDefConstructors = [ValCon "C" [TApp () (TCon () "b") (TCon () "a"), TCon () "Nat"]]
+            , astTypeDefConstructors = [ValCon "C" [TApp () (TVar () "b") (TVar () "a"), TCon () "Nat"]]
             , astTypeDefNameHints = []
             }
       progerror :: ProgError

--- a/primer/test/outputs/serialization/edit_response_2.json
+++ b/primer/test/outputs/serialization/edit_response_2.json
@@ -65,14 +65,14 @@
                                                     [],
                                                     "b"
                                                 ],
-                                                "tag": "TCon"
+                                                "tag": "TVar"
                                             },
                                             {
                                                 "contents": [
                                                     [],
                                                     "a"
                                                 ],
-                                                "tag": "TCon"
+                                                "tag": "TVar"
                                             }
                                         ],
                                         "tag": "TApp"

--- a/primer/test/outputs/serialization/prog.json
+++ b/primer/test/outputs/serialization/prog.json
@@ -64,14 +64,14 @@
                                                 [],
                                                 "b"
                                             ],
-                                            "tag": "TCon"
+                                            "tag": "TVar"
                                         },
                                         {
                                             "contents": [
                                                 [],
                                                 "a"
                                             ],
-                                            "tag": "TCon"
+                                            "tag": "TVar"
                                         }
                                     ],
                                     "tag": "TApp"

--- a/primer/test/outputs/serialization/typeDef.json
+++ b/primer/test/outputs/serialization/typeDef.json
@@ -11,14 +11,14 @@
                                     [],
                                     "b"
                                 ],
-                                "tag": "TCon"
+                                "tag": "TVar"
                             },
                             {
                                 "contents": [
                                     [],
                                     "a"
                                 ],
-                                "tag": "TCon"
+                                "tag": "TVar"
                             }
                         ],
                         "tag": "TApp"


### PR DESCRIPTION
We were accidentally using TCon to refer to a type parameter.
Whilst this test does not care whether things are well formed, this is
useful preparation for making global names qualified with a module name.
When that happens, the contents of a TCon will be a qualified name, but
the contents of a TVar will be a non-qualified (local) name,
necessitating a change here.