### PR TITLE
Bump Fourmolu to 0.7

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
 
       # Fourmolu updates often alter formatting arbitrarily, and we want to
       # have more control over this.
-      fourmoluVersion = "0.6.0.0";
+      fourmoluVersion = "0.7.0.1";
 
       forAllSupportedSystems = flake-utils.lib.eachSystem [
         "x86_64-linux"

--- a/primer-rel8/src/Primer/Database/Rel8/Schema.hs
+++ b/primer-rel8/src/Primer/Database/Rel8/Schema.hs
@@ -22,7 +22,7 @@ import Rel8 (
   Result,
   namesFromLabels,
  )
-import qualified Rel8 (
+import Rel8 qualified (
   TableSchema (..),
  )
 

--- a/primer-rel8/test/TestUtils.hs
+++ b/primer-rel8/test/TestUtils.hs
@@ -12,11 +12,11 @@ module TestUtils (
 import Foreword
 
 import Data.ByteString.Lazy.UTF8 as BL
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.String (String)
 import Data.Text (unpack)
 import Data.Typeable (typeOf)
-import qualified Database.PostgreSQL.Simple.Options as Options
+import Database.PostgreSQL.Simple.Options qualified as Options
 import Database.Postgres.Temp (
   DB,
   DirectoryType (Temporary),
@@ -83,7 +83,7 @@ import Test.Tasty.HUnit (
   assertBool,
   assertFailure,
  )
-import qualified Test.Tasty.HUnit as HUnit
+import Test.Tasty.HUnit qualified as HUnit
 
 -- The PostgreSQL host, username, and password can be chosen
 -- statically, but we need to choose the port dynamically in order to

--- a/primer-rel8/test/Tests/QuerySessionId.hs
+++ b/primer-rel8/test/Tests/QuerySessionId.hs
@@ -19,7 +19,7 @@ import Primer.Database (
 import Primer.Database.Rel8.Rel8Db (
   runRel8Db,
  )
-import qualified Primer.Database.Rel8.Schema as Schema (
+import Primer.Database.Rel8.Schema qualified as Schema (
   SessionRow (SessionRow, app, gitversion, name, uuid),
  )
 import Rel8 (lit)

--- a/primer-service/exe-server/Main.hs
+++ b/primer-service/exe-server/Main.hs
@@ -41,7 +41,7 @@ import Primer.App (
   App,
  )
 import Primer.Database (Version)
-import qualified Primer.Database as Db (
+import Primer.Database qualified as Db (
   ServiceCfg (..),
   serve,
  )
@@ -55,7 +55,7 @@ import Primer.Examples (
 import Primer.Server (
   serve,
  )
-import qualified StmContainers.Map as StmMap
+import StmContainers.Map qualified as StmMap
 import System.Directory (withCurrentDirectory)
 import System.Environment (lookupEnv)
 
@@ -168,7 +168,8 @@ run opts = case cmd opts of
       when seedDb $ do
         let env = Env initialSessions dbOpQueue ver
         flip runPrimerIO env $
-          forM_ seedApps $ uncurry addSession
+          forM_ seedApps $
+            uncurry addSession
       withCurrentDirectory root (serve initialSessions dbOpQueue ver port)
     db <- maybe defaultDb pure dbFlag
     runDb (Db.ServiceCfg dbOpQueue ver) db
@@ -179,7 +180,8 @@ main = execParser opts >>= run
     opts =
       info
         (helper <*> cmds)
-        ( fullDesc <> progDesc "A web service for Primer."
+        ( fullDesc
+            <> progDesc "A web service for Primer."
             <> header
               "primer-service - A web service for Primer."
         )

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -15,15 +15,15 @@ import Control.Concurrent.STM (
 
 import Data.OpenApi (OpenApi)
 import Data.Streaming.Network.Internal (HostPreference (HostIPv4Only))
-import qualified Data.Text.Lazy as LT (fromStrict)
-import qualified Data.Text.Lazy.Encoding as LT (encodeUtf8)
-import qualified Network.Wai as WAI
+import Data.Text.Lazy qualified as LT (fromStrict)
+import Data.Text.Lazy.Encoding qualified as LT (encodeUtf8)
+import Network.Wai qualified as WAI
 import Network.Wai.Handler.Warp (
   defaultSettings,
   setHost,
   setPort,
  )
-import qualified Network.Wai.Handler.Warp as Warp (runSettings)
+import Network.Wai.Handler.Warp qualified as Warp (runSettings)
 import Optics ((%), (.~), (?~))
 import Primer.API (
   Env (..),
@@ -44,7 +44,7 @@ import Primer.API (
   runPrimerIO,
   variablesInScope,
  )
-import qualified Primer.API as API
+import Primer.API qualified as API
 import Primer.Action (
   Action (Move),
   ActionError (TypeError),
@@ -95,7 +95,7 @@ import Primer.Database (
   Sessions,
   Version,
  )
-import qualified Primer.Database as Database (
+import Primer.Database qualified as Database (
   Op,
  )
 import Primer.Eval (BetaReductionDetail (..), EvalDetail (..))
@@ -127,7 +127,7 @@ import Servant (
   (:<|>) (..),
   (:>),
  )
-import qualified Servant (serve)
+import Servant qualified (serve)
 import Servant.OpenApi (toOpenApi)
 import Servant.OpenApi.OperationId (OpId)
 import Servant.Server.StaticFiles (serveDirectoryWith)

--- a/primer-service/src/Servant/OpenApi/OperationId.hs
+++ b/primer-service/src/Servant/OpenApi/OperationId.hs
@@ -46,7 +46,7 @@ instance
   toOpenApi _ =
     toOpenApi (Proxy @(Verb method status ctypes a))
       & traversalVL allOperations % #operationId
-      ?~ pack (symbolVal (Proxy @id))
+        ?~ pack (symbolVal (Proxy @id))
 
 -- | Similar to 'OperationId', but for Servant-provided convenience synonyms,
 -- like 'Get' or 'Post'
@@ -71,4 +71,4 @@ instance (KnownSymbol id, HasOpenApi (verb ctypes a)) => HasOpenApi (OpId id ver
   toOpenApi _ =
     toOpenApi (Proxy @(verb ctypes a))
       & traversalVL allOperations % #operationId
-      ?~ pack (symbolVal (Proxy @id))
+        ?~ pack (symbolVal (Proxy @id))

--- a/primer-service/test/Tests/Pagination.hs
+++ b/primer-service/test/Tests/Pagination.hs
@@ -8,7 +8,7 @@ import Foreword
 import Data.String (String)
 import Data.Text (unpack)
 import Data.UUID.V4 (nextRandom)
-import qualified Database.PostgreSQL.Simple.Options as Options
+import Database.PostgreSQL.Simple.Options qualified as Options
 import Database.Postgres.Temp (
   DB,
   DirectoryType (Temporary),
@@ -63,7 +63,7 @@ import System.Process.Typed (
  )
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
-import qualified Test.Tasty.HUnit as HUnit
+import Test.Tasty.HUnit qualified as HUnit
 
 (@?=) :: (MonadIO m, Eq a, Show a) => a -> a -> m ()
 x @?= y = liftIO $ x HUnit.@?= y

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -59,9 +59,9 @@ import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Zip (MonadZip)
 import Data.Aeson (ToJSON)
 import Data.Data (showConstr, toConstr)
-import qualified Data.Generics.Uniplate.Data as U
-import qualified Data.Map as Map
-import qualified ListT (toList)
+import Data.Generics.Uniplate.Data qualified as U
+import Data.Map qualified as Map
+import ListT qualified (toList)
 import Primer.App (
   App,
   EditAppM,
@@ -84,7 +84,7 @@ import Primer.App (
   runEditAppM,
   runQueryAppM,
  )
-import qualified Primer.App as App
+import Primer.App qualified as App
 import Primer.Core (
   ASTDef (..),
   Expr,
@@ -120,7 +120,7 @@ import Primer.Database (
   pageList,
   safeMkSessionName,
  )
-import qualified Primer.Database as Database (
+import Primer.Database qualified as Database (
   Op (
     Insert,
     ListSessions,
@@ -135,7 +135,7 @@ import qualified Primer.Database as Database (
  )
 import Primer.Module (moduleDefsQualified, moduleName, moduleTypesQualified)
 import Primer.Name (Name, unName)
-import qualified StmContainers.Map as StmMap
+import StmContainers.Map qualified as StmMap
 
 -- | The API environment.
 data Env = Env

--- a/primer/src/Primer/Action.hs
+++ b/primer/src/Primer/Action.hs
@@ -26,9 +26,9 @@ import Control.Monad.Fresh (MonadFresh)
 import Data.Aeson (Value)
 import Data.Generics.Product (typed)
 import Data.List (findIndex)
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import qualified Data.Text as T
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as T
 import Optics (set, (%), (?~))
 import Primer.Core (
   ASTDef (..),
@@ -62,7 +62,7 @@ import Primer.Core (
   valConName,
   valConType,
  )
-import qualified Primer.Core as C
+import Primer.Core qualified as C
 import Primer.Core.DSL (
   aPP,
   ann,
@@ -111,7 +111,7 @@ import Primer.Typecheck (
   maybeTypeOf,
   synth,
  )
-import qualified Primer.Typecheck as TC
+import Primer.Typecheck qualified as TC
 import Primer.Zipper (
   BindLoc' (..),
   CaseBindZ,

--- a/primer/src/Primer/Action/Available.hs
+++ b/primer/src/Primer/Action/Available.hs
@@ -8,7 +8,7 @@ module Primer.Action.Available (
 import Foreword
 
 import Data.Data (Data)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Optics (
   to,
   (%),
@@ -30,7 +30,7 @@ import Primer.Action (
   nameString,
   uniquifyDefName,
  )
-import qualified Primer.Action.Priorities as P
+import Primer.Action.Priorities qualified as P
 import Primer.Core (
   ASTDef (..),
   Bind' (..),
@@ -317,7 +317,8 @@ basicActionsForExpr l defName expr = case expr of
             Beginner -> NoFunctions
             _ -> Everything
        in actionWithInput (Code "x") "Use a variable" (P.useVar l) Primary $
-            ChooseVariable filterVars $ pure . ConstructVar
+            ChooseVariable filterVars $
+              pure . ConstructVar
 
     -- If we have a useful type, offer the refine action, otherwise offer the
     -- saturate action.
@@ -334,7 +335,8 @@ basicActionsForExpr l defName expr = case expr of
     insertVariableSaturatedRefined :: forall a. ExprMeta -> ActionSpec Expr a
     insertVariableSaturatedRefined m =
       actionWithInput (Code "f $ ?") "Apply a function to arguments" (P.useFunction l) Primary $
-        ChooseVariable OnlyFunctions $ \name -> [if offerRefined m then InsertRefinedVar name else InsertSaturatedVar name]
+        ChooseVariable OnlyFunctions $
+          \name -> [if offerRefined m then InsertRefinedVar name else InsertSaturatedVar name]
 
     annotateExpression :: forall a. ActionSpec Expr a
     annotateExpression = action (Code ":") "Annotate this expression with a type" (P.annotateExpr l) Primary [ConstructAnn]

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -68,8 +68,8 @@ import Data.Generics.Uniplate.Zipper (
  )
 import Data.List (intersect, (\\))
 import Data.List.Extra (anySame, disjoint, (!?))
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Optics (
   Field1 (_1),
   Field2 (_2),
@@ -139,11 +139,11 @@ import Primer.Core (
   _typeMetaLens,
  )
 import Primer.Core.DSL (create, emptyHole, tEmptyHole)
-import qualified Primer.Core.DSL as DSL
+import Primer.Core.DSL qualified as DSL
 import Primer.Core.Transform (foldApp, renameVar, unfoldAPP, unfoldApp, unfoldTApp)
 import Primer.Core.Utils (freeVars, regenerateExprIDs, regenerateTypeIDs, _freeTmVars, _freeTyVars, _freeVarsTy)
 import Primer.Eval (EvalDetail, EvalError)
-import qualified Primer.Eval as Eval
+import Primer.Eval qualified as Eval
 import Primer.EvalFull (Dir, EvalFullError (TimedOut), TerminationBound, evalFull)
 import Primer.JSON
 import Primer.Module (
@@ -624,20 +624,20 @@ applyProgAction prog mdefName = \case
       updateRefsInTypes =
         over
           (traversed % #_TypeDefAST % #astTypeDefConstructors % traversed % #valConArgs % traversed)
-          $ transform $
-            over (#_TCon % _2) updateName
+          $ transform
+          $ over (#_TCon % _2) updateName
       updateDefType =
         over
           #astDefType
-          $ transform $
-            over (#_TCon % _2) updateName
+          $ transform
+          $ over (#_TCon % _2) updateName
       updateDefBody =
         over
           #astDefExpr
-          $ transform $
-            over typesInExpr $
-              transform $
-                over (#_TCon % _2) updateName
+          $ transform
+          $ over typesInExpr
+          $ transform
+          $ over (#_TCon % _2) updateName
       updateName n = if n == old then new else n
   RenameCon type_ old (unsafeMkGlobalName . (fmap unName (unModuleName (qualifiedModule type_)),) -> new) ->
     editModuleSameSelectionCross (qualifiedModule type_) prog $ \(m, ms) -> do
@@ -685,8 +685,8 @@ applyProgAction prog mdefName = \case
               % #valConArgs
               % traversed
           )
-          $ over _freeVarsTy $
-            \(_, v) -> TVar () $ updateName v
+          $ over _freeVarsTy
+          $ \(_, v) -> TVar () $ updateName v
       updateName n = if n == old then new else n
   AddCon type_ index (unsafeMkGlobalName . (fmap unName (unModuleName (qualifiedModule type_)),) -> con) ->
     editModuleSameSelectionCross (qualifiedModule type_) prog $ \(m, ms) -> do

--- a/primer/src/Primer/Builtins.hs
+++ b/primer/src/Primer/Builtins.hs
@@ -31,7 +31,7 @@ module Primer.Builtins (
 
 import Foreword
 
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Primer.Core (
   ASTTypeDef (
     ASTTypeDef,

--- a/primer/src/Primer/Core/Transform.hs
+++ b/primer/src/Primer/Core/Transform.hs
@@ -16,7 +16,7 @@ import Foreword
 import Control.Monad.Fresh (MonadFresh)
 import Data.Data (Data)
 import Data.Generics.Uniplate.Data (descendM)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Optics (traverseOf)
 import Primer.Core (
   CaseBranch' (..),

--- a/primer/src/Primer/Core/Utils.hs
+++ b/primer/src/Primer/Core/Utils.hs
@@ -26,8 +26,8 @@ import Foreword
 import Control.Monad.Fresh (MonadFresh, fresh)
 import Data.Data (Data)
 import Data.Generics.Uniplate.Data (universe)
-import qualified Data.Map.Strict as M
-import qualified Data.Set as S
+import Data.Map.Strict qualified as M
+import Data.Set qualified as S
 import Data.Set.Optics (setOf)
 import Optics (
   Fold,

--- a/primer/src/Primer/Database.hs
+++ b/primer/src/Primer/Database.hs
@@ -44,21 +44,21 @@ import Control.Monad.STM (atomically)
 import Control.Monad.Trans (MonadTrans)
 import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Zip (MonadZip)
-import qualified Data.Text as Text (
+import Data.Text qualified as Text (
   strip,
   take,
   takeWhile,
  )
 import Data.UUID (UUID)
-import qualified Data.UUID as UUID (toText)
+import Data.UUID qualified as UUID (toText)
 import Data.UUID.V4 (nextRandom)
-import qualified ListT (toList)
+import ListT qualified (toList)
 import Optics (
   (.~),
  )
 import Primer.App (App)
 import Primer.JSON (CustomJSON (CustomJSON), ToJSON, VJSON)
-import qualified StmContainers.Map as StmMap
+import StmContainers.Map qualified as StmMap
 
 -- | A Primer version.
 --

--- a/primer/src/Primer/Eval.hs
+++ b/primer/src/Primer/Eval.hs
@@ -31,8 +31,8 @@ import Foreword
 import Control.Arrow ((***))
 import Control.Monad.Fresh (MonadFresh)
 import Data.Generics.Product (position)
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Optics (
   Field1 (_1),
   elemOf,

--- a/primer/src/Primer/EvalFull.hs
+++ b/primer/src/Primer/EvalFull.hs
@@ -21,8 +21,8 @@ import Foreword
 
 import Control.Monad.Extra (untilJustM)
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Set.Optics (setOf)
 import Data.Tuple.Extra (thd3)
 import GHC.Err (error)

--- a/primer/src/Primer/Examples.hs
+++ b/primer/src/Primer/Examples.hs
@@ -44,14 +44,14 @@ import Foreword hiding (
  )
 
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Primer.App (
   App,
   Prog (..),
   defaultProg,
   mkApp,
  )
-import qualified Primer.Builtins as B
+import Primer.Builtins qualified as B
 import Primer.Core (
   ASTDef (ASTDef),
   Def (DefAST),

--- a/primer/src/Primer/Name.hs
+++ b/primer/src/Primer/Name.hs
@@ -9,9 +9,9 @@ module Primer.Name (
 import Foreword
 
 import Control.Monad.Fresh (MonadFresh, fresh)
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Data (Data)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.String (String)
 import Numeric.Natural (Natural)
 import Primer.JSON

--- a/primer/src/Primer/Name/Fresh.hs
+++ b/primer/src/Primer/Name/Fresh.hs
@@ -11,11 +11,11 @@ module Primer.Name.Fresh (
 import Foreword
 
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Primer.Core (Expr, LocalName (LocalName, unLocalName), Type)
 import Primer.Core.Utils (freeVars, freeVarsTy)
 import Primer.Name (Name, NameCounter, freshName)
-import qualified Primer.Typecheck as TC
+import Primer.Typecheck qualified as TC
 import Primer.Zipper (
   ExprZ,
   TypeZ,

--- a/primer/src/Primer/Primitives.hs
+++ b/primer/src/Primer/Primitives.hs
@@ -12,7 +12,7 @@ module Primer.Primitives (
 import Foreword
 
 import Data.Bitraversable (bisequence)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Numeric.Natural (Natural)
 import Primer.Builtins (
   cJust,
@@ -217,7 +217,8 @@ allPrimDefs =
                       if y == 0
                         then con cNothing `aPP` tcon tInt
                         else
-                          con cJust `aPP` tcon tInt
+                          con cJust
+                            `aPP` tcon tInt
                             `app` int (x `div` y)
                   xs -> Left $ PrimFunError name xs
               }
@@ -232,7 +233,8 @@ allPrimDefs =
                       if y == 0
                         then con cNothing `aPP` tcon tInt
                         else
-                          con cJust `aPP` tcon tInt
+                          con cJust
+                            `aPP` tcon tInt
                             `app` int (x `mod` y)
                   xs -> Left $ PrimFunError name xs
               }
@@ -334,7 +336,8 @@ allPrimDefs =
                         then con cNothing `aPP` tcon tNat
                         else
                           con cJust
-                            `aPP` tcon tNat `app` nat (fromInteger x)
+                            `aPP` tcon tNat
+                            `app` nat (fromInteger x)
                   xs -> Left $ PrimFunError name xs
               }
           )

--- a/primer/src/Primer/Questions.hs
+++ b/primer/src/Primer/Questions.hs
@@ -15,8 +15,8 @@ module Primer.Questions (
 
 import Foreword
 
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Primer.Core (
   DefMap,
   GVarName,

--- a/primer/src/Primer/Refine.hs
+++ b/primer/src/Primer/Refine.hs
@@ -3,14 +3,14 @@ module Primer.Refine (refine, Inst (..)) where
 import Foreword
 
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Primer.Core (TyVarName, Type' (TForall, TFun, TVar))
-import qualified Primer.Core as C
+import Primer.Core qualified as C
 import Primer.Core.Utils (freshLocalName)
 import Primer.Name (NameCounter)
 import Primer.Subst (substTy, substTys)
-import qualified Primer.Typecheck as TC
+import Primer.Typecheck qualified as TC
 import Primer.Unification (InternalUnifyError, unify)
 import Primer.Zipper (bindersBelowTy, focus)
 

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -66,9 +66,9 @@ import Control.Monad.Fresh (MonadFresh (..))
 import Control.Monad.NestedError (MonadNestedError (..))
 import Data.Functor.Compose (Compose (Compose), getCompose)
 import Data.Generics.Product (HasType, position, typed)
-import qualified Data.Map as M
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as S
 import Data.Tuple.Extra (fst3)
 import Optics (Lens', over, set, traverseOf, view, (%))
 import Optics.Traversal (traversed)
@@ -377,7 +377,8 @@ checkTypeDefs tds = do
         (notElem (baseName tc) $ map (unLocalName . fst) params)
         "Duplicate names in one tydef: between type-def-name and parameter-names"
       local (noSmartHoles . extendLocalCxtTys params) $
-        mapM_ (checkKind KType <=< fakeMeta) $ concatMap valConArgs cons
+        mapM_ (checkKind KType <=< fakeMeta) $
+          concatMap valConArgs cons
     -- We need metadata to use checkKind, but we don't care about the output,
     -- just a yes/no answer. In this case it is fine to put nonsense in the
     -- metadata as it won't be inspected.
@@ -988,7 +989,9 @@ getGlobalNames = do
           ( \t def ->
               S.fromList $
                 (f t :) $
-                  map (f . valConName) $ maybe [] astTypeDefConstructors $ typeDefAST def
+                  map (f . valConName) $
+                    maybe [] astTypeDefConstructors $
+                      typeDefAST def
           )
           tyDefs
   pure $ S.union topLevel ctors

--- a/primer/src/Primer/Unification.hs
+++ b/primer/src/Primer/Unification.hs
@@ -3,8 +3,8 @@ module Primer.Unification (InternalUnifyError (..), unify) where
 import Foreword
 
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Optics (anyOf, getting, over, set)
 import Primer.Core (
   ID,
@@ -60,7 +60,9 @@ unify cxt unificationVars s t = do
   result <-
     runExceptT $
       flip execStateT mempty $
-        flip runReaderT initEnv $ unU $ unify' s t
+        flip runReaderT initEnv $
+          unU $
+            unify' s t
   case result of
     Left _err -> pure Nothing
     Right sb -> do

--- a/primer/src/Primer/Zipper.hs
+++ b/primer/src/Primer/Zipper.hs
@@ -60,9 +60,9 @@ import Data.Generics.Uniplate.Zipper (
   replaceHole,
   zipper,
  )
-import qualified Data.Generics.Uniplate.Zipper as Z
+import Data.Generics.Uniplate.Zipper qualified as Z
 import Data.List as List (delete)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Optics (
   filteredBy,
   ifolded,

--- a/primer/src/Primer/ZipperCxt.hs
+++ b/primer/src/Primer/ZipperCxt.hs
@@ -11,7 +11,7 @@ module Primer.ZipperCxt (
 import Foreword
 
 import Data.Generics.Product (Param (..), param, position)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Optics (set, view, (^.))
 import Primer.Core (
   Bind' (..),

--- a/primer/test/Gen/Core/Raw.hs
+++ b/primer/test/Gen/Core/Raw.hs
@@ -21,8 +21,8 @@ module Gen.Core.Raw (
 import Foreword
 
 import Hedgehog hiding (Var, check)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Primer.Core (
   Bind' (Bind),
   CaseBranch' (CaseBranch),

--- a/primer/test/Gen/Core/Typed.hs
+++ b/primer/test/Gen/Core/Typed.hs
@@ -31,16 +31,16 @@ import Foreword
 import Control.Monad.Fresh (MonadFresh, fresh)
 import Control.Monad.Morph (hoist)
 import Control.Monad.Reader (mapReaderT)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Gen.Core.Raw (genLVarName, genModuleName, genName, genTyVarName)
 import Hedgehog (
   GenT,
   MonadGen,
   PropertyT,
  )
-import qualified Hedgehog.Gen as Gen
+import Hedgehog.Gen qualified as Gen
 import Hedgehog.Internal.Property (forAllT)
-import qualified Hedgehog.Range as Range
+import Hedgehog.Range qualified as Range
 import Primer.Core (
   ASTTypeDef (..),
   Bind' (Bind),
@@ -175,12 +175,14 @@ freshTyConNameForCxt = qualifyName <$> genModuleName <*> freshNameForCxt
 genLVarNameAvoiding :: [TypeG] -> GenT WT LVarName
 genLVarNameAvoiding ty =
   (\vs -> freshen (foldMap freeVarsTy ty <> foldMap freeVarsTy vs) 0)
-    <$> asks localTmVars <*> genLVarName
+    <$> asks localTmVars
+    <*> genLVarName
 
 genTyVarNameAvoiding :: TypeG -> GenT WT TyVarName
 genTyVarNameAvoiding ty =
   (\vs -> freshen (freeVarsTy ty <> foldMap freeVarsTy vs) 0)
-    <$> asks localTmVars <*> genTyVarName
+    <$> asks localTmVars
+    <*> genTyVarName
 
 freshen :: Set (LocalName k') -> Int -> LocalName k -> LocalName k
 freshen fvs i n =

--- a/primer/test/TestUtils.hs
+++ b/primer/test/TestUtils.hs
@@ -30,7 +30,7 @@ import Control.Monad.Fresh (MonadFresh)
 import Data.Coerce (coerce)
 import Data.String (String, fromString)
 import Data.Typeable (typeOf)
-import qualified Hedgehog as H
+import Hedgehog qualified as H
 import Optics (over, set, view)
 import Primer.API (
   Env (..),
@@ -70,14 +70,14 @@ import Primer.Database (
  )
 import Primer.Name (Name (unName))
 import Primer.Primitives (allPrimDefs)
-import qualified StmContainers.Map as StmMap
-import qualified Test.Tasty.Discover as TD
+import StmContainers.Map qualified as StmMap
+import Test.Tasty.Discover qualified as TD
 import Test.Tasty.HUnit (
   assertBool,
   assertFailure,
  )
-import qualified Test.Tasty.HUnit as HUnit
-import qualified Test.Tasty.Hedgehog as TH
+import Test.Tasty.HUnit qualified as HUnit
+import Test.Tasty.Hedgehog qualified as TH
 
 withPrimDefs :: MonadFresh ID m => (Map GVarName PrimDef -> m a) -> m a
 withPrimDefs f = do

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -2,10 +2,10 @@ module Tests.Action.Available where
 
 import Foreword
 
-import qualified Data.ByteString.Lazy.Char8 as BS
+import Data.ByteString.Lazy.Char8 qualified as BS
 import Data.List.Extra (enumerate)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import GHC.Err (error)
 import Optics (toListOf, (%))
 import Primer.Action (ActionName (..), OfferedAction (name))

--- a/primer/test/Tests/App.hs
+++ b/primer/test/Tests/App.hs
@@ -20,7 +20,7 @@ import Primer.App (
 import Primer.Core (
   ID,
  )
-import qualified Primer.Examples as Examples
+import Primer.Examples qualified as Examples
 import Primer.Name (
   NameCounter,
  )

--- a/primer/test/Tests/Database.hs
+++ b/primer/test/Tests/Database.hs
@@ -2,7 +2,7 @@ module Tests.Database where
 
 import Foreword
 
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Primer.Database (
   defaultSessionName,
   fromSessionName,

--- a/primer/test/Tests/Eval.hs
+++ b/primer/test/Tests/Eval.hs
@@ -2,8 +2,8 @@ module Tests.Eval where
 
 import Foreword
 
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Optics ((^.))
 import Primer.App (
   EvalReq (EvalReq, evalReqExpr, evalReqRedex),
@@ -580,7 +580,8 @@ unit_tryReduce_case_name_clash = do
       result = runTryReduce mempty mempty (expr, i)
       expectedResult =
         create' $
-          let_ "x0" emptyHole $ let_ "y" (lvar "x") emptyHole
+          let_ "x0" emptyHole $
+            let_ "y" (lvar "x") emptyHole
   case result of
     Right (expr', CaseReduction detail) -> do
       expr' ~= expectedResult
@@ -625,7 +626,9 @@ unit_tryReduce_prim = do
   let ((expr, expectedResult, globals), i) =
         create . withPrimDefs $ \m ->
           (,,)
-            <$> gvar (primitiveGVar "eqChar") `app` char 'a' `app` char 'a'
+            <$> gvar (primitiveGVar "eqChar")
+            `app` char 'a'
+            `app` char 'a'
             <*> con cTrue
             <*> pure m
       result = runTryReduce (DefPrim <$> globals) mempty (expr, i)
@@ -644,7 +647,8 @@ unit_tryReduce_prim_fail_unsaturated = do
   let ((expr, globals), i) =
         create . withPrimDefs $ \m ->
           (,)
-            <$> gvar (primitiveGVar "eqChar") `app` char 'a'
+            <$> gvar (primitiveGVar "eqChar")
+            `app` char 'a'
             <*> pure m
       result = runTryReduce (DefPrim <$> globals) mempty (expr, i)
   result @?= Left NotRedex
@@ -654,7 +658,9 @@ unit_tryReduce_prim_fail_unreduced_args = do
   let ((expr, globals), i) =
         create . withPrimDefs $ \m ->
           (,)
-            <$> gvar (primitiveGVar "eqChar") `app` char 'a' `app` (gvar (primitiveGVar "toUpper") `app` char 'a')
+            <$> gvar (primitiveGVar "eqChar")
+            `app` char 'a'
+            `app` (gvar (primitiveGVar "toUpper") `app` char 'a')
             <*> pure m
       result = runTryReduce (DefPrim <$> globals) mempty (expr, i)
   result @?= Left NotRedex
@@ -916,13 +922,15 @@ unit_redexes_let_capture :: Assertion
 unit_redexes_let_capture =
   -- We should maybe rename the lambda, see https://github.com/hackworthltd/primer/issues/509
   assertBool "Cannot inline the variable, as would cause capture" $
-    Set.null $ redexesOf (let_ "x" (lvar "y") $ lam "y" $ lvar "x")
+    Set.null $
+      redexesOf (let_ "x" (lvar "y") $ lam "y" $ lvar "x")
 
 unit_redexes_lettype_capture :: Assertion
 unit_redexes_lettype_capture =
   -- We should maybe rename the forall, see https://github.com/hackworthltd/primer/issues/509
   assertBool "Cannot inline the variable, as would cause capture" $
-    Set.null $ redexesOf (letType "x" (tvar "y") (emptyHole `ann` tforall "y" KType (tvar "x")))
+    Set.null $
+      redexesOf (letType "x" (tvar "y") (emptyHole `ann` tforall "y" KType (tvar "x")))
 
 unit_redexes_letrec_1 :: Assertion
 unit_redexes_letrec_1 =
@@ -1035,7 +1043,7 @@ unit_redexes_prim_ann =
     expr =
       gvar (primitiveGVar "toUpper")
         `ann` (tcon tChar `tfun` tcon tChar)
-          `app` (char 'a' `ann` tcon tChar)
+        `app` (char 'a' `ann` tcon tChar)
 
 -- Test that handleEvalRequest will reduce imported terms
 unit_eval_modules :: Assertion

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -4,16 +4,16 @@ import Foreword hiding (unlines)
 
 import Data.Generics.Uniplate.Data (universe)
 import Data.List (span, (\\))
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as M
-import qualified Data.Map as Map
-import qualified Data.Set as S
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as M
+import Data.Map qualified as Map
+import Data.Set qualified as S
 import Data.String (unlines)
 import Gen.Core.Typed (WT, forAllT, genChk, genSyn, genWTType, isolateWT, propertyWT)
 import Hedgehog hiding (Property, Var, check, property, test, withDiscards, withTests)
-import qualified Hedgehog.Gen as Gen
+import Hedgehog.Gen qualified as Gen
 import Hedgehog.Internal.Property (LabelName (unLabelName))
-import qualified Hedgehog.Range as Range
+import Hedgehog.Range qualified as Range
 import Optics
 import Primer.App (
   EvalFullReq (EvalFullReq, evalFullCxtDir, evalFullMaxSteps, evalFullReqExpr),
@@ -47,7 +47,7 @@ import Primer.Core.Utils (
   generateIDs,
  )
 import Primer.EvalFull
-import qualified Primer.Examples as Examples (
+import Primer.Examples qualified as Examples (
   even,
   map,
   map',
@@ -553,7 +553,8 @@ unit_type_preservation_BETA_regression =
       foo = qualifyName (ModuleName ["M"]) "foo"
       fooTy = TForall () "d" KType $ TCon () tNat
       tmp ty e = case runTypecheckTestMWithPrims NoSmartHoles $
-        local (extendGlobalCxt [(foo, fooTy)]) $ check ty e of
+        local (extendGlobalCxt [(foo, fooTy)]) $
+          check ty e of
         Left err -> assertFailure $ show err
         Right _ -> pure ()
    in do
@@ -663,13 +664,15 @@ unit_regression_self_capture_let_let = do
   let e =
         lAM "y" $
           let_ "x" (emptyHole `ann` tvar "y") $
-            let_ "y" (emptyHole `ann` tvar "y") $ lvar "y"
+            let_ "y" (emptyHole `ann` tvar "y") $
+              lvar "y"
       z = "a10"
       f =
         lAM "y" $
           let_ "x" (emptyHole `ann` tvar "y") $
             let_ z (emptyHole `ann` tvar "y") $
-              let_ "y" (lvar z) $ lvar "y"
+              let_ "y" (lvar z) $
+                lvar "y"
       (e', i) = create e
       ev n = evalFullTest i mempty mempty n Chk e'
       x ~ y = x <~==> Left (TimedOut (create' y))
@@ -757,14 +760,14 @@ tasty_prim_hex_nat = withTests 20 . property $ do
                     )
                 ]
               <*> (con cJust `aPP` tcon tNat)
-                `app` ne
+              `app` ne
               <*> pure (DefPrim <$> globals)
           else create . withPrimDefs $ \globals ->
             (,,)
               <$> gvar (primitiveGVar "natToHex")
-                `app` ne
+              `app` ne
               <*> con cNothing
-                `aPP` tcon tChar
+              `aPP` tcon tChar
               <*> pure (DefPrim <$> globals)
       s = evalFullTest maxID builtinTypes gs 7 Syn e
   over evalResultExpr zeroIDs s === Right (zeroIDs r)
@@ -791,7 +794,7 @@ unit_prim_char_partial =
         create . withPrimDefs $ \globals ->
           (,)
             <$> gvar (primitiveGVar "eqChar")
-              `app` char 'a'
+            `app` char 'a'
             <*> pure (DefPrim <$> globals)
       s = evalFullTest maxID mempty gs 1 Syn e
    in do
@@ -1109,7 +1112,7 @@ unit_prim_ann =
             <$> ( gvar (primitiveGVar "toUpper")
                     `ann` (tcon tChar `tfun` tcon tChar)
                 )
-              `app` (char 'a' `ann` tcon tChar)
+            `app` (char 'a' `ann` tcon tChar)
             <*> char 'A'
             <*> pure (DefPrim <$> globals)
       s = evalFullTest maxID builtinTypes gs 2 Syn e
@@ -1125,22 +1128,22 @@ unit_prim_partial_map =
           (mapName, mapDef) <- Examples.map' modName
           (,,)
             <$> gvar mapName
-              `aPP` tcon tChar
-              `aPP` tcon tChar
-              `app` gvar (primitiveGVar "toUpper")
-              `app` list_
-                tChar
-                [ char 'a'
-                , char 'b'
-                , char 'c'
-                ]
+            `aPP` tcon tChar
+            `aPP` tcon tChar
+            `app` gvar (primitiveGVar "toUpper")
+            `app` list_
+              tChar
+              [ char 'a'
+              , char 'b'
+              , char 'c'
+              ]
             <*> list_
               tChar
               [ char 'A'
               , char 'B'
               , char 'C'
               ]
-              `ann` (tcon tList `tapp` tcon tChar)
+            `ann` (tcon tList `tapp` tcon tChar)
             <*> pure (M.singleton mapName mapDef <> (DefPrim <$> globals))
       s = evalFullTest maxID builtinTypes gs 65 Syn e
    in do
@@ -1226,7 +1229,7 @@ unaryPrimTest f x y =
         create . withPrimDefs $ \globals ->
           (,,)
             <$> gvar (primitiveGVar f)
-              `app` x
+            `app` x
             <*> y
             <*> pure (DefPrim <$> globals)
       s = evalFullTest maxID mempty gs 2 Syn e
@@ -1239,8 +1242,8 @@ binaryPrimTest f x y z =
         create . withPrimDefs $ \globals ->
           (,,)
             <$> gvar (primitiveGVar f)
-              `app` x
-              `app` y
+            `app` x
+            `app` y
             <*> z
             <*> pure (DefPrim <$> globals)
       s = evalFullTest maxID mempty gs 2 Syn e

--- a/primer/test/Tests/FreeVars.hs
+++ b/primer/test/Tests/FreeVars.hs
@@ -2,7 +2,7 @@ module Tests.FreeVars where
 
 import Foreword
 
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Primer.Builtins
 import Primer.Core (Kind (KType))
 import Primer.Core.DSL

--- a/primer/test/Tests/Gen/Core/Typed.hs
+++ b/primer/test/Tests/Gen/Core/Typed.hs
@@ -3,9 +3,8 @@
 -- generate well-typed terms
 module Tests.Gen.Core.Typed where
 
+import Data.Map qualified as M
 import Foreword hiding (diff)
-
-import qualified Data.Map as M
 import Gen.Core.Typed (
   WT,
   genChk,
@@ -143,18 +142,27 @@ tasty_genCxtExtending_is_extension =
     extendsGlobal
       (Cxt{typeDefs = tds1, localCxt = lc1, globalCxt = gc1, smartHoles = sh1})
       (Cxt{typeDefs = tds2, localCxt = lc2, globalCxt = gc2, smartHoles = sh2}) =
-        tds1 `M.isSubmapOf` tds2
-          && lc1 == lc2 -- we don't extend the locals
-          && lc1 == mempty -- and it doesn't make too much sense to do a global extension if already have locals in scope
-          && gc1 `M.isSubmapOf` gc2
-          && sh1 == sh2
+        tds1
+          `M.isSubmapOf` tds2
+          && lc1
+          == lc2 -- we don't extend the locals
+          && lc1
+          == mempty -- and it doesn't make too much sense to do a global extension if already have locals in scope
+          && gc1
+          `M.isSubmapOf` gc2
+          && sh1
+          == sh2
     extendsLocal
       (Cxt{typeDefs = tds1, localCxt = lc1, globalCxt = gc1, smartHoles = sh1})
       (Cxt{typeDefs = tds2, localCxt = lc2, globalCxt = gc2, smartHoles = sh2}) =
-        tds1 == tds2
-          && lc1 `M.isSubmapOf` lc2 -- we only extend the locals
-          && gc1 == gc2
-          && sh1 == sh2
+        tds1
+          == tds2
+          && lc1
+          `M.isSubmapOf` lc2 -- we only extend the locals
+          && gc1
+          == gc2
+          && sh1
+          == sh2
 
 tasty_genSyns :: Property
 tasty_genSyns = withTests 1000 $

--- a/primer/test/Tests/Primitives.hs
+++ b/primer/test/Tests/Primitives.hs
@@ -4,7 +4,7 @@ module Tests.Primitives where
 
 import Foreword
 
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Gen.Core.Typed (forAllT, genPrimCon, propertyWT)
 import Hedgehog (assert)
 import Hedgehog.Gen (choice)
@@ -61,7 +61,8 @@ unit_prim_con_scope_ast = do
   -- Char is in scope (though the wrong kind to accept 'PrimChar's!)
   assertBool "Char is not in scope?" $
     isRight $
-      test $ checkKind (KType `KFun` KType) =<< tcon tChar
+      test $
+        checkKind (KType `KFun` KType) =<< tcon tChar
   test (synth =<< char 'a') @?= Left (PrimitiveTypeNotInScope tChar)
   where
     charASTDef =

--- a/primer/test/Tests/Question.hs
+++ b/primer/test/Tests/Question.hs
@@ -7,8 +7,8 @@ import Data.List (nub, nubBy)
 import Gen.Core.Raw (evalExprGen, genKind, genName, genTyVarName, genType)
 import Hedgehog hiding (Property, check, property)
 import Hedgehog.Classes
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Primer.Builtins
 import Primer.Core (
   Expr,

--- a/primer/test/Tests/Refine.hs
+++ b/primer/test/Tests/Refine.hs
@@ -3,8 +3,8 @@ module Tests.Refine where
 import Foreword hiding (diff)
 
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Gen.Core.Typed (
   forAllT,
   freshTyVarNameForCxt,
@@ -20,8 +20,8 @@ import Hedgehog (
   success,
   (===),
  )
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Primer.Builtins (builtinModule, tBool, tList, tNat)
 import Primer.Core (
   Expr' (APP, Ann, App, EmptyHole),

--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -9,7 +9,7 @@ import Data.Aeson.Encode.Pretty (
   encodePretty',
  )
 import Data.ByteString.Lazy as BL
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.String (String)
 import Primer.Action (Action (Move, SetCursor), ActionError (IDNotFound), Movement (Child1))
 import Primer.App (

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -4,7 +4,7 @@ module Tests.Typecheck where
 import Foreword
 
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Gen.Core.Raw (
   evalExprGen,
   genTyConName,
@@ -16,8 +16,8 @@ import Gen.Core.Typed (
   propertyWT,
  )
 import Hedgehog hiding (Property, check, property, withDiscards, withTests)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Optics (over)
 import Primer.App (
   Prog,

--- a/primer/test/Tests/Unification.hs
+++ b/primer/test/Tests/Unification.hs
@@ -3,8 +3,8 @@ module Tests.Unification where
 import Foreword hiding (diff)
 
 import Control.Monad.Fresh (MonadFresh)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Gen.Core.Typed (
   WT,
   forAllT,
@@ -25,8 +25,8 @@ import Hedgehog (
   failure,
   (===),
  )
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Primer.Builtins (builtinModule, tList, tNat)
 import Primer.Core (
   ASTTypeDef (ASTTypeDef, astTypeDefConstructors, astTypeDefNameHints, astTypeDefParameters),

--- a/primer/test/Tests/Zipper.hs
+++ b/primer/test/Tests/Zipper.hs
@@ -10,7 +10,7 @@ import Gen.Core.Raw (
   runExprGen,
  )
 import Hedgehog hiding (Property, property)
-import qualified Hedgehog.Gen as Gen
+import Hedgehog.Gen qualified as Gen
 import Primer.Core
 import Primer.Zipper
 import TestUtils (Property, property)

--- a/primer/test/Tests/Zipper/BindersAbove.hs
+++ b/primer/test/Tests/Zipper/BindersAbove.hs
@@ -3,7 +3,7 @@ module Tests.Zipper.BindersAbove where
 
 import Foreword
 
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Primer.Action (
   Movement (..),
   moveExpr,


### PR DESCRIPTION
As noted in https://github.com/hackworthltd/primer/pull/502#discussion_r896241236, our CLI and HLS versions of Fourmolu were out of sync. This re-aligns them. So we can now turn format-on-save back on in our editors.

It would be nice if this wasn't a requirement. This is why I implemented https://github.com/haskell/haskell-language-server/pull/2763, but [it isn't clear whether that's currently usable](https://github.com/haskell/haskell-language-server/issues/2827).

As for the actual formatting changes introduced by bumping Fourmolu, they're all ultimately from Ormolu (so it's not my fault!).