### PR TITLE
Ensure API calls do not introduce shadowing

### DIFF
--- a/primer-benchmark/src/Benchmarks.hs
+++ b/primer-benchmark/src/Benchmarks.hs
@@ -23,7 +23,7 @@ import Primer.App.Utils (forgetProgTypecache)
 import Primer.Eval (
   NormalOrderOptions (UnderBinders),
   RunRedexOptions (RunRedexOptions, pushAndElide),
-  ViewRedexOptions (ViewRedexOptions, aggressiveElision, groupedLets),
+  ViewRedexOptions (ViewRedexOptions, aggressiveElision, avoidShadowing, groupedLets),
  )
 import Primer.EvalFull (
   Dir (Syn),
@@ -104,7 +104,7 @@ benchmarks =
   ]
   where
     evalOptionsN = UnderBinders
-    evalOptionsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+    evalOptionsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
     evalOptionsR = RunRedexOptions{pushAndElide = True}
     evalTestMPureLogs e maxEvals =
       evalTestM (maxID e)

--- a/primer/gen/Primer/Gen/Core/Raw.hs
+++ b/primer/gen/Primer/Gen/Core/Raw.hs
@@ -141,13 +141,16 @@ genLetrec = Letrec <$> genMeta <*> genLVarName <*> genExpr <*> genType <*> genEx
 genCase :: ExprGen Expr
 genCase = Case <$> genMeta <*> genExpr <*> Gen.list (Range.linear 0 5) genBranch <*> Gen.choice [pure CaseExhaustive, CaseFallback <$> genExpr]
   where
-    genBranch = CaseBranch <$> genScrut <*> Gen.list (Range.linear 0 5) genBind <*> genExpr
+    genBranch = CaseBranch <$> genScrut <*> genBinds (Range.linear 0 5) <*> genExpr
     genScrut =
       Gen.choice
         [ PatCon <$> genValConName
         , PatPrim <$> genPrimCon
         ]
-    genBind = Bind <$> genMeta <*> genLVarName
+    genBinds r = do
+      ns0 <- Gen.set r genLVarName
+      ns <- Gen.shuffle $ toList ns0
+      traverse (\n -> Bind <$> genMeta <*> pure n) ns
 
 genPrim :: ExprGen Expr
 genPrim = PrimCon <$> genMeta <*> genPrimCon

--- a/primer/gen/Primer/Gen/Core/Typed.hs
+++ b/primer/gen/Primer/Gen/Core/Typed.hs
@@ -37,6 +37,7 @@ import Control.Monad.Morph (hoist)
 import Control.Monad.Reader (mapReaderT)
 import Data.List.Extra (nubSortOn)
 import Data.Map qualified as M
+import Data.Set qualified as S
 import Hedgehog (
   GenT,
   MonadGen,
@@ -470,9 +471,11 @@ genChk ty = do
                         ]
                     fmap (Just . (,fb)) . for vcs $ \(c, params) -> do
                       ns <- for params $ \nt -> (,nt) <$> genLVarNameAvoiding [ty, nt]
+                      unless (distinct $ map fst ns) Gen.discard
                       let binds = map (Bind () . fst) ns
                       CaseBranch (PatCon c) binds <$> local (extendLocalCxts ns) (genChk ty)
             pure $ Case () e brs fb
+    distinct xs = length xs == S.size (S.fromList xs)
     casePrim :: WT (Maybe (GenT WT ExprG))
     casePrim = do
       primGens <- genPrimCon

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -233,6 +233,7 @@ test-suite primer-test
     Tests.Questions
     Tests.Refine
     Tests.Serialization
+    Tests.Shadowing
     Tests.Subst
     Tests.Transform
     Tests.Typecheck

