### PR TITLE
refactor: inline ExprAnyFresh

### DIFF
--- a/primer/src/Primer/Core.hs
+++ b/primer/src/Primer/Core.hs
@@ -56,7 +56,6 @@ module Primer.Core (
   primConName,
   PrimFun (..),
   primFunType,
-  ExprAnyFresh,
   PrimFunError (..),
   ValCon (..),
   valConType,
@@ -539,7 +538,7 @@ primConName = \case
 data PrimFun = PrimFun
   { primFunTypes :: forall m. MonadFresh ID m => m ([Type], Type)
   -- ^ the function's arguments and return type
-  , primFunDef :: [Expr' () ()] -> Either PrimFunError ExprAnyFresh
+  , primFunDef :: [Expr' () ()] -> Either PrimFunError (forall m. MonadFresh ID m => m Expr)
   }
 
 primFunType :: forall m. MonadFresh ID m => PrimFun -> m Type
@@ -550,8 +549,6 @@ primFunType pf = do
     f x y = do
       id <- fresh
       pure $ TFun (Meta id Nothing Nothing) x y
-
-type ExprAnyFresh = forall m. MonadFresh ID m => m Expr
 
 data PrimFunError
   = -- | We have attempted to apply a primitive function to invalid args.

--- a/primer/src/Primer/Eval.hs
+++ b/primer/src/Primer/Eval.hs
@@ -56,7 +56,6 @@ import Primer.Core (
   DefMap,
   Expr,
   Expr' (..),
-  ExprAnyFresh,
   GVarName,
   HasID (_id),
   ID,
@@ -983,7 +982,7 @@ munless x b = if b then mempty else x
 
 -- | If this node is a reducible application of a primitive, return the name of the primitive, the arguments, and
 -- (a computation for building) the result.
-tryPrimFun :: Map GVarName PrimDef -> Expr -> Maybe (GVarName, [Expr], ExprAnyFresh)
+tryPrimFun :: Map GVarName PrimDef -> Expr -> Maybe (GVarName, [Expr], forall m. MonadFresh ID m => m Expr)
 tryPrimFun primDefs expr
   | -- Since no primitive functions are polymorphic, there is no need to unfoldAPP
     (Var _ (GlobalVarRef name), args) <- bimap stripAnns (map stripAnns) $ unfoldApp expr

--- a/primer/src/Primer/EvalFull.hs
+++ b/primer/src/Primer/EvalFull.hs
@@ -51,7 +51,6 @@ import Primer.Core (
     Letrec,
     Var
   ),
-  ExprAnyFresh,
   ExprMeta,
   GVarName,
   ID,
@@ -155,7 +154,7 @@ data Redex
     RenameSelfLet LVarName Expr Expr
   | -- As RenameSelfLet, but for LetType. (Note that it is unnecessary for letrec.)
     RenameSelfLetType TyVarName Type Expr
-  | ApplyPrimFun ExprAnyFresh
+  | ApplyPrimFun (forall m. MonadFresh ID m => m Expr)
 
 -- there are only trivial redexes in types.
 -- Note that the let must appear in the surrounding Expr (not in a type itself)


### PR DESCRIPTION
This had always been the intention after we moved to GHC 9.2. In
7b5a4a0cde40b0ec537af1b15e04930d9a1e348a we dropped the newtype wrapper
but neglected to inline it.