### PR TITLE
refactor: convert varRefName to a function

### DIFF
--- a/primer/src/Primer/Core.hs
+++ b/primer/src/Primer/Core.hs
@@ -83,7 +83,7 @@ import Data.Data (Data)
 import Data.Generics.Product
 import Data.Generics.Uniplate.Data ()
 import Data.Generics.Uniplate.Zipper (Zipper, hole, replaceHole)
-import Optics (AffineFold, Lens, Lens', Traversal, afailing, lens, lensVL, set, view, (%))
+import Optics (AffineFold, Lens, Lens', Traversal, afailing, lens, set, view, (%))
 import Primer.JSON
 import Primer.Name (Name, unsafeMkName)
 
@@ -231,10 +231,10 @@ data TmVarRef
   deriving (Eq, Show, Data, Generic)
   deriving (FromJSON, ToJSON) via VJSON TmVarRef
 
-varRefName :: Lens' TmVarRef Name
-varRefName = lensVL $ \f -> \case
-  GlobalVarRef (GlobalName n) -> GlobalVarRef . GlobalName <$> f n
-  LocalVarRef (LocalName n) -> LocalVarRef . LocalName <$> f n
+varRefName :: TmVarRef -> Name
+varRefName = \case
+  GlobalVarRef (GlobalName n) -> n
+  LocalVarRef (LocalName n) -> n
 
 -- Note [Synthesisable constructors]
 -- Whilst our calculus is heavily inspired by bidirectional type systems

--- a/primer/src/Primer/Core/Transform.hs
+++ b/primer/src/Primer/Core/Transform.hs
@@ -14,7 +14,6 @@ import Foreword
 import Data.Data (Data)
 import Data.Generics.Uniplate.Data (descendM)
 import qualified Data.List.NonEmpty as NE
-import Optics ((^.))
 import Primer.Core (CaseBranch' (..), Expr' (..), LVarName, LocalName (unLocalName), TmVarRef (..), TyVarName, Type' (..), bindName, varRefName)
 
 -- AST transformations.
@@ -26,8 +25,8 @@ import Primer.Core (CaseBranch' (..), Expr' (..), LVarName, LocalName (unLocalNa
 -- See the tests for explanation and examples.
 renameVar :: (Data a, Data b) => TmVarRef -> TmVarRef -> Expr' a b -> Maybe (Expr' a b)
 renameVar x y =
-  let xn = x ^. varRefName
-      yn = y ^. varRefName
+  let xn = varRefName x
+      yn = varRefName y
    in \case
         Lam m v e
           | LocalVarRef v == x -> pure $ Lam m v e
@@ -60,7 +59,7 @@ renameVar x y =
           | v == y -> Nothing
           -- If we have the same Name, but different local/global scopes
           -- also bail out as something has gone wrong.
-          | v ^. varRefName == xn || v ^. varRefName == yn -> Nothing
+          | varRefName v == xn || varRefName v == yn -> Nothing
           | otherwise -> pure $ Var m v
         e -> descendM (renameVar x y) e
 


### PR DESCRIPTION
This was only ever used as a standalone getter. Since it does not make
much sense to change the `Name` inside a `VarRef` without caring whether it
is a local or global, we remove the ability to set via the lens. This
could be done by writing a `Getter`, but there does not seem any advantage
in using that over a plain function.