### PR TITLE
fix: make instance compatible with ghc9

### DIFF
--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -36,7 +36,7 @@ deriving via Text instance (ToSchema Name)
 
 -- For GlobalName and LVarName, we must derive ToSchema via Name,
 -- as that is how the To/FromJSON instances are derived
-deriving via Name instance (Typeable k => ToSchema (GlobalName k))
+deriving via Name instance Typeable k => ToSchema (GlobalName k)
 deriving via Name instance (ToSchema LVarName)
 instance ToSchema Tree
 instance ToSchema Def


### PR DESCRIPTION
GHC 9 is more strict in what instances it accepts. In particular, the
instance must look (eliding some details) like
  instance cxt => head
without any parentheses at top level. I.e.
  instance (c => t)
would parse as "empty context, head = (c => t)", and be rightly
rejected.