### PR TITLE
fix: Set required `primer-service` Docker image env vars.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -369,7 +369,18 @@
                       "https://github.com/hackworthltd/primer";
                     "org.opencontainers.image.revision" = self.rev or "dirty";
                   };
+
                   ExposedPorts = { "${toString port}/tcp" = { }; };
+
+                  Env = [
+                    # Needed for the `primer-service` banner.
+                    "LANG=C.UTF-8"
+
+                    # Sqitch will fail in a container if these are not
+                    # set. Their specific values are not important.
+                    "SQITCH_EMAIL=root@localhost"
+                    "SQITCH_FULLNAME=Primer User"
+                  ];
                 };
             };
           in

--- a/nixos-tests/docker-image.nix
+++ b/nixos-tests/docker-image.nix
@@ -59,13 +59,6 @@ makeTest {
           extraOptions = [ "--network=host" ];
           environment = {
             DATABASE_URL = database_url;
-
-            # Needed for the `primer-service` banner.
-            LANG = "C.UTF-8";
-
-            # Sqitch will fail in a container if these are not set.
-            SQITCH_EMAIL = "primer-user@hackworthltd.com";
-            SQITCH_FULLNAME = "Primer User";
           };
         };
       };


### PR DESCRIPTION
We used to set these in the NixOS test, but they're needed in
production containers, as well, so now we set them on the container
itself.
