### PR TITLE
refactor: use focusOn in Primer.Action.Available

### DIFF
--- a/primer/src/Primer/Action.hs
+++ b/primer/src/Primer/Action.hs
@@ -135,6 +135,7 @@ import Primer.Zipper (
   target,
   top,
   unfocus,
+  unfocusExpr,
   unfocusLoc,
   unfocusType,
   up,
@@ -516,7 +517,7 @@ applyActionsToBody sh modules def actions =
           e = unfocus ze
       e' <- exprTtoExpr <$> check (forgetTypeIDs (astDefType def)) e
       let def' = def{astDefExpr = e'}
-      case focusOn targetID (focus e') of
+      case focusOn targetID e' of
         Nothing -> throwError $ InternalFailure "lost ID after typechecking"
         Just z -> pure (def', z)
 
@@ -527,7 +528,7 @@ applyActionAndCheck ty action z = do
       targetID = getID z'
   typedAST <- check (forgetTypeIDs ty) e
   -- Refocus on where we were previously
-  case focusOn targetID (focus (exprTtoExpr typedAST)) of
+  case focusOn targetID (exprTtoExpr typedAST) of
     Just z'' -> pure z''
     Nothing -> throwError $ CustomFailure action "internal error: lost ID after typechecking"
 
@@ -561,7 +562,7 @@ synthZ z =
    in do
         (_, typedAST) <- synth e
         -- Refocus on where we were previously
-        pure $ focusOn targetID $ focus $ exprTtoExpr typedAST
+        pure $ focusOn targetID $ exprTtoExpr typedAST
 
 applyAction' :: ActionM m => Action -> Loc -> m Loc
 applyAction' a = case a of
@@ -629,7 +630,7 @@ applyAction' a = case a of
       _ -> throwError $ CustomFailure a s
 
 setCursor :: ActionM m => ID -> ExprZ -> m Loc
-setCursor i e = case focusOn i (top e) of
+setCursor i e = case focusOn i (unfocusExpr e) of
   Just e' -> pure e'
   Nothing -> throwError $ IDNotFound i
 

--- a/primer/src/Primer/Action/Available.hs
+++ b/primer/src/Primer/Action/Available.hs
@@ -65,7 +65,6 @@ import Primer.Zipper (
   BindLoc' (BindCase),
   Loc' (InBind, InExpr, InType),
   caseBindZFocus,
-  focus,
   focusOn,
   focusOnTy,
   target,
@@ -226,7 +225,7 @@ findNodeWithParent ::
   Expr' (Meta a) (Meta b) ->
   Maybe (SomeNode a b, Maybe (SomeNode a b))
 findNodeWithParent id x = do
-  z <- focusOn id (focus x)
+  z <- focusOn id x
   Just
     ( case z of
         InExpr ez -> (ExprNode $ target ez, ExprNode . target <$> up ez)
@@ -243,7 +242,7 @@ findNodeWithParent id x = do
 
 -- | Find a sub-type in a larger type by its ID.
 findType :: forall b. Data b => ID -> Type' (Meta b) -> Maybe (Type' (Meta b))
-findType id ty = target <$> focusOnTy id (focus ty)
+findType id ty = target <$> focusOnTy id ty
 
 -- | An ActionSpec is an OfferedAction that needs
 -- metadata in order to be used. Typically this is because it starts with

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -179,7 +179,6 @@ import Primer.Zipper (
   bindersAboveTy,
   bindersAboveTypeZ,
   current,
-  focus,
   focusOn,
   focusOnTy,
   focusOnlyType,
@@ -406,8 +405,8 @@ focusNodeDefs defs defname nodeid =
   case lookupASTDef defname defs of
     Nothing -> throwError $ DefNotFound defname
     Just def ->
-      let mzE = locToEither <$> focusOn nodeid (focus $ astDefExpr def)
-          mzT = focusOnTy nodeid $ focus $ astDefType def
+      let mzE = locToEither <$> focusOn nodeid (astDefExpr def)
+          mzT = focusOnTy nodeid $ astDefType def
        in case fmap Left mzE <|> fmap Right mzT of
             Nothing -> throwError $ ActionError (IDNotFound nodeid)
             Just x -> pure x

--- a/primer/src/Primer/Eval.hs
+++ b/primer/src/Primer/Eval.hs
@@ -100,7 +100,6 @@ import Primer.Zipper (
   Loc' (InExpr, InType),
   TypeZ,
   current,
-  focus,
   focusOn,
   foldAbove,
   prior,
@@ -340,7 +339,7 @@ step globals expr i = runExceptT $ do
 -- Returns Nothing if the node is a type, because types can't be evaluated in Primer.
 findNodeByID :: ID -> Expr -> Maybe (Locals, Either ExprZ TypeZ)
 findNodeByID i expr = do
-  loc <- focusOn i (focus expr)
+  loc <- focusOn i expr
   case loc of
     InExpr z ->
       let locals = foldAbove collectBinding z

--- a/primer/src/Primer/Zipper.hs
+++ b/primer/src/Primer/Zipper.hs
@@ -326,8 +326,12 @@ replace :: (IsZipper za a) => a -> za -> za
 replace = over asZipper . replaceHole
 
 -- | Focus on the node with the given 'ID', if it exists in the expression
-focusOn :: (Data a, Data b, Eq a, HasID a, HasID b) => ID -> ExprZ' a b -> Maybe (Loc' a b)
-focusOn i = fmap snd . search matchesID
+focusOn :: (Data a, Data b, Eq a, HasID a, HasID b) => ID -> Expr' a b -> Maybe (Loc' a b)
+focusOn i = focusOn' i . focus
+
+-- | Focus on the node with the given 'ID', if it exists in the focussed expression
+focusOn' :: (Data a, Data b, Eq a, HasID a, HasID b) => ID -> ExprZ' a b -> Maybe (Loc' a b)
+focusOn' i = fmap snd . search matchesID
   where
     matchesID z
       -- If the current target has the correct ID, return that
@@ -343,9 +347,17 @@ focusOn i = fmap snd . search matchesID
 focusOnTy ::
   (Data b, HasID b) =>
   ID ->
+  Type' b ->
+  Maybe (Zipper (Type' b) (Type' b))
+focusOnTy i = focusOnTy' i . focus
+
+-- | Focus on the node with the given 'ID', if it exists in the focussed type
+focusOnTy' ::
+  (Data b, HasID b) =>
+  ID ->
   Zipper (Type' b) (Type' b) ->
   Maybe (Zipper (Type' b) (Type' b))
-focusOnTy i = fmap snd . search matchesID
+focusOnTy' i = fmap snd . search matchesID
   where
     matchesID z
       -- If the current target has the correct ID, return that

--- a/primer/test/Tests/Zipper.hs
+++ b/primer/test/Tests/Zipper.hs
@@ -25,7 +25,7 @@ hprop_focusOn_unfocus_roundtrip :: Property
 hprop_focusOn_unfocus_roundtrip = property $ do
   e <- forAll $ evalExprGen 0 genExpr
   i <- forAll $ Gen.element $ idsIn e
-  case focusOn i (focus e) of
+  case focusOn i e of
     Just e' -> unfocus e' === e
     _ -> annotateShow i >> failure
 
@@ -35,7 +35,7 @@ hprop_focusOn_succeeds_on_valid_ids :: Property
 hprop_focusOn_succeeds_on_valid_ids = property $ do
   e <- forAll $ evalExprGen 0 genExpr
   forM_ (idsIn e) $ \i -> do
-    case focusOn i (focus e) of
+    case focusOn i e of
       Just (InExpr e') -> getID (target e') === i
       Just (InType t) -> getID (target t) === i
       Just (InBind (BindCase b)) -> getID (target b) === i


### PR DESCRIPTION
We have a manually-coded search for a node which can easily be implemented in terms of `focusOn`.