### PR TITLE
refactor: rename a stale test "unit_good_defaultPrimsProg"

### DIFF
--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -751,8 +751,8 @@ defaultFullProg = do
         . over (#progModule % #moduleDefs) ((DefPrim <$> m) <>)
         $ p
 
-unit_good_defaultPrimsProg :: Assertion
-unit_good_defaultPrimsProg = checkProgWellFormed defaultFullProg
+unit_good_defaultFullProg :: Assertion
+unit_good_defaultFullProg = checkProgWellFormed defaultFullProg
 
 _defIDs :: Traversal' ASTDef ID
 _defIDs = #astDefExpr % (_exprMeta % _id `adjoin` _exprTypeMeta % _id) `adjoin` #astDefType % _typeMeta % _id


### PR DESCRIPTION
In 7249e02d6c1969a00135a7aeadeebd40703b1c65 we renamed defaultPrimsProg
to defaultFullProg, but forgot to rename the corresponding test.