### PR TITLE
fix: Drop support for no-longer-used Axios bindings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ cabal.project.local*
 
 # generated files
 /openapi.json
-/axios-bindings/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,4 @@ openapi.json: build
 	cabal run -v0 primer-service:exe:primer-openapi > $@
 	openapi-generator-cli validate --recommend -i $@
 
-axios-bindings: openapi.json
-	openapi-generator-cli generate -i openapi.json -o axios-bindings -g typescript-axios
-
-.PHONY: $(targets) weeder axios-bindings
+.PHONY: $(targets) weeder

--- a/README.md
+++ b/README.md
@@ -214,15 +214,13 @@ Note: we follow the [same convention as the maintainer of
 Sqitch](https://github.com/sqitchers/sqitch/issues/239#issuecomment-118943207)
 when setting PostgreSQL search paths/schema prefixes in our scripts.
 
-# Generating Axios bindings
+# Generating an OpenAPI spec
 
-We can automatically generate TypeScript Axios bindings for
-`primer-service`:
+We can automatically generate an OpenAPI spec for `primer-service`:
 
 ```sh
-make axios-bindings
+make openapi.json
 ```
 
-This will place the generated bindings in the `axios-bindings`
-subdirectory. (Note: do not check these bindings into this
-repository.)
+This will place the generated spec in a file named `openapi.json`.
+(Note: do not check this generated file into this repository.)


### PR DESCRIPTION
Note that we still support OpenAPI spec generation.

Fixes https://github.com/hackworthltd/primer/issues/227.