### PR TITLE
feat: Add `addSession` and `getApp` to the HTTP API.

### DIFF
--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -45,6 +45,7 @@ import Primer.API (
   evalStep,
   flushSessions,
   generateNames,
+  getApp,
   getProgram,
   getSessionName,
   getVersion,
@@ -203,6 +204,11 @@ type PrimerLegacyAPI =
     --   session-specific API, as it's not scoped by the current
     --   session ID like those methods are.
   :<|> "copy-session" :> ReqBody '[JSON] SessionId :> Post '[JSON] SessionId
+
+    -- GET /api/app
+    --    Exposes the 'getApp' operation. This is useful for testing,
+    --    but not much else.
+  :<|> "app" :> Capture "id" SessionId :> Get '[JSON] App
 
        -- GET /api/version
        --   Get the current git version of the server
@@ -409,6 +415,7 @@ primerServer = openAPIServer :<|> legacyServer
     legacyServer =
       ( addSession
           :<|> copySession
+          :<|> getApp
           :<|> getVersion
           :<|> ( \sid ->
                   getSessionName sid

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -352,9 +352,7 @@ liftQueryAppM h sid = withSession' sid (QueryApp $ runQueryAppM h)
 --
 -- Note: this API method is currently a special case, and we do not
 -- expect typical API clients to use it. Its primary use is for
--- testing. Whether we should add it to the HTTP API is tracked here:
---
--- https://github.com/hackworthltd/primer/issues/550
+-- testing.
 getApp :: (MonadIO m, MonadThrow m) => SessionId -> PrimerM m App
 getApp sid = withSession' sid $ QueryApp identity
 


### PR DESCRIPTION
We would like to use these via the HTTP API so that we can add whole programs (sessions) to the database from the Primer DSL, as opposed to building them action-by-action via the action API.