### PR TITLE
test: tweak Gen.Core.Raw.genName to reuse names more often

### DIFF
--- a/primer/test/Gen/Core/Raw.hs
+++ b/primer/test/Gen/Core/Raw.hs
@@ -162,14 +162,14 @@ genID = do
   put (i + 1)
   pure $ i + 1
 
-genName :: ExprGen Name
+genName :: MonadGen m => m Name
 genName = unsafeMkName <$> Gen.frequency [(9, fixed), (1, random)]
   where
     fixed = Gen.element ["x", "y", "z", "foo", "bar"]
     random = Gen.text (Range.linear 1 10) Gen.alpha
 
-genLVarName :: ExprGen LVarName
+genLVarName :: MonadGen m => m LVarName
 genLVarName = LocalName <$> genName
 
-genTyVarName :: ExprGen TyVarName
+genTyVarName :: MonadGen m => m TyVarName
 genTyVarName = LocalName <$> genName


### PR DESCRIPTION
Previously we were generating random strings. This had the problem that
it would not pick up bugs due to shadowing etc very frequently. We now
pick from a small set of fixed names 90% of the time, and generate a
random string the other 10%.