### PR TITLE
chore: Core does not need UndecidableInstances

### DIFF
--- a/primer/src/Primer/Core.hs
+++ b/primer/src/Primer/Core.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 -- This module defines the core AST and some functions for operating on it.
 


### PR DESCRIPTION
This has not been needed since b85521843eca623b096a2b23a083b2ac055483b5.