### PR TITLE
fix: RenameCon affects case branch labels

### DIFF
--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -68,6 +68,7 @@ import qualified Data.Set as Set
 import Optics (
   Field1 (_1),
   Field2 (_2),
+  Field3 (_3),
   ReversibleOptic (re),
   over,
   toListOf,
@@ -612,7 +613,9 @@ applyProgAction prog mdefName = \case
           type_
       updateDefs =
         over (traversed % #_DefAST % #astDefExpr) $
-          transform $ over (#_Con % _2) updateName
+          transform $
+            over (#_Con % _2) updateName
+              . over (#_Case % _3 % traversed % #_CaseBranch % _1) updateName
       updateName n = if n == old then new else n
   RenameTypeParam type_ old (unsafeMkLocalName -> new) -> do
     traverseOf

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -794,8 +794,16 @@ unit_RenameCon =
           [ do
               x <-
                 hole
-                  ( hole
-                      (con cA)
+                  ( hole $
+                      case_
+                        ( con cA `aPP` tEmptyHole `aPP` tEmptyHole
+                            `app` con (vcn "True")
+                            `app` con (vcn "True")
+                            `app` con (vcn "True")
+                        )
+                        [ branch cA [("p", Nothing), ("q", Nothing), ("p1", Nothing)] emptyHole
+                        , branch cB [("x", Nothing)] emptyHole
+                        ]
                   )
               astDef "def" x <$> tEmptyHole
           ]
@@ -812,8 +820,16 @@ unit_RenameCon =
         @?= forgetIDs
           ( fst . create $
               hole
-                ( hole
-                    (con $ vcn "A'")
+                ( hole $
+                    case_
+                      ( con (vcn "A'") `aPP` tEmptyHole `aPP` tEmptyHole
+                          `app` con (vcn "True")
+                          `app` con (vcn "True")
+                          `app` con (vcn "True")
+                      )
+                      [ branch (vcn "A'") [("p", Nothing), ("q", Nothing), ("p1", Nothing)] emptyHole
+                      , branch cB [("x", Nothing)] emptyHole
+                      ]
                 )
           )
 


### PR DESCRIPTION
When renaming a constructor `C` to `D`, we must not only rename every
use of it as a constructor, but also where it appears as a branch label.
For example, in the code
```
    case x of
      C y -> (True, C 1)
```
there are two usages of `C` to rename. Previously we only changed the
`C 1` and not the `C y`.