### PR TITLE
ci: switch to circuithub/nix-buildkite.

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -10,7 +10,7 @@ steps:
   - command: nix-buildkite
     label: ":nixos: :buildkite:"
     plugins:
-      - hackworthltd/nix-buildkite#hackworthltd-v5:
+      - circuithub/nix-buildkite:
           file: ci.nix
           post-build-hook:
             /run/current-system/sw/bin/buildkite-private-post-build-hook


### PR DESCRIPTION
All our patches are now upstream.