### PR TITLE
fix: RenameModule should look inside the selection

### DIFF
--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -55,6 +55,7 @@ import Data.Aeson (
   genericToEncoding,
  )
 import Data.Bitraversable (bimapM)
+import Data.Data (Data)
 import Data.Generics.Product (position)
 import Data.Generics.Uniplate.Operations (descendM, transform, transformM)
 import Data.Generics.Uniplate.Zipper (
@@ -78,6 +79,7 @@ import Optics (
   (.~),
   (?~),
   (^.),
+  _Just,
   _Left,
   _Right,
  )
@@ -148,6 +150,7 @@ import Primer.Module (
   moduleDefsQualified,
   moduleTypesQualified,
   renameModule,
+  renameModule',
  )
 import Primer.Name (Name (unName), NameCounter, freshName, unsafeMkName)
 import Primer.Primitives (primitiveModule)
@@ -289,7 +292,7 @@ data Selection = Selection
   -- ^ the ID of some ASTDef
   , selectedNode :: Maybe NodeSelection
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Data)
   deriving (ToJSON, FromJSON) via VJSON Selection
 
 -- | A selected node, in the body or type signature of some definition.
@@ -299,11 +302,11 @@ data NodeSelection = NodeSelection
   , nodeId :: ID
   , meta :: Either ExprMeta TypeMeta
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Data)
   deriving (ToJSON, FromJSON) via VJSON NodeSelection
 
 data NodeType = BodyNode | SigNode
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Data)
   deriving (ToJSON, FromJSON) via VJSON NodeType
 
 -- | The type of requests which can mutate the application state.
@@ -822,7 +825,10 @@ applyProgAction prog mdefName = \case
             Nothing -> throwError RenameModuleNameClash
             Just renamedMods ->
               if imported curMods == imported renamedMods
-                then pure $ prog & #progModule .~ editable renamedMods
+                then
+                  pure $
+                    prog & #progModule .~ editable renamedMods
+                      & #progSelection % _Just %~ renameModule' oldName n
                 else
                   throwError $
                     -- It should never happen that the action edits an

--- a/primer/src/Primer/Module.hs
+++ b/primer/src/Primer/Module.hs
@@ -8,6 +8,7 @@ module Primer.Module (
   insertDef,
   deleteDef,
   renameModule,
+  renameModule',
 ) where
 
 import Data.Data (Data)
@@ -79,4 +80,9 @@ renameModule fromName toName = traverse rn1
     rn1 m =
       if moduleName m == toName
         then Nothing
-        else pure $ transformBi (\n -> if n == fromName then toName else n) m
+        else pure $ renameModule' fromName toName m
+
+-- | Renames all occurrences of the given 'ModuleName'. This does not
+-- detect name clashes, see 'renameModule'
+renameModule' :: Data a => ModuleName -> ModuleName -> a -> a
+renameModule' fromName toName = transformBi (\n -> if n == fromName then toName else n)

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -1194,15 +1194,30 @@ unit_defaultFullProg_no_clash =
         assertBool "Expected every type making up defaultFullProg to have distinct names" $ not $ anySame typeNames
         assertBool "Expected every term making up defaultFullProg to have distinct names" $ not $ anySame termNames
 
+-- We make sure to check that references get updated, including in our selection
 unit_rename_module :: Assertion
 unit_rename_module =
   let test = do
         importModules [builtinModule]
-        handleEditRequest [RenameModule ["Module2"]]
+        handleEditRequest
+          [ moveToDef "main"
+          , BodyAction [ConstructVar $ globalVarRef "main"]
+          , RenameModule ["Module2"]
+          ]
       a = newEmptyApp
    in case fst $ runAppTestM (ID $ appIdCounter a) a test of
         Left err -> assertFailure $ show err
-        Right p -> unModuleName (moduleName $ progModule p) @?= ["Module2"]
+        Right p -> do
+          unModuleName (moduleName $ progModule p) @?= ["Module2"]
+          selectedDef <$> progSelection p @?= Just (qualifyName (ModuleName ["Module2"]) "main")
+          case Map.elems (moduleDefs $ progModule p) of
+            [DefAST d] -> do
+              let expectedName = qualifyName (ModuleName ["Module2"]) "main"
+              astDefName d @?= expectedName
+              case astDefExpr d of
+                Var _ (GlobalVarRef r) -> r @?= expectedName
+                e -> assertFailure $ "Expected def to equal `Module2.main`, found " <> show e
+            _ -> assertFailure "Expected exactly one def"
 
 unit_rename_module_clash :: Assertion
 unit_rename_module_clash =


### PR DESCRIPTION
Otherwise we may well still have the old module name recorded in the
selection, meaning that if we do any more actions in the same batch we
may get a surprising DefNotFound error.