### PR TITLE
feat(primer-service): Add a naïve CORS policy.

### DIFF
--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -53,6 +53,7 @@ library
     , uuid               ^>=1.3
     , wai                ^>=3.2
     , wai-app-static     ^>=3.1
+    , wai-cors           ^>=0.2.7
     , warp               ^>=3.3
 
 executable primer-service


### PR DESCRIPTION
Notes:

* This policy was created using the following references:

https://stackoverflow.com/questions/63876281/cors-problem-while-making-a-fetch-call-from-ui-app-to-servant-server
https://stackoverflow.com/questions/41399055/haskell-yesod-cors-problems-with-browsers-options-requests-when-doing-post-req/56256513#56256513
https://github.com/larskuhtz/wai-cors/issues/29#issuecomment-642812203

We've also added `PUT` to the list of CORS methods recommended in the
last reference, as our API uses it.

* This policy does not specify any origins, which means its origins
are equivalent to "*". Therefore, this policy will not work with
credentialed requests. This is fine for now.

* This policy does not specify an `Access-Control-Max-Age` (via
wai-cors's `corsMaxAge` field), and therefore responses to browser
preflight requests will only be cached for 5 seconds. This is helpful
for testing, but is obviously not ideal for production use, so this
will need to be addressed if we decide to use CORS in production.
