### PR TITLE
feat!: Switch to a path-based session parameter for OpenAPI bindings.

### DIFF
--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -114,6 +114,7 @@ import Primer.OpenAPI ()
 import Primer.Pagination (Paginated, PaginationParams, pagedDefaultClamp)
 import Primer.Typecheck (TypeError (TypeDoesNotMatchArrow))
 import Servant (
+  Capture,
   Get,
   Handler (..),
   JSON,
@@ -162,10 +163,9 @@ type API =
 type PrimerAPI = PrimerOpenAPI :<|> PrimerLegacyAPI
 
 type PrimerOpenAPI =
-  "api" :> (
+  "api" :> "sessions" :> (
     -- POST /api/sessions
     --   create a new session on the backend, returning its id
-    "sessions" :>
     Summary "Create a new session" :>
     OpId "createSession" Post '[JSON] SessionId
 
@@ -177,13 +177,13 @@ type PrimerOpenAPI =
     --   testing. Note that in a production system, this endpoint should
     --   obviously be authentication-scoped and only return the list of
     --   sessions that the caller is authorized to see.
-  :<|> QueryFlag "inMemory" :> "sessions" :>
+  :<|> QueryFlag "inMemory" :>
     PaginationParams :>
     Summary "List sessions" :>
     OpId "getSessionList" Get '[JSON] (Paginated Session)
 
     -- The rest of the API is scoped to a particular session
-  :<|> QueryParam' '[Required, Strict] "session" SessionId :> SOpenAPI
+  :<|> Capture "sessionId" SessionId :> SOpenAPI
   )
 
 type PrimerLegacyAPI =
@@ -216,7 +216,7 @@ type PrimerLegacyAPI =
 
 -- | The session-specific bits of the api
 type SOpenAPI = (
-    -- GET /api/program
+    -- GET /api/sessions/:sessionId/program
     --   Get the current program state
     "program" :>
     Summary "Get the current program state" :>


### PR DESCRIPTION
BREAKING CHANGE: This changes the path for the OpenAPI `/api/program` endpoint to `/api/sessions/:sessionId/program`.

We've never been quite certain about how we wanted to deal with session parameters in URLs. In the Vonnegut days, we even debated putting them in an HTTP header as a way of treating them as a semi-secret and/or sort of auth token [1]. Based on my historical research, it appears we decided to use query parameters chiefly because that was the most obvious implementation choice when we were building the Vonnegut frontend in PureScript, and because nobody particularly cared otherwise. [2] [3] [4] (We later changed to a hash-based approach to allow the frontend to intercept them before passing them to the backend, but that concern is no longer relevant in our new React-based frontend. [5])

With the benefit of some more experience, I think it makes more sense to take a session-as-a-resource-based approach and embed the ID in the URL. This is the de facto standard [6], and I believe it'll lead to more rational URL schemes, especially for our new OpenAPI-based API.

(I'm not bothering to retrofit this change onto the legacy API as that time would better be spent converting the legacy API to the new OpenAPI bindings.)

[1] https://github.com/hackworthltd/vonnegut/pull/307#discussion_r586835220

[2] https://github.com/hackworthltd/vonnegut/pull/307#discussion_r586348912

[3] craftdocs://open?blockId=58731614-59DD-4CB2-B94E-25B66F8FCD43&spaceId=8b43f204-aeeb-b8ce-45cc-73a653745299

[4] https://github.com/hackworthltd/vonnegut/pull/307#discussion_r587415524

[5] craftdocs://open?blockId=6A5D62EA-6767-496D-9195-0403A484D3EE&spaceId=8b43f204-aeeb-b8ce-45cc-73a653745299

[6] https://stackoverflow.com/questions/9169081/rest-apis-custom-http-headers-vs-url-parameters
