### PR TITLE
chore: update comment

### DIFF
--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -303,12 +303,10 @@ instance ToJSON Tree
 -- (this is expected to evolve as we flesh out the API)
 data Prog = Prog
   { types :: [TyConName]
-  , -- We don't use Map ID Def, as the JSON encoding would be as an object,
-  -- where keys are IDs converted to strings and we have no nice way of
-  -- saying "all the keys of this object should parse as numbers". Similarly,
-  -- it is rather redundant as each Def carries a defID field (which is
-  -- encoded as a number), and it is difficult to enforce that "the keys of
-  -- this object match the defID field of the corresponding value".
+  , -- We don't use Map Name Def as it is rather redundant since each
+  -- Def carries a name field, and it is difficult to enforce that
+  -- "the keys of this object match the name field of the
+  -- corresponding value".
   defs :: [Def]
   }
   deriving (Generic)


### PR DESCRIPTION
In 2411df4e0a869a9bb4add8aebfac346fbc1e3cdd, we changed how we identify
definitions from `ID`s to `Name`s, but this comment was missed.