### PR TITLE
fix: RenameModule should clear the selection

### DIFF
--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -822,7 +822,10 @@ applyProgAction prog mdefName = \case
             Nothing -> throwError RenameModuleNameClash
             Just renamedMods ->
               if imported curMods == imported renamedMods
-                then pure $ prog & #progModule .~ editable renamedMods
+                then
+                  pure $
+                    prog & #progModule .~ editable renamedMods
+                      & #progSelection .~ Nothing
                 else
                   throwError $
                     -- It should never happen that the action edits an


### PR DESCRIPTION
Otherwise we may well still have the old module name recorded in the
selection, meaning that if we do any more actions in the same batch we
may get a surprising DefNotFound error. Another design choice would be
to rename any reference to the module inside the selection. We choose
to just erase the selection for simplicity and to partially revert the
semantic change in RenameModule introduced in
5150bbc56f82b2da7b606121f69fdf7a9b683871
(Note that this is still a semantic change in RenameModule compared to
before that commit, since we now clear the selection)