### PR TITLE
fix: Rename `API.Tree`'s `style` field to `flavor`

### DIFF
--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -376,7 +376,7 @@ getProgram sid = withSession' sid $ QueryApp $ viewProg . handleGetProgramReques
 data Tree = Tree
   { nodeId :: Text
   -- ^ a unique identifier
-  , style :: NodeFlavor
+  , flavor :: NodeFlavor
   , body :: NodeBody
   , childTrees :: [Tree]
   , rightChild :: Maybe Tree
@@ -491,7 +491,7 @@ viewTreeExpr e0 = case e0 of
   Hole _ e ->
     Tree
       { nodeId
-      , style = FlavorHole
+      , flavor = FlavorHole
       , body = NoBody
       , childTrees = [viewTreeExpr e]
       , rightChild = Nothing
@@ -499,7 +499,7 @@ viewTreeExpr e0 = case e0 of
   EmptyHole _ ->
     Tree
       { nodeId
-      , style = FlavorEmptyHole
+      , flavor = FlavorEmptyHole
       , body = NoBody
       , childTrees = []
       , rightChild = Nothing
@@ -507,7 +507,7 @@ viewTreeExpr e0 = case e0 of
   Ann _ e t ->
     Tree
       { nodeId
-      , style = FlavorAnn
+      , flavor = FlavorAnn
       , body = NoBody
       , childTrees = [viewTreeExpr e, viewTreeType t]
       , rightChild = Nothing
@@ -515,7 +515,7 @@ viewTreeExpr e0 = case e0 of
   App _ e1 e2 ->
     Tree
       { nodeId
-      , style = FlavorApp
+      , flavor = FlavorApp
       , body = NoBody
       , childTrees = [viewTreeExpr e1, viewTreeExpr e2]
       , rightChild = Nothing
@@ -523,7 +523,7 @@ viewTreeExpr e0 = case e0 of
   APP _ e t ->
     Tree
       { nodeId
-      , style = FlavorAPP
+      , flavor = FlavorAPP
       , body = NoBody
       , childTrees = [viewTreeExpr e, viewTreeType t]
       , rightChild = Nothing
@@ -531,7 +531,7 @@ viewTreeExpr e0 = case e0 of
   Con _ s ->
     Tree
       { nodeId
-      , style = FlavorCon
+      , flavor = FlavorCon
       , body = TextBody $ showGlobal s
       , childTrees = []
       , rightChild = Nothing
@@ -539,7 +539,7 @@ viewTreeExpr e0 = case e0 of
   Lam _ s e ->
     Tree
       { nodeId
-      , style = FlavorLam
+      , flavor = FlavorLam
       , body = TextBody $ unName $ unLocalName s
       , childTrees = [viewTreeExpr e]
       , rightChild = Nothing
@@ -547,7 +547,7 @@ viewTreeExpr e0 = case e0 of
   LAM _ s e ->
     Tree
       { nodeId
-      , style = FlavorLAM
+      , flavor = FlavorLAM
       , body = TextBody $ unName $ unLocalName s
       , childTrees = [viewTreeExpr e]
       , rightChild = Nothing
@@ -555,19 +555,19 @@ viewTreeExpr e0 = case e0 of
   Var _ ref ->
     Tree
       { nodeId
-      , style
+      , flavor
       , body
       , childTrees = []
       , rightChild = Nothing
       }
     where
-      (style, body) = case ref of
+      (flavor, body) = case ref of
         GlobalVarRef n -> (FlavorGlobalVar, TextBody $ showGlobal n)
         LocalVarRef n -> (FlavorLocalVar, TextBody $ unName $ unLocalName n)
   Let _ s e1 e2 ->
     Tree
       { nodeId
-      , style = FlavorLet
+      , flavor = FlavorLet
       , body = TextBody $ unName $ unLocalName s
       , childTrees = [viewTreeExpr e1, viewTreeExpr e2]
       , rightChild = Nothing
@@ -575,7 +575,7 @@ viewTreeExpr e0 = case e0 of
   LetType _ s t e ->
     Tree
       { nodeId
-      , style = FlavorLetType
+      , flavor = FlavorLetType
       , body = TextBody $ unName $ unLocalName s
       , childTrees = [viewTreeExpr e, viewTreeType t]
       , rightChild = Nothing
@@ -583,7 +583,7 @@ viewTreeExpr e0 = case e0 of
   Letrec _ s e1 t e2 ->
     Tree
       { nodeId
-      , style = FlavorLetrec
+      , flavor = FlavorLetrec
       , body = TextBody $ unName $ unLocalName s
       , childTrees = [viewTreeExpr e1, viewTreeType t, viewTreeExpr e2]
       , rightChild = Nothing
@@ -591,7 +591,7 @@ viewTreeExpr e0 = case e0 of
   Case _ e bs ->
     Tree
       { nodeId
-      , style = FlavorCase
+      , flavor = FlavorCase
       , body = NoBody
       , childTrees = [viewTreeExpr e]
       , -- seeing as the inner function always returns a `Just`,
@@ -608,18 +608,18 @@ viewTreeExpr e0 = case e0 of
                  in Just
                       Tree
                         { nodeId = boxId
-                        , style = FlavorPattern
+                        , flavor = FlavorPattern
                         , body =
                             BoxBody
                               Tree
                                 { nodeId = patternRootId
-                                , style = FlavorCon
+                                , flavor = FlavorCon
                                 , body = TextBody $ showGlobal con
                                 , childTrees =
                                     binds <&> \(Bind m v) ->
                                       Tree
                                         { nodeId = show $ m ^. _id
-                                        , style = FlavorLocalVar
+                                        , flavor = FlavorLocalVar
                                         , body = TextBody $ unName $ unLocalName v
                                         , childTrees = []
                                         , rightChild = Nothing
@@ -636,7 +636,7 @@ viewTreeExpr e0 = case e0 of
   PrimCon _ pc ->
     Tree
       { nodeId
-      , style = FlavorPrimCon
+      , flavor = FlavorPrimCon
       , body = TextBody $ case pc of
           PrimChar c -> T.singleton c
           PrimInt c -> show c
@@ -652,7 +652,7 @@ viewTreeType t0 = case t0 of
   TEmptyHole _ ->
     Tree
       { nodeId
-      , style = FlavorTEmptyHole
+      , flavor = FlavorTEmptyHole
       , body = NoBody
       , childTrees = []
       , rightChild = Nothing
@@ -660,7 +660,7 @@ viewTreeType t0 = case t0 of
   THole _ t ->
     Tree
       { nodeId
-      , style = FlavorTHole
+      , flavor = FlavorTHole
       , body = NoBody
       , childTrees = [viewTreeType t]
       , rightChild = Nothing
@@ -668,7 +668,7 @@ viewTreeType t0 = case t0 of
   TCon _ n ->
     Tree
       { nodeId
-      , style = FlavorTCon
+      , flavor = FlavorTCon
       , body = TextBody $ showGlobal n
       , childTrees = []
       , rightChild = Nothing
@@ -676,7 +676,7 @@ viewTreeType t0 = case t0 of
   TFun _ t1 t2 ->
     Tree
       { nodeId
-      , style = FlavorTFun
+      , flavor = FlavorTFun
       , body = NoBody
       , childTrees = [viewTreeType t1, viewTreeType t2]
       , rightChild = Nothing
@@ -684,7 +684,7 @@ viewTreeType t0 = case t0 of
   TVar _ n ->
     Tree
       { nodeId
-      , style = FlavorTVar
+      , flavor = FlavorTVar
       , body = TextBody $ unName $ unLocalName n
       , childTrees = []
       , rightChild = Nothing
@@ -692,7 +692,7 @@ viewTreeType t0 = case t0 of
   TApp _ t1 t2 ->
     Tree
       { nodeId
-      , style = FlavorTApp
+      , flavor = FlavorTApp
       , body = NoBody
       , childTrees = [viewTreeType t1, viewTreeType t2]
       , rightChild = Nothing
@@ -700,7 +700,7 @@ viewTreeType t0 = case t0 of
   TForall _ n k t ->
     Tree
       { nodeId
-      , style = FlavorTForall
+      , flavor = FlavorTForall
       , body = TextBody $ withKindAnn $ unName $ unLocalName n
       , childTrees = [viewTreeType t]
       , rightChild = Nothing

--- a/primer/test/outputs/APITree/Expr
+++ b/primer/test/outputs/APITree/Expr
@@ -1,33 +1,33 @@
 Tree
     { nodeId = "9"
-    , style = FlavorLet
+    , flavor = FlavorLet
     , body = TextBody "x"
     , childTrees =
         [ Tree
             { nodeId = "10"
-            , style = FlavorCon
+            , flavor = FlavorCon
             , body = TextBody "Builtins.True"
             , childTrees = []
             , rightChild = Nothing
             }
         , Tree
             { nodeId = "11"
-            , style = FlavorLetrec
+            , flavor = FlavorLetrec
             , body = TextBody "y"
             , childTrees =
                 [ Tree
                     { nodeId = "12"
-                    , style = FlavorApp
+                    , flavor = FlavorApp
                     , body = NoBody
                     , childTrees =
                         [ Tree
                             { nodeId = "13"
-                            , style = FlavorHole
+                            , flavor = FlavorHole
                             , body = NoBody
                             , childTrees =
                                 [ Tree
                                     { nodeId = "14"
-                                    , style = FlavorCon
+                                    , flavor = FlavorCon
                                     , body = TextBody "Builtins.Just"
                                     , childTrees = []
                                     , rightChild = Nothing
@@ -37,12 +37,12 @@ Tree
                             }
                         , Tree
                             { nodeId = "15"
-                            , style = FlavorHole
+                            , flavor = FlavorHole
                             , body = NoBody
                             , childTrees =
                                 [ Tree
                                     { nodeId = "16"
-                                    , style = FlavorGlobalVar
+                                    , flavor = FlavorGlobalVar
                                     , body = TextBody "M.unboundName"
                                     , childTrees = []
                                     , rightChild = Nothing
@@ -55,12 +55,12 @@ Tree
                     }
                 , Tree
                     { nodeId = "17"
-                    , style = FlavorTHole
+                    , flavor = FlavorTHole
                     , body = NoBody
                     , childTrees =
                         [ Tree
                             { nodeId = "18"
-                            , style = FlavorTCon
+                            , flavor = FlavorTCon
                             , body = TextBody "Builtins.Maybe"
                             , childTrees = []
                             , rightChild = Nothing
@@ -70,49 +70,49 @@ Tree
                     }
                 , Tree
                     { nodeId = "19"
-                    , style = FlavorAnn
+                    , flavor = FlavorAnn
                     , body = NoBody
                     , childTrees =
                         [ Tree
                             { nodeId = "20"
-                            , style = FlavorLam
+                            , flavor = FlavorLam
                             , body = TextBody "i"
                             , childTrees =
                                 [ Tree
                                     { nodeId = "21"
-                                    , style = FlavorLAM
+                                    , flavor = FlavorLAM
                                     , body = TextBody "β"
                                     , childTrees =
                                         [ Tree
                                             { nodeId = "22"
-                                            , style = FlavorApp
+                                            , flavor = FlavorApp
                                             , body = NoBody
                                             , childTrees =
                                                 [ Tree
                                                     { nodeId = "23"
-                                                    , style = FlavorAPP
+                                                    , flavor = FlavorAPP
                                                     , body = NoBody
                                                     , childTrees =
                                                         [ Tree
                                                             { nodeId = "24"
-                                                            , style = FlavorLetType
+                                                            , flavor = FlavorLetType
                                                             , body = TextBody "b"
                                                             , childTrees =
                                                                 [ Tree
                                                                     { nodeId = "26"
-                                                                    , style = FlavorAPP
+                                                                    , flavor = FlavorAPP
                                                                     , body = NoBody
                                                                     , childTrees =
                                                                         [ Tree
                                                                             { nodeId = "27"
-                                                                            , style = FlavorCon
+                                                                            , flavor = FlavorCon
                                                                             , body = TextBody "Builtins.Left"
                                                                             , childTrees = []
                                                                             , rightChild = Nothing
                                                                             }
                                                                         , Tree
                                                                             { nodeId = "28"
-                                                                            , style = FlavorTVar
+                                                                            , flavor = FlavorTVar
                                                                             , body = TextBody "b"
                                                                             , childTrees = []
                                                                             , rightChild = Nothing
@@ -122,7 +122,7 @@ Tree
                                                                     }
                                                                 , Tree
                                                                     { nodeId = "25"
-                                                                    , style = FlavorTCon
+                                                                    , flavor = FlavorTCon
                                                                     , body = TextBody "Builtins.Bool"
                                                                     , childTrees = []
                                                                     , rightChild = Nothing
@@ -132,7 +132,7 @@ Tree
                                                             }
                                                         , Tree
                                                             { nodeId = "29"
-                                                            , style = FlavorTVar
+                                                            , flavor = FlavorTVar
                                                             , body = TextBody "β"
                                                             , childTrees = []
                                                             , rightChild = Nothing
@@ -142,12 +142,12 @@ Tree
                                                     }
                                                 , Tree
                                                     { nodeId = "30"
-                                                    , style = FlavorCase
+                                                    , flavor = FlavorCase
                                                     , body = NoBody
                                                     , childTrees =
                                                         [ Tree
                                                             { nodeId = "31"
-                                                            , style = FlavorLocalVar
+                                                            , flavor = FlavorLocalVar
                                                             , body = TextBody "i"
                                                             , childTrees = []
                                                             , rightChild = Nothing
@@ -156,11 +156,11 @@ Tree
                                                     , rightChild = Just
                                                         ( Tree
                                                             { nodeId = "30P0"
-                                                            , style = FlavorPattern
+                                                            , flavor = FlavorPattern
                                                             , body = BoxBody
                                                                 ( Tree
                                                                     { nodeId = "30P0B"
-                                                                    , style = FlavorCon
+                                                                    , flavor = FlavorCon
                                                                     , body = TextBody "Builtins.Zero"
                                                                     , childTrees = []
                                                                     , rightChild = Nothing
@@ -169,7 +169,7 @@ Tree
                                                             , childTrees =
                                                                 [ Tree
                                                                     { nodeId = "32"
-                                                                    , style = FlavorCon
+                                                                    , flavor = FlavorCon
                                                                     , body = TextBody "Builtins.False"
                                                                     , childTrees = []
                                                                     , rightChild = Nothing
@@ -178,16 +178,16 @@ Tree
                                                             , rightChild = Just
                                                                 ( Tree
                                                                     { nodeId = "30P1"
-                                                                    , style = FlavorPattern
+                                                                    , flavor = FlavorPattern
                                                                     , body = BoxBody
                                                                         ( Tree
                                                                             { nodeId = "30P1B"
-                                                                            , style = FlavorCon
+                                                                            , flavor = FlavorCon
                                                                             , body = TextBody "Builtins.Succ"
                                                                             , childTrees =
                                                                                 [ Tree
                                                                                     { nodeId = "33"
-                                                                                    , style = FlavorLocalVar
+                                                                                    , flavor = FlavorLocalVar
                                                                                     , body = TextBody "n"
                                                                                     , childTrees = []
                                                                                     , rightChild = Nothing
@@ -199,24 +199,24 @@ Tree
                                                                     , childTrees =
                                                                         [ Tree
                                                                             { nodeId = "34"
-                                                                            , style = FlavorApp
+                                                                            , flavor = FlavorApp
                                                                             , body = NoBody
                                                                             , childTrees =
                                                                                 [ Tree
                                                                                     { nodeId = "35"
-                                                                                    , style = FlavorApp
+                                                                                    , flavor = FlavorApp
                                                                                     , body = NoBody
                                                                                     , childTrees =
                                                                                         [ Tree
                                                                                             { nodeId = "36"
-                                                                                            , style = FlavorEmptyHole
+                                                                                            , flavor = FlavorEmptyHole
                                                                                             , body = NoBody
                                                                                             , childTrees = []
                                                                                             , rightChild = Nothing
                                                                                             }
                                                                                         , Tree
                                                                                             { nodeId = "37"
-                                                                                            , style = FlavorLocalVar
+                                                                                            , flavor = FlavorLocalVar
                                                                                             , body = TextBody "x"
                                                                                             , childTrees = []
                                                                                             , rightChild = Nothing
@@ -226,7 +226,7 @@ Tree
                                                                                     }
                                                                                 , Tree
                                                                                     { nodeId = "38"
-                                                                                    , style = FlavorLocalVar
+                                                                                    , flavor = FlavorLocalVar
                                                                                     , body = TextBody "y"
                                                                                     , childTrees = []
                                                                                     , rightChild = Nothing
@@ -252,41 +252,41 @@ Tree
                             }
                         , Tree
                             { nodeId = "39"
-                            , style = FlavorTFun
+                            , flavor = FlavorTFun
                             , body = NoBody
                             , childTrees =
                                 [ Tree
                                     { nodeId = "40"
-                                    , style = FlavorTCon
+                                    , flavor = FlavorTCon
                                     , body = TextBody "Builtins.Nat"
                                     , childTrees = []
                                     , rightChild = Nothing
                                     }
                                 , Tree
                                     { nodeId = "41"
-                                    , style = FlavorTForall
+                                    , flavor = FlavorTForall
                                     , body = TextBody "α"
                                     , childTrees =
                                         [ Tree
                                             { nodeId = "42"
-                                            , style = FlavorTApp
+                                            , flavor = FlavorTApp
                                             , body = NoBody
                                             , childTrees =
                                                 [ Tree
                                                     { nodeId = "43"
-                                                    , style = FlavorTApp
+                                                    , flavor = FlavorTApp
                                                     , body = NoBody
                                                     , childTrees =
                                                         [ Tree
                                                             { nodeId = "44"
-                                                            , style = FlavorTCon
+                                                            , flavor = FlavorTCon
                                                             , body = TextBody "Builtins.Either"
                                                             , childTrees = []
                                                             , rightChild = Nothing
                                                             }
                                                         , Tree
                                                             { nodeId = "45"
-                                                            , style = FlavorTCon
+                                                            , flavor = FlavorTCon
                                                             , body = TextBody "Builtins.Bool"
                                                             , childTrees = []
                                                             , rightChild = Nothing
@@ -296,7 +296,7 @@ Tree
                                                     }
                                                 , Tree
                                                     { nodeId = "46"
-                                                    , style = FlavorTVar
+                                                    , flavor = FlavorTVar
                                                     , body = TextBody "α"
                                                     , childTrees = []
                                                     , rightChild = Nothing

--- a/primer/test/outputs/APITree/Type
+++ b/primer/test/outputs/APITree/Type
@@ -1,45 +1,45 @@
 Tree
     { nodeId = "0"
-    , style = FlavorTFun
+    , flavor = FlavorTFun
     , body = NoBody
     , childTrees =
         [ Tree
             { nodeId = "1"
-            , style = FlavorTCon
+            , flavor = FlavorTCon
             , body = TextBody "Builtins.Nat"
             , childTrees = []
             , rightChild = Nothing
             }
         , Tree
             { nodeId = "2"
-            , style = FlavorTForall
+            , flavor = FlavorTForall
             , body = TextBody "a"
             , childTrees =
                 [ Tree
                     { nodeId = "3"
-                    , style = FlavorTApp
+                    , flavor = FlavorTApp
                     , body = NoBody
                     , childTrees =
                         [ Tree
                             { nodeId = "4"
-                            , style = FlavorTHole
+                            , flavor = FlavorTHole
                             , body = NoBody
                             , childTrees =
                                 [ Tree
                                     { nodeId = "5"
-                                    , style = FlavorTApp
+                                    , flavor = FlavorTApp
                                     , body = NoBody
                                     , childTrees =
                                         [ Tree
                                             { nodeId = "6"
-                                            , style = FlavorTCon
+                                            , flavor = FlavorTCon
                                             , body = TextBody "Builtins.List"
                                             , childTrees = []
                                             , rightChild = Nothing
                                             }
                                         , Tree
                                             { nodeId = "7"
-                                            , style = FlavorTEmptyHole
+                                            , flavor = FlavorTEmptyHole
                                             , body = NoBody
                                             , childTrees = []
                                             , rightChild = Nothing
@@ -52,7 +52,7 @@ Tree
                             }
                         , Tree
                             { nodeId = "8"
-                            , style = FlavorTVar
+                            , flavor = FlavorTVar
                             , body = TextBody "a"
                             , childTrees = []
                             , rightChild = Nothing


### PR DESCRIPTION
This corrects an oversight from when `NodeStyle` was renamed to `NodeFlavor`.