### PR TITLE
test: Tests/Transform.hs reports failing line numbers

### DIFF
--- a/primer/test/Tests/Transform.hs
+++ b/primer/test/Tests/Transform.hs
@@ -208,14 +208,14 @@ unit_cross_ann =
 unit_cross_aPP :: Assertion
 unit_cross_aPP = afterRenameCross "x" "y" (aPP emptyHole $ tvar "x") (Just $ aPP emptyHole $ tvar "y")
 
-afterRename :: LVarName -> LVarName -> S Expr -> Maybe (S Expr) -> Assertion
+afterRename :: HasCallStack => LVarName -> LVarName -> S Expr -> Maybe (S Expr) -> Assertion
 afterRename = afterRename' renameLocalVar clearMeta
   where
     -- Clear the backend-created metadata (IDs and cached types) in the given expression
     clearMeta :: Expr' ExprMeta TypeMeta -> Expr' (Maybe Value) (Maybe Value)
     clearMeta = over _exprMeta (view _metadata) . over _exprTypeMeta (view _metadata)
 
-afterRenameTy :: TyVarName -> TyVarName -> S Type -> Maybe (S Type) -> Assertion
+afterRenameTy :: HasCallStack => TyVarName -> TyVarName -> S Type -> Maybe (S Type) -> Assertion
 afterRenameTy = afterRename' renameTyVar clearMeta
   where
     -- Clear the backend-created metadata (IDs and cached types) in the given expression
@@ -223,7 +223,7 @@ afterRenameTy = afterRename' renameTyVar clearMeta
     clearMeta = over _typeMeta (view _metadata)
 
 -- | A helper to test the renaming of type variables inside terms
-afterRenameCross :: TyVarName -> TyVarName -> S Expr -> Maybe (S Expr) -> Assertion
+afterRenameCross :: HasCallStack => TyVarName -> TyVarName -> S Expr -> Maybe (S Expr) -> Assertion
 afterRenameCross = afterRename' renameTyVarExpr clearMeta
   where
     -- Clear the backend-created metadata (IDs and cached types) in the given expression
@@ -231,7 +231,7 @@ afterRenameCross = afterRename' renameTyVarExpr clearMeta
     clearMeta = over _exprMeta (view _metadata) . over _exprTypeMeta (view _metadata)
 
 afterRename' ::
-  (Show a, Show b, Eq a, Eq b) =>
+  (HasCallStack, Show a, Show b, Eq a, Eq b) =>
   (LocalName k -> LocalName k -> a -> Maybe a) ->
   (a -> b) ->
   LocalName k ->


### PR DESCRIPTION
Previously Tasty.HUnit would blame the `@?=` line in the helpers, rather
than their callers. This is the same fix as
adab6f3f7a4ae3514d29bce6a078448a86184508 implements for the Eval and
Typecheck tests.