### PR TITLE
fix: alphaEqTy did not handle repeated binder names properly

### DIFF
--- a/primer/test/Tests/AlphaEquality.hs
+++ b/primer/test/Tests/AlphaEquality.hs
@@ -83,6 +83,11 @@ unit_11 =
     (create_ (tforall "a" KType $ tcon tBool `tfun` (tcon tList `tapp` tvar "a")))
     (create_ (tcon tBool `tfun` tforall "a" KType (tcon tList `tapp` tvar "a")))
 
+unit_repeated_names :: Assertion
+unit_repeated_names =
+  create_ (tforall "b" KType (tforall "foo" KType (tforall "x" KType $ tvar "x")))
+    @?= create_ (tforall "foo" KType (tforall "foo" KType (tforall "x" KType $ tvar "x")))
+
 hprop_refl :: Property
 hprop_refl = property $ do
   t <- forgetTypeIDs <$> forAll (evalExprGen 0 genType)


### PR DESCRIPTION
Note that the maps 'p' and 'q' need not have the same size if types have
repeated names in their binders. Let's just explicitly count how many
binders we have gone under.