### PR TITLE
fix: viewTreeExpr renders local and global vars distinctly

### DIFF
--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -78,12 +78,13 @@ import qualified Primer.App as App
 import Primer.Core (
   ASTDef (..),
   Expr,
-  Expr' (APP, Ann, LetType, Letrec, PrimCon),
+  Expr' (APP, Ann, LetType, Letrec, PrimCon, Var),
   GVarName,
   ID,
   Kind,
   LVarName,
   PrimCon (..),
+  TmVarRef (GlobalVarRef, LocalVarRef),
   TyConName,
   TyVarName,
   Type,
@@ -348,7 +349,14 @@ viewProg p =
 -- It is expected to evolve in the future.
 viewTreeExpr :: Expr -> Tree
 viewTreeExpr = U.para $ \e exprChildren ->
-  let c = toS $ showConstr $ toConstr e
+  let c = case e of
+        -- We need to disambiguate between local and global references
+        -- as using uniplate to extract the names will get the name inside
+        -- the TmVarRef, rendering both a local and global as 'Var x' if
+        -- we did not have this special case.
+        Var _ (LocalVarRef _) -> "LVar"
+        Var _ (GlobalVarRef _) -> "GVar"
+        _ -> toS $ showConstr $ toConstr e
       n = case e of
         PrimCon _ pc -> case pc of
           PrimChar c' -> show c'

--- a/primer/test/Tests/API.hs
+++ b/primer/test/Tests/API.hs
@@ -46,6 +46,14 @@ unit_viewTreeExpr_injective_globalvar :: Assertion
 unit_viewTreeExpr_injective_globalvar =
   distinctTreeExpr (gvar "0") (gvar "1")
 
+-- When we changed how references were handled so 'Expr' had one constructor
+-- that handled both local and global variable references, there was a
+-- regression where they both rendered identically.
+-- This is a regression test for said issue.
+unit_viewTreeExpr_injective_locglobvar :: Assertion
+unit_viewTreeExpr_injective_locglobvar =
+  distinctTreeExpr (lvar "x") (gvar "x")
+
 unit_viewTreeExpr_injective_let :: Assertion
 unit_viewTreeExpr_injective_let =
   distinctTreeExpr (let_ "x" emptyHole emptyHole) (let_ "y" emptyHole emptyHole)


### PR DESCRIPTION
The change in 494f82c unifying local and global variable handling had
the unfortunate side effect of rendering them both as the tree 'Var x'.
We add some special case handling to make it clear if it is a local or
global reference.