### PR TITLE
fix: Catch `Rel8DbException`s and restart the database service.

### DIFF
--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -66,6 +66,7 @@ executable primer-service
   hs-source-dirs:     exe-server
   default-language:   Haskell2010
   default-extensions:
+    NoImplicitPrelude
     DataKinds
     DeriveDataTypeable
     DeriveGeneric
@@ -88,6 +89,7 @@ executable primer-service
     , base
     , bytestring            >=0.10.8.2 && <=0.12
     , directory             ^>=1.3
+    , exceptions
     , hasql                 ^>=1.5
     , optparse-applicative  ^>=0.17
     , primer


### PR DESCRIPTION
Prior to this commit, when a `Rel8DbException` is thrown (e.g.,
because Primer can't load a session due to its not having been
schema-migrated), `primer-service` will print the exception's `Show`
representation to the console and die. This has been fine up until
now, but it's time to get a bit more professional in how we handle
such exceptions.

This commit catches any `Rel8DbException`, prints the exception's
`Show` representation to `stderr`, and restarts the database service.

This commit is not meant to be the final version of this improved
exception-handling scheme. For one thing, we need to add proper
logging of these exceptions when they occur; see
https://github.com/hackworthltd/primer/issues/179. For another, we
need to be more selective about which exceptions leave the database in
a restartable state, and which ones indicate that we may want to kill
the server in order to mitigate possible database corruption; see
https://github.com/hackworthltd/primer/issues/381.