--- a/primer/src/Primer/Core/Transform.hs
+++ b/primer/src/Primer/Core/Transform.hs
@@ -4,6 +4,7 @@ module Primer.Core.Transform (
   renameTyVar,
   renameTyVarExpr,
   unfoldApp,
+  unfoldAPP,
   unfoldTApp,
   decomposeTAppCon,
   foldTApp,
@@ -212,6 +213,13 @@ unfoldApp :: Expr' a b c -> (Expr' a b c, [Expr' a b c])
 unfoldApp = second reverse . go
   where
     go (App _ f x) = let (g, args) = go f in (g, x : args)
+    go e = (e, [])
+
+-- | Unfold a nested term-level type application into the application head and a list of arguments.
+unfoldAPP :: Expr' a b c -> (Expr' a b c, [Type' b c])
+unfoldAPP = second reverse . go
+  where
+    go (APP _ f x) = let (g, args) = go f in (g, x : args)
     go e = (e, [])
 
 -- | Unfold a nested type-level application into the application head and a list of arguments.

--- a/primer/src/Primer/Eval/Redex.hs
+++ b/primer/src/Primer/Eval/Redex.hs
@@ -43,6 +43,7 @@ import Optics (
   getting,
   ifiltered,
   isnd,
+  preview,
   summing,
   to,
   traverseOf,
@@ -165,6 +166,7 @@ import Primer.Typecheck.Utils (
 import Primer.Zipper (
   LetBinding,
   LetBinding' (LetBind, LetTyBind, LetrecBind),
+  bindersBelow,
   bindersBelowTy,
   focus,
   getBoundHereDn,
@@ -189,6 +191,9 @@ data ViewRedexOptions = ViewRedexOptions
   -- down) (@False@). E.g. in @let x=e in C s t@ (where @s@ and @t@
   -- do not refer to @x@) whether we reduce to @C s t@ or
   -- @C (let x = e in s) (let x = e in t)@.
+  , avoidShadowing :: Bool
+  -- ^ Whether to introduce extra renamings to avoid shadowing
+  -- (note that we will always rename to avoid capture where necessary).
   }
 
 newtype RunRedexOptions = RunRedexOptions
@@ -525,6 +530,15 @@ _freeVarsLetBinding =
 _freeVarsLetTypeBinding :: Fold LetTypeBinding TyVarName
 _freeVarsLetTypeBinding = _LetTypeBind % _2 % getting _freeVarsTy % _2
 
+boundVarsLetBinding :: LetBinding -> Set Name
+boundVarsLetBinding = \case
+  LetBind _ e -> bindersBelow $ focus e
+  LetrecBind _ e t -> bindersBelow (focus e) <> S.map unLocalName (bindersBelowTy (focus t))
+  LetTyBind l -> S.map unLocalName $ boundVarsLetBindingTy l
+
+boundVarsLetBindingTy :: LetTypeBinding -> Set TyVarName
+boundVarsLetBindingTy (LetTypeBind _ t) = bindersBelowTy (focus t)
+
 data Dir = Syn | Chk
   deriving stock (Eq, Show, Read, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON Dir
@@ -532,10 +546,11 @@ data Dir = Syn | Chk
 viewCaseRedex ::
   forall l m.
   (MonadLog (WithSeverity l) m, ConvertLogMessage EvalLog l) =>
+  ViewRedexOptions ->
   TypeDefMap ->
   Expr ->
   MaybeT m Redex
-viewCaseRedex tydefs = \case
+viewCaseRedex opts tydefs = \case
   orig@(Case _ scrut [] (CaseFallback rhs)) -> do
     -- If we have @case e of _ -> t@, then this reduces to @t@ without inspecting @e@
     -- i.e. a @case@ which does not actually discriminate is lazy
@@ -623,7 +638,7 @@ viewCaseRedex tydefs = \case
        the last doesn't need any renaming.)
     -}
     renameBindings meta scrutinee branches fallbackBranch patterns orig =
-      let avoid = freeVars scrutinee
+      let avoid = freeVars scrutinee <> mwhen opts.avoidShadowing (bindersBelow $ focus scrutinee)
           binders = maybe mempty (S.fromList . map (unLocalName . bindName)) patterns
        in hoistMaybe
             $ if S.disjoint avoid binders
@@ -695,7 +710,8 @@ viewRedex opts tydefs globals dir = \case
     , null letBindings
     , n <- letBindingName $ snd letBinding1
     , not opts.aggressiveElision || n `S.member` freeVars expr'
-    , S.disjoint (getBoundHereDn expr') (setOf (_2 % (_freeVarsLetBinding `summing` to letBindingName)) letBinding1) ->
+    , S.disjoint (getBoundHereDn expr') (setOf (_2 % (_freeVarsLetBinding `summing` to letBindingName)) letBinding1)
+    , not opts.avoidShadowing || S.disjoint (getBoundHereDn expr') (boundVarsLetBinding . snd $ letBinding1) ->
         pure
           $ PushLet
             { bindings = pure $ first getID letBinding1
@@ -706,7 +722,8 @@ viewRedex opts tydefs globals dir = \case
     , not $ isLeaf body
     , (_, unused) <- partitionLets (letBinding1 : letBindings) body
     , not opts.aggressiveElision || null unused
-    , S.disjoint (getBoundHereDn body) (setOf (folded % _2 % (_freeVarsLetBinding `summing` to letBindingName)) $ letBinding1 : letBindings) ->
+    , S.disjoint (getBoundHereDn body) (setOf (folded % _2 % (_freeVarsLetBinding `summing` to letBindingName)) $ letBinding1 : letBindings)
+    , not opts.avoidShadowing || S.disjoint (getBoundHereDn body) (foldMap' (boundVarsLetBinding . snd) $ letBinding1 : letBindings) ->
         pure
           $ PushLet
             { bindings = first getID <$> letBinding1 :| letBindings
@@ -737,12 +754,12 @@ viewRedex opts tydefs globals dir = \case
             , orig
             }
   l@(Lam meta var body) -> do
-    avoid <- cxtToAvoid
+    avoid <- liftA2 (<>) cxtToAvoid $ when' opts.avoidShadowing cxtToAvoidShadow
     if unLocalName var `S.member` avoid
       then pure $ RenameBindingsLam{var, meta, body, avoid, orig = l}
       else mzero
   l@(LAM meta v body) -> do
-    avoid <- cxtToAvoid
+    avoid <- liftA2 (<>) cxtToAvoid $ when' opts.avoidShadowing cxtToAvoidShadow
     if unLocalName v `S.member` avoid
       then pure $ RenameBindingsLAM{tyvar = v, meta, body, avoid, orig = l}
       else mzero
@@ -778,18 +795,22 @@ viewRedex opts tydefs globals dir = \case
         }
   APP{} -> mzero
   e@(Case meta scrutinee branches fallbackBranch) -> do
-    avoid <- cxtToAvoid
+    avoid <- liftA2 (<>) cxtToAvoid $ when' opts.avoidShadowing cxtToAvoidShadow
     -- TODO: we arbitrarily decide that renaming takes priority over reducing the case
     -- This is good for evalfull, but bad for interactive use.
     -- Maybe we want to offer both. See
     -- https://github.com/hackworthltd/primer/issues/734
     if getBoundHereDn e `S.disjoint` avoid
-      then lift $ viewCaseRedex tydefs e
+      then lift $ viewCaseRedex opts tydefs e
       else pure $ RenameBindingsCase{meta, scrutinee, branches, fallbackBranch, avoid, orig = e}
   orig@(Ann _ expr ty) | Chk <- dir, concreteTy ty -> pure $ Upsilon{expr, ann = ty, orig}
   _ -> mzero
   where
     isLeaf = null . children
+
+-- | As 'when', but with a monoidal return
+when' :: (Applicative f, Monoid a) => Bool -> f a -> f a
+when' b m = if b then m else pure mempty
 
 -- Decompose @let a = s in let b0 = t0 in ... let bn = tn in e@
 -- into @(LetBind a s, let b0=t0 in ... e, [LetBind b0 t0, ..., LetBind bn tn], e)@
@@ -862,7 +883,8 @@ viewRedexType opts = \case
     , not $ isLeaf ty'
     , null letBindings
     , not opts.aggressiveElision || letTypeBindingName' (snd letBinding1) `S.member` freeVarsTy ty'
-    , S.disjoint (getBoundHereDnTy ty') (setOf (_2 % (_freeVarsLetTypeBinding `summing` to letTypeBindingName')) letBinding1) ->
+    , S.disjoint (getBoundHereDnTy ty') (setOf (_2 % (_freeVarsLetTypeBinding `summing` to letTypeBindingName')) letBinding1)
+    , not opts.avoidShadowing || S.disjoint (getBoundHereDnTy ty') (boundVarsLetBindingTy . snd $ letBinding1) ->
         purer
           $ PushLetType
             { bindings = pure $ first getID letBinding1
@@ -873,7 +895,8 @@ viewRedexType opts = \case
     , not $ isLeaf body
     , (_, unused) <- partitionLetsTy (letBinding1 : letBindings) body
     , not opts.aggressiveElision || null unused
-    , S.disjoint (getBoundHereDnTy body) (setOf (folded % _2 % (_freeVarsLetTypeBinding `summing` to letTypeBindingName')) (letBinding1 : letBindings)) ->
+    , S.disjoint (getBoundHereDnTy body) (setOf (folded % _2 % (_freeVarsLetTypeBinding `summing` to letTypeBindingName')) (letBinding1 : letBindings))
+    , not opts.avoidShadowing || S.disjoint (getBoundHereDnTy body) (foldMap' (boundVarsLetBindingTy . snd) $ letBinding1 : letBindings) ->
         purer
           $ PushLetType
             { bindings = first getID <$> letBinding1 :| letBindings
@@ -901,7 +924,7 @@ viewRedexType opts = \case
             , orig
             }
   orig@(TForall meta origBinder kind body) -> do
-    avoid <- cxtToAvoidTy
+    avoid <- liftA2 (<>) cxtToAvoidTy $ when' opts.avoidShadowing cxtToAvoidTyShadow
     pure
       $ if origBinder `S.member` avoid
         then
@@ -936,6 +959,21 @@ cxtToAvoidTy :: MonadReader Cxt m => m (S.Set TyVarName)
 cxtToAvoidTy = do
   Cxt cxt <- ask
   pure $ foldMap' (setOf (_LetTyBind % _LetTypeBind % (_1 `summing` _2 % getting _freeVarsTy % _2))) cxt
+
+-- We may want to push some let bindings (the Cxt) under a
+-- binder; what variable names must the binder avoid for this to
+-- not cause shadowing?
+-- (NB: this does not include 'cxtToAvoid' which must additionally
+-- be avoided else capture may occur)
+cxtToAvoidShadow :: MonadReader Cxt m => m (S.Set Name)
+cxtToAvoidShadow = do
+  Cxt cxt <- ask
+  pure $ foldMap' boundVarsLetBinding cxt
+
+cxtToAvoidTyShadow :: MonadReader Cxt m => m (S.Set TyVarName)
+cxtToAvoidTyShadow = do
+  Cxt cxt <- ask
+  pure $ foldMap' (maybe mempty boundVarsLetBindingTy . preview _LetTyBind) cxt
 
 -- TODO: deal with metadata. https://github.com/hackworthltd/primer/issues/6
 runRedex :: forall l m. MonadEval l m => RunRedexOptions -> Redex -> m (Expr, EvalDetail)

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -919,6 +919,7 @@ checkBranch t (vc, args) (CaseBranch nb patterns rhs) =
     -- We check an invariant due to paranoia
     assertCorrectCon
     sh <- asks smartHoles
+    unless (distinct $ bindName <$> patterns) $ throwError' $ DuplicateBinders $ bindName <$> patterns
     (fixedPats, fixedRHS) <- case (length args == length patterns, sh) of
       (False, NoSmartHoles) -> throwError' CaseBranchWrongNumberPatterns
       -- if the branch is nonsense, replace it with a sensible pattern and an empty hole

--- a/primer/src/Primer/Typecheck/TypeError.hs
+++ b/primer/src/Primer/Typecheck/TypeError.hs
@@ -3,7 +3,7 @@ module Primer.Typecheck.TypeError (TypeError (..)) where
 import Foreword
 
 import Primer.Core (Expr, Pattern)
-import Primer.Core.Meta (TmVarRef, TyConName, ValConName)
+import Primer.Core.Meta (LVarName, TmVarRef, TyConName, ValConName)
 import Primer.Core.Type (Type')
 import Primer.JSON (CustomJSON (..), FromJSON, PrimerJSON, ToJSON)
 import Primer.Name (Name)
@@ -35,6 +35,9 @@ data TypeError
   | -- | Either wrong number, wrong constructors or wrong order. The fields are @name of the ADT@, @branches given@, @wildcard/fallback branch given@
     WrongCaseBranches TyConName [Pattern] Bool
   | CaseBranchWrongNumberPatterns
+  | -- | One AST node binds the same name twice
+    -- (currently this can only happen in a case branch)
+    DuplicateBinders [LVarName]
   | KindError KindError
   deriving stock (Eq, Show, Read, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON TypeError

--- a/primer/src/Primer/Zipper.hs
+++ b/primer/src/Primer/Zipper.hs
@@ -428,7 +428,9 @@ getBoundHereUp e = getBoundHere (current e) (Just $ prior e)
 
 -- Get the names bound within the focussed subtree
 bindersBelow :: ExprZ -> S.Set Name
-bindersBelow = foldBelow getBoundHereDn
+bindersBelow = foldBelow $ \e ->
+  getBoundHereDn e
+    <> maybe mempty (S.map unLocalName . bindersBelowTy . focusOnlyType) (focusType $ focus e)
 
 -- Get all names bound by this layer of an expression, for any child.
 -- E.g. for a "match" we get all vars bound by each branch.

--- a/primer/src/Primer/Zipper.hs
+++ b/primer/src/Primer/Zipper.hs
@@ -67,6 +67,7 @@ module Primer.Zipper (
   SomeNode (..),
   findNodeWithParent,
   findTypeOrKind,
+  FoldAbove' (FA),
 ) where
 
 import Foreword

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -1892,15 +1892,29 @@ unit_case_prim =
 
 -- * Utilities
 
-evalFullTest :: HasCallStack => ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> IO (Either EvalFullError Expr)
-evalFullTest id_ tydefs globals n d e = do
+evalFullTest' ::
+  HasCallStack =>
+  ViewRedexOptions ->
+  ID ->
+  TypeDefMap ->
+  DefMap ->
+  TerminationBound ->
+  Dir ->
+  Expr ->
+  IO (Either EvalFullError Expr)
+evalFullTest' optsV id_ tydefs globals n d e = do
   let optsN = UnderBinders
-  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
   let optsR = RunRedexOptions{pushAndElide = True}
   let (r, logs) = evalTestM id_ $ runPureLogT $ evalFull @EvalLog optsN optsV optsR tydefs globals n d e
   assertNoSevereLogs logs
   distinctIDs r
   pure r
+
+evalFullTest :: HasCallStack => ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> IO (Either EvalFullError Expr)
+evalFullTest = evalFullTest' ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
+
+evalFullTestAvoidShadowing :: HasCallStack => ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> IO (Either EvalFullError Expr)
+evalFullTestAvoidShadowing = evalFullTest' ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = True}
 
 evalFullTestExactSteps :: HasCallStack => ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> IO Expr
 evalFullTestExactSteps id_ tydefs globals n d e = do

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -796,7 +796,7 @@ tasty_open_closed_agree_base_types :: Property
 tasty_open_closed_agree_base_types = withDiscards 1000
   $ propertyWT testModules
   $ do
-    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
     let optsR = RunRedexOptions{pushAndElide = True}
     ty <- forAllT $ Gen.element @[] [tBool, tNat, tInt]
     tm' <- forAllT $ genChk $ TCon () ty
@@ -836,7 +836,7 @@ tasty_resume = withDiscards 2000
 -- A helper for tasty_resume, and tasty_resume_regression
 resumeTest :: [Module] -> Dir -> Expr -> PropertyT WT ()
 resumeTest mods dir t = do
-  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
   let optsR = RunRedexOptions{pushAndElide = True}
   let globs = foldMap' moduleDefsQualified mods
   tds <- asks typeDefs
@@ -1246,7 +1246,7 @@ tasty_type_preservation = withTests 1000
   $ withDiscards 2000
   $ propertyWT testModules
   $ do
-    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
     let optsR = RunRedexOptions{pushAndElide = True}
     let globs = foldMap' moduleDefsQualified $ create' $ sequence testModules
     tds <- asks typeDefs
@@ -1817,7 +1817,7 @@ tasty_unique_ids = withTests 1000
   $ withDiscards 2000
   $ propertyWT testModules
   $ do
-    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
     let optsR = RunRedexOptions{pushAndElide = True}
     let globs = foldMap' moduleDefsQualified $ create' $ sequence testModules
     tds <- asks typeDefs
@@ -1895,7 +1895,7 @@ unit_case_prim =
 evalFullTest :: HasCallStack => ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> IO (Either EvalFullError Expr)
 evalFullTest id_ tydefs globals n d e = do
   let optsN = UnderBinders
-  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
   let optsR = RunRedexOptions{pushAndElide = True}
   let (r, logs) = evalTestM id_ $ runPureLogT $ evalFull @EvalLog optsN optsV optsR tydefs globals n d e
   assertNoSevereLogs logs
@@ -1921,7 +1921,7 @@ evalFullTestClosed gl id_ tydefs globals n d e = do
   let gl' = case gl of
         GroupedLets -> True
         SingleLets -> False
-  let optsV = ViewRedexOptions{groupedLets = gl', aggressiveElision = True}
+  let optsV = ViewRedexOptions{groupedLets = gl', aggressiveElision = True, avoidShadowing = False}
   let optsR = RunRedexOptions{pushAndElide = True}
   let (r, logs) = evalTestM id_ $ runPureLogT $ evalFull @EvalLog optsN optsV optsR tydefs globals n d e
   assertNoSevereLogs logs
@@ -1931,7 +1931,7 @@ evalFullTestClosed gl id_ tydefs globals n d e = do
 evalFullTasty :: MonadTest m => ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> m (Either EvalFullError Expr)
 evalFullTasty id_ tydefs globals n d e = do
   let optsN = UnderBinders
-  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
   let optsR = RunRedexOptions{pushAndElide = True}
   let (r, logs) = evalTestM id_ $ runPureLogT $ evalFull @EvalLog optsN optsV optsR tydefs globals n d e
   testNoSevereLogs logs

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -378,7 +378,7 @@ unit_12 =
         expect <- con0 cTrue `ann` tcon tBool
         pure (expr, expect)
    in do
-        s <- evalFullTestExactSteps maxID builtinTypes mempty 10 Syn e
+        s <- evalFullTestExactSteps maxID builtinTypes mempty 9 Syn e
         s ~== expected
 
 unit_13 :: Assertion
@@ -529,8 +529,8 @@ unit_letrec_body_first =
           (con cCons [lvar "x", lvar "xs"])
           (tcon tList `tapp` tEmptyHole)
       (expr, maxID) = create $ lx $ lxs (lvar "xs")
-      expected1 = create' $ lx $ lxs $ con cCons [lvar "x", lvar "xs"] `ann` (tcon tList `tapp` tEmptyHole)
-      expected2 = create' $ lx (lxs $ con cCons [lvar "x", lvar "xs"]) `ann` (tcon tList `tapp` tEmptyHole)
+      expected1 = create' $ lx $ lxs (con cCons [lvar "x", lvar "xs"]) `ann` (tcon tList `tapp` tEmptyHole)
+      expected2 = create' $ lx (lxs (con cCons [lvar "x", lvar "xs"])) `ann` (tcon tList `tapp` tEmptyHole)
       expected3 = create' $ con cCons [lx $ lvar "x", lx $ lxs $ lvar "xs"] `ann` (tcon tList `tapp` tEmptyHole)
    in do
         e1 <- evalFullTest maxID builtinTypes mempty 1 Syn expr
@@ -1122,7 +1122,6 @@ unit_let_self_capture =
           , expr4
           , expected4a
           , expected4b
-          , expected4c
           )
         , maxID
         ) = create $ do
@@ -1139,16 +1138,9 @@ unit_let_self_capture =
             lAM "a"
               $ lam "f"
               $ lam "x"
-              $ letrec "x" (lvar "f" `app` lvar "x") (tvar "a")
-              $ (lvar "f" `app` lvar "x")
-              `ann` tvar "a"
-          expect4b <-
-            lAM "a"
-              $ lam "f"
-              $ lam "x"
               $ letrec "x" (lvar "f" `app` lvar "x") (tvar "a") (lvar "f" `app` lvar "x")
               `ann` tvar "a"
-          expect4c <-
+          expect4b <-
             lAM "a"
               $ lam "f"
               $ lam "x"
@@ -1165,7 +1157,6 @@ unit_let_self_capture =
             , e4
             , expect4a
             , expect4b
-            , expect4c
             )
       s1 n = evalFullTest maxID mempty mempty n Chk expr1
       s2 n = evalFullTest maxID mempty mempty n Chk expr2
@@ -1189,7 +1180,6 @@ unit_let_self_capture =
         s3 3 >>= (<~==> Right expected3b)
         s4 1 >>= (<~==> Left (TimedOut expected4a))
         s4 2 >>= (<~==> Left (TimedOut expected4b))
-        s4 3 >>= (<~==> Left (TimedOut expected4c))
 
 -- | @spanM p mxs@ returns a tuple where the first component is the
 -- values coming from the longest prefix of @mxs@ all of which satisfy

--- a/primer/test/Tests/Prelude/Utils.hs
+++ b/primer/test/Tests/Prelude/Utils.hs
@@ -10,7 +10,7 @@ import Primer.Core.DSL (apps', create', gvar)
 import Primer.Eval (
   NormalOrderOptions (UnderBinders),
   RunRedexOptions (RunRedexOptions, pushAndElide),
-  ViewRedexOptions (ViewRedexOptions, aggressiveElision, groupedLets),
+  ViewRedexOptions (ViewRedexOptions, aggressiveElision, avoidShadowing, groupedLets),
  )
 import Primer.EvalFull (Dir (Chk), EvalFullError, EvalLog, TerminationBound, evalFull)
 import Primer.Log (runPureLogT)
@@ -55,7 +55,7 @@ functionOutput f args = functionOutput' f (map Left args)
 functionOutput' :: GVarName -> [Either (TestM Expr) (TestM Type)] -> TerminationBound -> Either EvalFullError Expr
 functionOutput' f args depth =
   let optsN = UnderBinders
-      optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+      optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = False}
       optsR = RunRedexOptions{pushAndElide = True}
       (r, logs) = evalTestM 0 $ runPureLogT $ do
         e <- apps' (gvar f) $ bimap lift lift <$> args

--- a/primer/test/Tests/Shadowing.hs
+++ b/primer/test/Tests/Shadowing.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE ViewPatterns #-}
+
+module Tests.Shadowing where
+
+import Foreword
+
+import Data.Data (Data)
+import Data.Generics.Uniplate.Data qualified as U
+import Data.Set qualified as Set
+import Hedgehog (annotateShow, discard, failure, forAll, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Primer.Core (
+  Expr,
+  Expr' (Case, Var),
+  LocalName (unLocalName),
+  TmVarRef (GlobalVarRef),
+  Type',
+ )
+import Primer.Core.DSL (ann, app, create, create', lam, let_, lvar, tEmptyHole, tfun)
+import Primer.Core.Utils (freeGlobalVars)
+import Primer.Eval (
+  AvoidShadowing (AvoidShadowing),
+  Dir (Syn),
+  NormalOrderOptions (StopAtBinders, UnderBinders),
+  RunRedexOptions (RunRedexOptions, pushAndElide),
+  ViewRedexOptions (ViewRedexOptions, aggressiveElision, avoidShadowing, groupedLets),
+  redexes,
+  step,
+ )
+import Primer.EvalFull (EvalFullError (..), EvalLog, evalFullStepCount)
+import Primer.Gen.Core.Typed (forAllT)
+import Primer.Module (moduleDefsQualified)
+import Primer.Name (Name)
+import Primer.Test.Util (failWhenSevereLogs)
+import Primer.Typecheck (Cxt (typeDefs))
+import Primer.Zipper (
+  FoldAbove' (FA, current, prior),
+  Loc' (InExpr),
+  bindersAbove,
+  focus,
+  focusOn,
+  focusOnlyType,
+  focusType,
+  getBoundHereUp,
+  getBoundHereUpTy,
+  target,
+ )
+import Tasty (Property, withDiscards, withTests)
+import Test.Tasty.HUnit (Assertion)
+import Tests.Eval.Utils (genDirTm, testModules)
+import Tests.EvalFull (evalFullTestAvoidShadowing, (<~==>))
+import Tests.Gen.Core.Typed (propertyWTInExtendedGlobalCxt)
+
+{-
+Evaluation can result in variable shadowing even when there are no repeated binders in the initial term.
+We detect this shadowing and rename to avoid it.
+  (λf. f f : (? -> ?) -> ?) (λg y. g y)
+reduces in 4 steps to
+  (let g = (let f = λg y. g y : ? -> ? in f : ?) in λy. g y) : ? : ?
+if we did not worry about shadowing, we would then push the 'let g' and get
+  (λy. let g = (let f = λg y. g y : ? -> ? in f : ?) in g y) : ? : ?
+where the 'y' is shadowed.
+However, we instead do a renaming step and get
+  (let g = (let f = λg y. g y : ? -> ? in f : ?) in λz. let y = z in g y) : ? : ?
+-}
+unit_shadow_no_reused_binders :: Assertion
+unit_shadow_no_reused_binders =
+  let ((e, expect), maxID) = create $ do
+        e0 <-
+          ( lam "f" (lvar "f" `app` lvar "f")
+              `ann` ((tEmptyHole `tfun` tEmptyHole) `tfun` tEmptyHole)
+            )
+            `app` lam "g" (lam "y" $ lvar "g" `app` lvar "y")
+        e4 <-
+          ( let_
+              "g"
+              ( let_
+                  "f"
+                  (lam "g" (lam "y" $ lvar "g" `app` lvar "y") `ann` (tEmptyHole `tfun` tEmptyHole))
+                  (lvar "f")
+                  `ann` tEmptyHole
+              )
+              (lam "y" $ lvar "g" `app` lvar "y")
+              `ann` tEmptyHole
+            )
+            `ann` tEmptyHole
+        let z = "a88"
+        e5 <-
+          ( let_
+              "g"
+              ( let_
+                  "f"
+                  (lam "g" (lam "y" $ lvar "g" `app` lvar "y") `ann` (tEmptyHole `tfun` tEmptyHole))
+                  (lvar "f")
+                  `ann` tEmptyHole
+              )
+              (lam z $ let_ "y" (lvar z) $ lvar "g" `app` lvar "y")
+              `ann` tEmptyHole
+            )
+            `ann` tEmptyHole
+        pure (e0, [(0, e0), (4, e4), (5, e5)])
+   in do
+        for_ @[] expect $ \(s, ex) -> do
+          a <- evalFullTestAvoidShadowing maxID mempty mempty s Syn e
+          a <~==> Left (TimedOut ex)
+
+-- We use this type to compute a "tree of binders", which are a view of
+-- an expression (or type) where we only care about the tree shape and
+-- what subtrees binders scope over. (In fact, we don't strictly preserve
+-- the tree shape, as it is sometimes easier to insert extra empty nodes.)
+-- The 'a' parameter (node labels) are only needed for implementation of
+-- 'binderTree'
+data Tree a b = Node a [(b, Tree a b)]
+  deriving stock (Functor, Show)
+
+instance Bifunctor Tree where
+  bimap f g (Node a xs) = Node (f a) $ map (bimap g (bimap f g)) xs
+
+foldTree :: (a -> [(b, c)] -> c) -> Tree a b -> c
+foldTree f (Node a xs) = f a $ map (second $ foldTree f) xs
+
+-- NB: there are no children in kinds, so we need not look in the metadata
+-- NB: any binder in types (∀ only) scopes over all type children
+binderTreeTy :: forall b c. (Data b, Data c, Eq b, Eq c) => Type' b c -> Tree () (Set Name)
+binderTreeTy = noNodeLabels' . go
+  where
+    go :: Type' b c -> Tree (Type' b c) (Set Name)
+    go = U.para $ \ty children ->
+      Node ty $ map (\c@(Node c' _) -> (Set.map unLocalName $ getBoundHereUpTy FA{prior = c', current = ty}, c)) children
+
+-- Note this DOES NOT check if anything in the metadata's TypeCache
+-- is shadowed (or is shadowing); (see 'binderTree'). Currently
+-- it happens that we can ascribe a type of '∀a. _' to
+-- a subterm that happens to be under an 'a' binder. See
+-- https://github.com/hackworthltd/primer/issues/556
+noShadowing :: (Data a, Data b, Data c, Eq a, Eq b, Eq c) => Expr' a b c -> Shadowing
+noShadowing = checkShadowing . binderTree
+
+noShadowingTy :: (Data b, Data c, Eq b, Eq c) => Type' b c -> Shadowing
+noShadowingTy = checkShadowing . binderTreeTy
+
+noNodeLabels' :: Tree a' b' -> Tree () b'
+noNodeLabels' = bimap (const ()) identity
+
+binderTree :: forall a b c. (Data a, Data b, Data c, Eq a, Eq b, Eq c) => Expr' a b c -> Tree () (Set Name)
+binderTree = noNodeLabels' . go
+  where
+    noNodeLabels :: Tree () b' -> Tree (Maybe a') b'
+    noNodeLabels = bimap (const Nothing) identity
+    go :: Expr' a b c -> Tree (Maybe (Expr' a b c)) (Set Name)
+    go = U.para $ \e exprChildren' ->
+      let exprChildren =
+            map
+              ( \c@(Node c' _) ->
+                  ( case c' of
+                      Nothing -> mempty -- no term binders scope over metadata or type children
+                      Just c'' -> getBoundHereUp $ FA{prior = c'', current = e}
+                  , c
+                  )
+              )
+              exprChildren'
+          typeChildren = case target . focusOnlyType <$> focusType (focus e) of
+            Just ty -> [binderTreeTy ty]
+            Nothing -> mempty
+       in {-
+             -- We don't include metadata. see
+             -- https://github.com/hackworthltd/primer/issues/556
+             metaChildren = case e ^. _exprMetaLens % _type of
+               Nothing -> mempty
+               Just (TCChkedAt ty) -> [binderTreeTy ty]
+               Just (TCSynthed ty) -> [binderTreeTy ty]
+               Just (TCEmb (TCBoth ty1 ty2)) -> [binderTreeTy ty1, binderTreeTy ty2]
+             -}
+
+          Node (Just e) $ exprChildren <> map ((mempty,) . noNodeLabels) typeChildren {- <> metaChildren-}
+
+data Shadowing = ShadowingExists (Set Name) | ShadowingNotExists
+  deriving stock (Eq, Show)
+
+checkShadowing :: Tree () (Set Name) -> Shadowing
+checkShadowing t =
+  let shadows = fst $ foldTree f t
+   in if Set.null shadows
+        then ShadowingNotExists
+        else ShadowingExists shadows
+  where
+    f :: () -> [(Set Name, (Set Name, Set Name))] -> (Set Name, Set Name)
+    f () xs =
+      let allSubtreeBinds = Set.unions $ map (snd . snd) xs
+          bindsHere = Set.unions $ map fst xs
+          allBinds = bindsHere <> allSubtreeBinds
+          shadowing = Set.unions $ map (\(newBinders, (oldShadows, oldBinders)) -> oldShadows <> Set.intersection newBinders oldBinders) xs
+       in (shadowing, allBinds)
+
+-- Check evaluation does not introduce shadowing, except in some known cases
+tasty_eval_full_shadow :: Property
+tasty_eval_full_shadow = withTests 500
+  $ withDiscards 2000
+  $ propertyWTInExtendedGlobalCxt testModules
+  $ do
+    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True, avoidShadowing = True}
+    let optsR = RunRedexOptions{pushAndElide = True}
+    let globs = foldMap' moduleDefsQualified $ create' $ sequence testModules
+    optsN <- forAll $ Gen.element @[] [StopAtBinders, UnderBinders]
+    tds <- asks typeDefs
+    (dir, t, _ty) <- genDirTm
+    unless (noShadowing t == ShadowingNotExists) discard
+    when (isKnownShadow optsN t) discard
+    n <- forAll $ Gen.integral (Range.linear 1 20)
+    (_steps, s) <- failWhenSevereLogs $ evalFullStepCount @EvalLog optsN optsV optsR tds globs n dir t
+    annotateShow s
+    noShadowing (getEvalResultExpr s) === ShadowingNotExists
+  where
+    -- Inlining a global under a binder may cause shadowing, as we don't track
+    -- what new binders this may bring into scope
+    -- This can be a global term definition, or a case reduction bringing in part of a global type defininiton
+    isKnownShadow UnderBinders e = not $ Set.null (freeGlobalVars e) && null [() | Case{} <- U.universe e]
+    isKnownShadow StopAtBinders _ = False
+
+tasty_eval_shadow :: Property
+tasty_eval_shadow =
+  withDiscards 2000
+    $ propertyWTInExtendedGlobalCxt testModules
+    $ do
+      let globs = foldMap' moduleDefsQualified $ create' $ sequence testModules
+      tds <- asks typeDefs
+      (dir, t, _ty) <- genDirTm
+      unless (noShadowing t == ShadowingNotExists) discard
+      rs <- failWhenSevereLogs $ redexes @EvalLog AvoidShadowing tds globs dir t
+      when (null rs) discard
+      i <- forAllT $ Gen.element rs
+      when (isKnownShadow $ focusOn i t) discard
+      s <- failWhenSevereLogs $ step @EvalLog AvoidShadowing tds globs t dir i
+      case s of
+        Left err -> annotateShow err >> failure
+        Right (s', _) -> do
+          annotateShow s
+          noShadowing s' === ShadowingNotExists
+  where
+    -- Inlining a global under a binder may cause shadowing, as we don't track
+    -- what new binders this may bring into scope
+    isKnownShadow (Just (InExpr ez@(target -> Var _ (GlobalVarRef _)))) = not $ Set.null $ bindersAbove ez
+    isKnownShadow _ = False
+
+getEvalResultExpr :: Either EvalFullError Expr -> Expr
+getEvalResultExpr = \case
+  Left (TimedOut e) -> e
+  Right e -> e

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -51,6 +51,7 @@ import Primer.Builtins (
   tList,
   tMaybe,
   tNat,
+  tPair,
  )
 import Primer.Builtins.DSL (
   listOf,
@@ -516,6 +517,15 @@ unit_case_branches :: Assertion
 unit_case_branches =
   ann (case_ (con0 cZero `ann` tcon tNat) [branch' (["M"], "C") [] $ lvar "x"]) (tcon tBool)
     `smartSynthGives` ann (case_ (con0 cZero `ann` tcon tNat) [branch cZero [] emptyHole, branch cSucc [("a9", Nothing)] emptyHole]) (tcon tBool) -- Fragile name here "a9"
+
+unit_case_distinct_binds :: Assertion
+unit_case_distinct_binds =
+  ( case_
+      (emptyHole `ann` (tcon tPair `tapp` tEmptyHole `tapp` tEmptyHole))
+      [branch cMakePair [("x", Nothing), ("x", Nothing)] emptyHole]
+      `ann` tEmptyHole
+  )
+    `expectFailsWith` const (DuplicateBinders ["x", "x"])
 
 unit_remove_hole :: Assertion
 unit_remove_hole =

--- a/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
@@ -47,12 +47,12 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "α"
+                                { option = "γ"
                                 , context = Nothing
                                 , matchesType = False
                                 }
                             , Option
-                                { option = "γ"
+                                { option = "α1"
                                 , context = Nothing
                                 , matchesType = False
                                 }
@@ -231,12 +231,12 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "α"
+                                { option = "γ"
                                 , context = Nothing
                                 , matchesType = False
                                 }
                             , Option
-                                { option = "γ"
+                                { option = "α1"
                                 , context = Nothing
                                 , matchesType = False
                                 }
@@ -971,12 +971,12 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "α"
+                                { option = "γ"
                                 , context = Nothing
                                 , matchesType = False
                                 }
                             , Option
-                                { option = "γ"
+                                { option = "α1"
                                 , context = Nothing
                                 , matchesType = False
                                 }


### PR DESCRIPTION
Both "construction" api calls and evaluation will not introduce shadowing into a program which currently contains none, except in a few specific cases:
- evaluation under a binder in one of two situations (both "inline a global which has a binder of the same name as a local one")
  - inline a global variable, e.g. `λx. foo` reduces to `λx. λx.t` where `foo = λx.t`
    (note that we don't have the same problem for local `let f = λx.t in λx.s` as we will notice the shadowing issue when considering pushing the `let` under the lambda and do an initial renaming step `let f = λx.t in λy.let x=y in t`)
  - case-of-known-constructor, which "inlines" parts of the type definition: `Λα. case C t : T of C x -> s` reduces to `Λα. let x = t : ∀α.A in s` when we have `data T = C (∀α.A)`
- actions
  - anything with a student-specified name, since they can manually request a clashing name
  - converting let to letrec: `let x = (let x = t in ?) in ?` will be converted to `letrec x = (let x = t in ?) in ?` and now the `x` is shadowed in `t`.


To do this, we had to make some minor changes
- TC: forbid `case e of C x x -> ...` where we have duplicate binders. I think that this was never intended to be accepted
- tweak the evaluation of a  `letrec x = t : T in x` from `letrec x = t : T in (t : T)` to `(letrec x = t : T in t) : T`, else `x` can be shadowed in `T`.
- fix a bug in `bindersBelow`
- add an option to eval to avoid shadowing: whenever we may push some lets under a binder we check for shadowing as well as capture; i.e. for `let x = t in λy.s` we always ensured `y` was not free in `t` and `x` is different to `y` (capture),  we now also check that there are no `y` binders inside `t` (shadowing).