### PR TITLE
fix: genTypeDefGroup should never refer to a local var

### DIFF
--- a/primer/test/Gen/Core/Typed.hs
+++ b/primer/test/Gen/Core/Typed.hs
@@ -438,14 +438,15 @@ genGlobalCxtExtension =
   local forgetLocals $
     Gen.list (Range.linear 1 5) $
       (,) <$> (qualifyName <$> genModuleName <*> genName) <*> genWTType KType
-  where
-    -- we are careful to not let the globals depend on whatever locals may be in
-    -- the cxt
-    forgetLocals cxt = cxt{localCxt = mempty}
+
+-- We are careful to not let generated globals depend on whatever
+-- locals may be in the cxt
+forgetLocals :: Cxt -> Cxt
+forgetLocals cxt = cxt{localCxt = mempty}
 
 -- Generates a group of potentially-mutually-recursive typedefs
 genTypeDefGroup :: GenT WT [TypeDef]
-genTypeDefGroup = do
+genTypeDefGroup = local forgetLocals $ do
   let genParams = Gen.list (Range.linear 0 5) $ (,) <$> freshTyVarNameForCxt <*> genWTKind
   nps <- Gen.list (Range.linear 1 5) $ (,) <$> freshTyConNameForCxt <*> genParams
   -- create empty typedefs to temporarilly extend the context, so can do recursive types

--- a/primer/test/Tests/Gen/Core/Typed.hs
+++ b/primer/test/Tests/Gen/Core/Typed.hs
@@ -80,7 +80,7 @@ propertyWTInExtendedGlobalCxt :: [Module] -> PropertyT WT () -> Property
 propertyWTInExtendedGlobalCxt mods = propertyWT mods . inExtendedGlobalCxt
 
 propertyWTInExtendedLocalGlobalCxt :: [Module] -> PropertyT WT () -> Property
-propertyWTInExtendedLocalGlobalCxt mods = propertyWT mods . inExtendedLocalCxt . inExtendedGlobalCxt
+propertyWTInExtendedLocalGlobalCxt mods = propertyWT mods . inExtendedGlobalCxt . inExtendedLocalCxt
 
 hprop_genTy :: Property
 hprop_genTy = withTests 1000 $
@@ -122,6 +122,13 @@ hprop_genCxtExtending_typechecks = withTests 1000 $
     checkValidContextTest cxt
     cxt' <- forAllT $ local (const cxt) genCxtExtendingLocal
     checkValidContextTest cxt'
+
+hprop_inExtendedLocalGlobalCxt_valid :: Property
+hprop_inExtendedLocalGlobalCxt_valid = withTests 1000 $
+  withDiscards 2000 $
+    propertyWTInExtendedLocalGlobalCxt [builtinModule, primitiveModule] $ do
+      cxt <- ask
+      checkValidContextTest cxt
 
 hprop_genCxtExtending_is_extension :: Property
 hprop_genCxtExtending_is_extension =


### PR DESCRIPTION
Since it runs in the WT monad, it may happen to be called with some
non-empty local context (which can contain type variables). We should
ignore this since type definitions are global things, and these locals
would be out of scope.

Another way of solving the problem is to change
propertyWTInExtendedLocalGlobalCxt to extend locals and globals in the
other order. (Since the extension functions prepend some setup actions,
the way it was previously written actually extends with locals first, so
that when genTypeDefGroup runs it may have local type variables in the
context).

Whilst changing either one of these functions would be enough on its
own, we implement both fixes for robustness.

We add a property test which (without the other changes in this commit)
very quickly finds an UnknownTypeVariable error due to a type
definition being generated that refers to a local variable.