### PR TITLE
refactor: Remove redundant `Primer.Eval` record prefixes.

### DIFF
--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -363,14 +363,14 @@ testEndpoints =
     reductionDetail =
       BetaReduction
         BetaReductionDetail
-          { betaBefore = expr
-          , betaAfter = expr
-          , betaBindingName = "x"
-          , betaLambdaID = 0
-          , betaLetID = 0
-          , betaArgID = 0
-          , betaBodyID = 0
-          , betaTypes = Just (ty, ty)
+          { before = expr
+          , after = expr
+          , bindingName = "x"
+          , lambdaID = 0
+          , letID = 0
+          , argID = 0
+          , bodyID = 0
+          , types = Just (ty, ty)
           }
 
 primerApi :: Proxy PrimerAPI

--- a/primer/src/Primer/Eval.hs
+++ b/primer/src/Primer/Eval.hs
@@ -172,146 +172,146 @@ data EvalDetail
 
 -- | Detailed information about a beta reduction (of a λ or Λ).
 -- If λ:
--- - 'betaLambdaID' is the ID of the λ
--- - 'betaLetID' is the ID of the let
--- - 'betaTypes' is optionally the domain type and codomain type of the λ
+-- - 'lambdaID' is the ID of the λ
+-- - 'letID' is the ID of the let
+-- - 'types' is optionally the domain type and codomain type of the λ
 -- - i.e. k ~ ATmVar, domain ~ Type, codomain ~ Type
 -- If Λ:
--- - 'betaLambdaID' is the ID of the Λ
--- - 'betaLetID' is the ID of the "let type"
--- - 'betaTypes' is optionally the domain kind and codomain type of the λ
+-- - 'lambdaID' is the ID of the Λ
+-- - 'letID' is the ID of the "let type"
+-- - 'types' is optionally the domain kind and codomain type of the λ
 -- - i.e. k ~ ATyVar, domain ~ Kind, codomain ~ Type
 data BetaReductionDetail k domain codomain = BetaReductionDetail
-  { betaBefore :: Expr
-  , betaAfter :: Expr
-  , betaBindingName :: LocalName k
-  , betaLambdaID :: ID
-  , betaLetID :: ID
-  , betaArgID :: ID
-  , betaBodyID :: ID
-  , betaTypes :: Maybe (domain, codomain)
+  { before :: Expr
+  , after :: Expr
+  , bindingName :: LocalName k
+  , lambdaID :: ID
+  , letID :: ID
+  , argID :: ID
+  , bodyID :: ID
+  , types :: Maybe (domain, codomain)
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "beta" (BetaReductionDetail k domain codomain)
+  deriving (FromJSON, ToJSON) via PrimerJSON (BetaReductionDetail k domain codomain)
 
 data LocalVarInlineDetail k = LocalVarInlineDetail
-  { localVarInlineLetID :: ID
+  { letID :: ID
   -- ^ ID of the let expression that binds this variable
-  , localVarInlineVarID :: ID
+  , varID :: ID
   -- ^ ID of the variable being replaced
-  , localVarInlineBindingName :: LocalName k
+  , bindingName :: LocalName k
   -- ^ Name of the variable
-  , localVarInlineValueID :: ID
+  , valueID :: ID
   -- ^ ID of the expression or type that the variable is bound to
-  , localVarInlineReplacementID :: ID
+  , replacementID :: ID
   -- ^ ID of the expression or type that has replaced the variable in the result
-  , localVarInlineIsTypeVar :: Bool
+  , isTypeVar :: Bool
   -- ^ If 'True', the variable being inlined is a type variable.
   -- Otherwise it is a term variable.
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "localVarInline" (LocalVarInlineDetail k)
+  deriving (FromJSON, ToJSON) via PrimerJSON (LocalVarInlineDetail k)
 
 data GlobalVarInlineDetail = GlobalVarInlineDetail
-  { globalVarInlineDef :: ASTDef
+  { def :: ASTDef
   -- ^ The definition that the variable refers to
-  , globalVarInlineVar :: Expr
+  , var :: Expr
   -- ^ The variable being replaced
-  , globalVarInlineAfter :: Expr
+  , after :: Expr
   -- ^ The result of the reduction
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "globalVarInline" GlobalVarInlineDetail
+  deriving (FromJSON, ToJSON) via PrimerJSON GlobalVarInlineDetail
 
 data CaseReductionDetail = CaseReductionDetail
-  { caseBefore :: Expr
+  { before :: Expr
   -- ^ the case expression before reduction
-  , caseAfter :: Expr
+  , after :: Expr
   -- ^ the resulting expression after reduction
-  , caseTargetID :: ID
+  , targetID :: ID
   -- ^ the ID of the target (scrutinee)
-  , caseTargetCtorID :: ID
+  , targetCtorID :: ID
   -- ^ the ID of the constructor node in the target
-  , caseCtorName :: ValConName
+  , ctorName :: ValConName
   -- ^ the name of the matching constructor
-  , caseTargetArgIDs :: [ID]
+  , targetArgIDs :: [ID]
   -- ^ the arguments to the constructor in the target
-  , caseBranchBindingIDs :: [ID]
+  , branchBindingIDs :: [ID]
   -- ^ the bindings in the case branch (one for each arg above)
-  , caseBranchRhsID :: ID
+  , branchRhsID :: ID
   -- ^ the right hand side of the selected case branch
-  , caseLetIDs :: [ID]
+  , letIDs :: [ID]
   -- ^ the let expressions binding each argument in the result
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "case" CaseReductionDetail
+  deriving (FromJSON, ToJSON) via PrimerJSON CaseReductionDetail
 
 data LetRemovalDetail = LetRemovalDetail
-  { letRemovalBefore :: Expr
+  { before :: Expr
   -- ^ the let expression before reduction
-  , letRemovalAfter :: Expr
+  , after :: Expr
   -- ^ the resulting expression after reduction
-  , letRemovalBindingName :: Name
+  , bindingName :: Name
   -- ^ the name of the unused bound variable (either term or type variable)
-  , letRemovalLetID :: ID
+  , letID :: ID
   -- ^ the full let expression
-  , letRemovalBodyID :: ID
+  , bodyID :: ID
   -- ^ the right hand side of the let
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "letRemoval" LetRemovalDetail
+  deriving (FromJSON, ToJSON) via PrimerJSON LetRemovalDetail
 
 data LetRenameDetail = LetRenameDetail
-  { letRenameBefore :: Expr
+  { before :: Expr
   -- ^ the let expression before reduction
-  , letRenameAfter :: Expr
+  , after :: Expr
   -- ^ the resulting expression after reduction
-  , letRenameBindingNameOld :: Name
+  , bindingNameOld :: Name
   -- ^ the old name of the let-bound variable
-  , letRenameBindingNameNew :: Name
+  , bindingNameNew :: Name
   -- ^ the new name of the let-bound variable
-  , letRenameLetID :: ID
+  , letID :: ID
   -- ^ the full let expression
-  , letRenameBindingOccurrences :: [ID]
+  , bindingOccurrences :: [ID]
   -- ^ where the old name occurred inside the bound expression
-  , letRenameBodyID :: ID
+  , bodyID :: ID
   -- ^ the right hand side of the let
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "letRename" LetRenameDetail
+  deriving (FromJSON, ToJSON) via PrimerJSON LetRenameDetail
 
 data PushAppIntoLetrecDetail = PushAppIntoLetrecDetail
-  { pushAppIntoLetrecBefore :: Expr
+  { before :: Expr
   -- ^ the expression before reduction
-  , pushAppIntoLetrecAfter :: Expr
+  , after :: Expr
   -- ^ the expression after reduction
-  , pushAppIntoLetrecArgID :: ID
+  , argID :: ID
   -- ^ the ID of the argument to the application
-  , pushAppIntoLetrecLetrecID :: ID
+  , letrecID :: ID
   -- ^ the ID of the letrec
-  , pushAppIntoLetrecLamID :: ID
+  , lamID :: ID
   -- ^ the ID of the lambda
-  , pushAppIntoLetrecLetBindingName :: LVarName
+  , letBindingName :: LVarName
   -- ^ The name of the variable bound by the letrec
-  , pushAppIntoLetrecIsTypeApplication :: Bool
+  , isTypeApplication :: Bool
   -- ^ If 'True', the application is of a big lambda to a type.
   -- Otherwise it is of a small lambda to a term.
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "pushAppIntoLetrec" PushAppIntoLetrecDetail
+  deriving (FromJSON, ToJSON) via PrimerJSON PushAppIntoLetrecDetail
 
 data ApplyPrimFunDetail = ApplyPrimFunDetail
-  { applyPrimFunBefore :: Expr
+  { before :: Expr
   -- ^ the expression before reduction
-  , applyPrimFunAfter :: Expr
+  , after :: Expr
   -- ^ the expression after reduction
-  , applyPrimFunName :: GVarName
+  , name :: GVarName
   -- ^ the name of the primitive function
-  , applyPrimFunArgIDs :: [ID]
+  , argIDs :: [ID]
   -- ^ the IDs of the arguments to the application
   }
   deriving (Eq, Show, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSONPrefix "applyPrimFun" ApplyPrimFunDetail
+  deriving (FromJSON, ToJSON) via PrimerJSON ApplyPrimFunDetail
 
 -- | A map from local variable names to the ID of their binding, their bound
 -- value and whether anything in their value would be captured by an intervening
@@ -628,14 +628,14 @@ tryReduceExpr globals locals = \case
       ( expr
       , BetaReduction
           BetaReductionDetail
-            { betaBefore = App mApp lam arg
-            , betaAfter = expr
-            , betaBindingName = x
-            , betaLambdaID = lam ^. _id
-            , betaLetID = expr ^. _id
-            , betaArgID = arg ^. _id
-            , betaBodyID = body ^. _id
-            , betaTypes = Nothing
+            { before = App mApp lam arg
+            , after = expr
+            , bindingName = x
+            , lambdaID = lam ^. _id
+            , letID = expr ^. _id
+            , argID = arg ^. _id
+            , bodyID = body ^. _id
+            , types = Nothing
             }
       )
   -- Beta reduction (with annotation)
@@ -668,14 +668,14 @@ tryReduceExpr globals locals = \case
       ( expr
       , BetaReduction
           BetaReductionDetail
-            { betaBefore = App mApp annotation arg
-            , betaAfter = expr
-            , betaBindingName = x
-            , betaLambdaID = lam ^. _id
-            , betaLetID = letexpr ^. _id
-            , betaArgID = arg ^. _id
-            , betaBodyID = body ^. _id
-            , betaTypes = types
+            { before = App mApp annotation arg
+            , after = expr
+            , bindingName = x
+            , lambdaID = lam ^. _id
+            , letID = letexpr ^. _id
+            , argID = arg ^. _id
+            , bodyID = body ^. _id
+            , types = types
             }
       )
   -- (letrec x : T = t in λ ...) e  ~> letrec x : T = t in ((λ...) e)
@@ -687,13 +687,13 @@ tryReduceExpr globals locals = \case
       ( expr
       , PushAppIntoLetrec
           PushAppIntoLetrecDetail
-            { pushAppIntoLetrecBefore = before
-            , pushAppIntoLetrecAfter = expr
-            , pushAppIntoLetrecArgID = e2 ^. _id
-            , pushAppIntoLetrecLetrecID = mLet ^. _id
-            , pushAppIntoLetrecLamID = lam ^. _id
-            , pushAppIntoLetrecLetBindingName = x
-            , pushAppIntoLetrecIsTypeApplication = False
+            { before = before
+            , after = expr
+            , argID = e2 ^. _id
+            , letrecID = mLet ^. _id
+            , lamID = lam ^. _id
+            , letBindingName = x
+            , isTypeApplication = False
             }
       )
 
@@ -705,10 +705,10 @@ tryReduceExpr globals locals = \case
           ( expr
           , ApplyPrimFun
               ApplyPrimFunDetail
-                { applyPrimFunBefore = before
-                , applyPrimFunAfter = expr
-                , applyPrimFunName = name
-                , applyPrimFunArgIDs = args ^. mapping _id
+                { before = before
+                , after = expr
+                , name = name
+                , argIDs = args ^. mapping _id
                 }
           )
 
@@ -733,14 +733,14 @@ tryReduceExpr globals locals = \case
       ( expr
       , BETAReduction
           BetaReductionDetail
-            { betaBefore = APP mAPP lam arg
-            , betaAfter = expr
-            , betaBindingName = x
-            , betaLambdaID = lam ^. _id
-            , betaLetID = expr ^. _id
-            , betaArgID = arg ^. _id
-            , betaBodyID = body ^. _id
-            , betaTypes = Nothing
+            { before = APP mAPP lam arg
+            , after = expr
+            , bindingName = x
+            , lambdaID = lam ^. _id
+            , letID = expr ^. _id
+            , argID = arg ^. _id
+            , bodyID = body ^. _id
+            , types = Nothing
             }
       )
   -- Beta reduction of big lambda (with annotation)
@@ -762,14 +762,14 @@ tryReduceExpr globals locals = \case
           ( expr
           , BETAReduction
               BetaReductionDetail
-                { betaBefore = APP mAPP annotation t
-                , betaAfter = expr
-                , betaBindingName = x
-                , betaLambdaID = lam ^. _id
-                , betaLetID = expr ^. _id
-                , betaArgID = t ^. _id
-                , betaBodyID = body ^. _id
-                , betaTypes = Just (k, b)
+                { before = APP mAPP annotation t
+                , after = expr
+                , bindingName = x
+                , lambdaID = lam ^. _id
+                , letID = expr ^. _id
+                , argID = t ^. _id
+                , bodyID = body ^. _id
+                , types = Just (k, b)
                 }
           )
       _ -> throwError $ BadBigLambdaAnnotation annotation
@@ -782,13 +782,13 @@ tryReduceExpr globals locals = \case
       ( expr
       , PushAppIntoLetrec
           PushAppIntoLetrecDetail
-            { pushAppIntoLetrecBefore = before
-            , pushAppIntoLetrecAfter = expr
-            , pushAppIntoLetrecArgID = e2 ^. _id
-            , pushAppIntoLetrecLetrecID = mLet ^. _id
-            , pushAppIntoLetrecLamID = lam ^. _id
-            , pushAppIntoLetrecLetBindingName = x
-            , pushAppIntoLetrecIsTypeApplication = True
+            { before = before
+            , after = expr
+            , argID = e2 ^. _id
+            , letrecID = mLet ^. _id
+            , lamID = lam ^. _id
+            , letBindingName = x
+            , isTypeApplication = True
             }
       )
   -- Beta reduction of an inner big lambda application
@@ -819,12 +819,12 @@ tryReduceExpr globals locals = \case
           ( e'
           , LocalVarInline
               LocalVarInlineDetail
-                { localVarInlineLetID = i
-                , localVarInlineVarID = mVar ^. _id
-                , localVarInlineValueID = e ^. _id
-                , localVarInlineBindingName = x
-                , localVarInlineReplacementID = e' ^. _id
-                , localVarInlineIsTypeVar = False
+                { letID = i
+                , varID = mVar ^. _id
+                , valueID = e ^. _id
+                , bindingName = x
+                , replacementID = e' ^. _id
+                , isTypeVar = False
                 }
           )
   -- Inline global variable
@@ -838,9 +838,9 @@ tryReduceExpr globals locals = \case
       ( expr
       , GlobalVarInline
           GlobalVarInlineDetail
-            { globalVarInlineVar = Var mVar (GlobalVarRef x)
-            , globalVarInlineDef = def
-            , globalVarInlineAfter = expr
+            { var = Var mVar (GlobalVarRef x)
+            , def = def
+            , after = expr
             }
       )
   expr@(Let meta x e body)
@@ -893,15 +893,15 @@ tryReduceExpr globals locals = \case
                 ( expr'
                 , CaseReduction
                     CaseReductionDetail
-                      { caseBefore = Case m scrut branches
-                      , caseAfter = expr'
-                      , caseTargetID = scrut ^. _id
-                      , caseTargetCtorID = mCon ^. _id
-                      , caseCtorName = c
-                      , caseTargetArgIDs = map (^. _id) termArgs
-                      , caseBranchBindingIDs = map (^. _id) binds
-                      , caseBranchRhsID = rhs ^. _id
-                      , caseLetIDs = letIDs
+                      { before = Case m scrut branches
+                      , after = expr'
+                      , targetID = scrut ^. _id
+                      , targetCtorID = mCon ^. _id
+                      , ctorName = c
+                      , targetArgIDs = map (^. _id) termArgs
+                      , branchBindingIDs = map (^. _id) binds
+                      , branchRhsID = rhs ^. _id
+                      , letIDs = letIDs
                       }
                 )
             Nothing -> throwError NoMatchingCaseBranch
@@ -912,11 +912,11 @@ tryReduceExpr globals locals = \case
         ( body
         , LetRemoval
             LetRemovalDetail
-              { letRemovalBefore = expr
-              , letRemovalAfter = body
-              , letRemovalBindingName = unLocalName x
-              , letRemovalLetID = meta ^. _id
-              , letRemovalBodyID = body ^. _id
+              { before = expr
+              , after = body
+              , bindingName = unLocalName x
+              , letID = meta ^. _id
+              , bodyID = body ^. _id
               }
         )
     mkLetRenameDetail expr body binding meta = do
@@ -934,13 +934,13 @@ tryReduceExpr globals locals = \case
         ( expr'
         , LetRename
             LetRenameDetail
-              { letRenameBefore = expr
-              , letRenameAfter = expr'
-              , letRenameBindingNameOld = x
-              , letRenameBindingNameNew = y
-              , letRenameLetID = meta ^. _id
-              , letRenameBindingOccurrences = occ
-              , letRenameBodyID = body ^. _id
+              { before = expr
+              , after = expr'
+              , bindingNameOld = x
+              , bindingNameNew = y
+              , letID = meta ^. _id
+              , bindingOccurrences = occ
+              , bodyID = body ^. _id
               }
         )
 
@@ -963,12 +963,12 @@ tryReduceType _globals locals = \case
           ( t'
           , LocalTypeVarInline
               LocalVarInlineDetail
-                { localVarInlineLetID = i
-                , localVarInlineVarID = mTVar ^. _id
-                , localVarInlineValueID = t ^. _id
-                , localVarInlineBindingName = x
-                , localVarInlineReplacementID = t' ^. _id
-                , localVarInlineIsTypeVar = True
+                { letID = i
+                , varID = mTVar ^. _id
+                , valueID = t ^. _id
+                , bindingName = x
+                , replacementID = t' ^. _id
+                , isTypeVar = True
                 }
           )
   _ -> throwError NotRedex

--- a/primer/src/Primer/JSON.hs
+++ b/primer/src/Primer/JSON.hs
@@ -1,9 +1,13 @@
-module Primer.JSON (CustomJSON (..), PrimerJSON, PrimerJSONPrefix, ToJSON, FromJSON, ToJSONKey, FromJSONKey) where
-
-import Foreword
+module Primer.JSON (
+  CustomJSON (..),
+  PrimerJSON,
+  ToJSON,
+  FromJSON,
+  ToJSONKey,
+  FromJSONKey,
+) where
 
 import Data.Aeson (FromJSONKey, ToJSONKey)
-import Data.List (stripPrefix)
 import Deriving.Aeson
 
 -- | A type for 'Primer' style JSON encoding.
@@ -11,18 +15,3 @@ import Deriving.Aeson
 -- API.
 -- This is designed to be compatible with purescript-foreign-generic.
 type PrimerJSON a = CustomJSON '[NoAllNullaryToStringTag] a
-
--- | Like 'PrimerJSON' but strips the given prefix from field names.
--- Useful if your Haskell fields are fooA, fooB and you want the corresponding purescript
--- record to use a, b.
--- This should only be used for records whose fields all begin with the given prefix, followed by a
--- capital letter.
-type PrimerJSONPrefix prefix a = CustomJSON '[NoAllNullaryToStringTag, FieldLabelModifier (StripPrefixAndStartLowercase prefix)] a
-
-data StripPrefixAndStartLowercase prefix
-
-instance KnownSymbol prefix => StringModifier (StripPrefixAndStartLowercase prefix) where
-  getStringModifier s = case stripPrefix (symbolVal (Proxy @prefix)) s of
-    Just "" -> ""
-    Just (c : s') -> toLower c : s'
-    Nothing -> s

--- a/primer/test/Tests/Eval.hs
+++ b/primer/test/Tests/Eval.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module Tests.Eval where
 
 import Foreword
@@ -93,14 +95,14 @@ unit_tryReduce_beta = do
   case result of
     Right (expr, BetaReduction detail) -> do
       expr ~= expectedResult
-      betaBefore detail ~= input
-      betaAfter detail ~= expectedResult
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaLetID detail @?= expr ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
-      betaTypes detail @?= Nothing
+      detail.before ~= input
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.letID @?= expr ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
+      detail.types @?= Nothing
     _ -> assertFailure $ show result
 
 unit_tryReduce_beta_annotation :: Assertion
@@ -117,14 +119,14 @@ unit_tryReduce_beta_annotation = do
           pure (l, x, a, i, r, t1, t2)
       result = runTryReduce mempty mempty (input, maxid)
   case result of
-    Right (expr, BetaReduction detail@BetaReductionDetail{betaTypes = Just (l, r)}) -> do
+    Right (expr, BetaReduction detail@BetaReductionDetail{types = Just (l, r)}) -> do
       expr ~= expectedResult
-      betaBefore detail ~= input
-      betaAfter detail ~= expectedResult
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
+      detail.before ~= input
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
       l ~~= argType
       r ~~= resultType
     _ -> assertFailure $ show result
@@ -143,14 +145,14 @@ unit_tryReduce_beta_annotation_hole = do
           pure (l, x, a, i, r, t1, t2)
       result = runTryReduce mempty mempty (input, maxid)
   case result of
-    Right (expr, BetaReduction detail@BetaReductionDetail{betaTypes = Just (l, r)}) -> do
+    Right (expr, BetaReduction detail@BetaReductionDetail{types = Just (l, r)}) -> do
       expr ~= expectedResult
-      betaBefore detail ~= input
-      betaAfter detail ~= expectedResult
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
+      detail.before ~= input
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
       l ~~= argType
       r ~~= resultType
     _ -> assertFailure $ show result
@@ -170,13 +172,13 @@ unit_tryReduce_beta_nested = do
   case result of
     Right (expr, BetaReduction detail) -> do
       expr ~= expectedResult
-      betaBefore detail ~= create' (app (lam "x" (lam "y" (lvar "x"))) (con' ["M"] "C"))
-      betaAfter detail ~= create' (let_ "x" (con' ["M"] "C") (lam "y" (lvar "x")))
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
-      betaTypes detail @?= Nothing
+      detail.before ~= create' (app (lam "x" (lam "y" (lvar "x"))) (con' ["M"] "C"))
+      detail.after ~= create' (let_ "x" (con' ["M"] "C") (lam "y" (lvar "x")))
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
+      detail.types @?= Nothing
     _ -> assertFailure $ show result
 
 unit_tryReduce_beta_annotation_nested :: Assertion
@@ -193,14 +195,14 @@ unit_tryReduce_beta_annotation_nested = do
           pure (l, x, a, i, r, t1, t2)
       result = runTryReduce mempty mempty (input, maxid)
   case result of
-    Right (expr, BetaReduction detail@BetaReductionDetail{betaTypes = Just (l, r)}) -> do
+    Right (expr, BetaReduction detail@BetaReductionDetail{types = Just (l, r)}) -> do
       expr ~= expectedResult
-      betaBefore detail ~= create' (app (ann (lam "x" (lvar "x")) (tfun (tcon' ["M"] "A") (tcon' ["M"] "B"))) (con' ["M"] "C"))
-      betaAfter detail ~= create' (ann (let_ "x" (ann (con' ["M"] "C") (tcon' ["M"] "A")) (lvar "x")) (tcon' ["M"] "B"))
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
+      detail.before ~= create' (app (ann (lam "x" (lvar "x")) (tfun (tcon' ["M"] "A") (tcon' ["M"] "B"))) (con' ["M"] "C"))
+      detail.after ~= create' (ann (let_ "x" (ann (con' ["M"] "C") (tcon' ["M"] "A")) (lvar "x")) (tcon' ["M"] "B"))
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
       l ~~= argType
       r ~~= resultType
     _ -> assertFailure $ show result
@@ -229,14 +231,14 @@ unit_tryReduce_beta_name_clash = do
   case result of
     Right (expr, BetaReduction detail) -> do
       expr ~= expectedResult
-      betaBefore detail ~= input
-      betaAfter detail ~= expectedResult
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaLetID detail @?= expr ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
-      betaTypes detail @?= Nothing
+      detail.before ~= input
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.letID @?= expr ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
+      detail.types @?= Nothing
     _ -> assertFailure $ show result
 
 unit_tryReduce_BETA :: Assertion
@@ -253,14 +255,14 @@ unit_tryReduce_BETA = do
   case result of
     Right (expr, BETAReduction detail) -> do
       expr ~= expectedResult
-      betaBefore detail ~= input
-      betaAfter detail ~= expectedResult
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaLetID detail @?= expr ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
-      betaTypes detail @?= Nothing
+      detail.before ~= input
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.letID @?= expr ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
+      detail.types @?= Nothing
     _ -> assertFailure $ show result
 
 unit_tryReduce_BETA_name_clash :: Assertion
@@ -278,14 +280,14 @@ unit_tryReduce_BETA_name_clash = do
   case result of
     Right (expr, BETAReduction detail) -> do
       expr ~= expectedResult
-      betaBefore detail ~= input
-      betaAfter detail ~= expectedResult
-      betaBindingName detail @?= "x"
-      betaLambdaID detail @?= lambda ^. _id
-      betaLetID detail @?= expr ^. _id
-      betaArgID detail @?= arg ^. _id
-      betaBodyID detail @?= body ^. _id
-      betaTypes detail @?= Nothing
+      detail.before ~= input
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.lambdaID @?= lambda ^. _id
+      detail.letID @?= expr ^. _id
+      detail.argID @?= arg ^. _id
+      detail.bodyID @?= body ^. _id
+      detail.types @?= Nothing
     _ -> assertFailure $ show result
 
 unit_tryReduce_local_term_var :: Assertion
@@ -298,12 +300,12 @@ unit_tryReduce_local_term_var = do
     Right (expr', LocalVarInline detail) -> do
       expr' ~= val
 
-      localVarInlineLetID detail @?= 5
-      localVarInlineVarID detail @?= 0
-      localVarInlineBindingName detail @?= "x"
-      localVarInlineValueID detail @?= 1
-      localVarInlineReplacementID detail @?= 2
-      localVarInlineIsTypeVar detail @?= False
+      detail.letID @?= 5
+      detail.varID @?= 0
+      detail.bindingName @?= "x"
+      detail.valueID @?= 1
+      detail.replacementID @?= 2
+      detail.isTypeVar @?= False
     _ -> assertFailure $ show result
 
 unit_tryReduce_local_type_var :: Assertion
@@ -316,12 +318,12 @@ unit_tryReduce_local_type_var = do
     Right (ty, LocalTypeVarInline detail) -> do
       ty ~~= val
 
-      localVarInlineLetID detail @?= 5
-      localVarInlineVarID detail @?= 0
-      localVarInlineBindingName detail @?= "x"
-      localVarInlineValueID detail @?= 1
-      localVarInlineReplacementID detail @?= 2
-      localVarInlineIsTypeVar detail @?= True
+      detail.letID @?= 5
+      detail.varID @?= 0
+      detail.bindingName @?= "x"
+      detail.valueID @?= 1
+      detail.replacementID @?= 2
+      detail.isTypeVar @?= True
     _ -> assertFailure $ show result
 
 unit_tryReduce_global_var :: Assertion
@@ -339,9 +341,9 @@ unit_tryReduce_global_var = do
     Right (expr', GlobalVarInline detail) -> do
       expr' ~= expectedResult
 
-      globalVarInlineDef detail @?= def
-      globalVarInlineVar detail @?= expr
-      globalVarInlineAfter detail @?= expr'
+      detail.def @?= def
+      detail.var @?= expr
+      detail.after @?= expr'
     _ -> assertFailure $ show result
 
 unit_tryReduce_let :: Assertion
@@ -353,11 +355,11 @@ unit_tryReduce_let = do
     Right (expr', LetRemoval detail) -> do
       expr' ~= expectedResult
 
-      letRemovalBefore detail @?= expr
-      letRemovalAfter detail ~= expectedResult
-      letRemovalBindingName detail @?= "x"
-      letRemovalLetID detail @?= 0
-      letRemovalBodyID detail @?= 2
+      detail.before @?= expr
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.letID @?= 0
+      detail.bodyID @?= 2
     _ -> assertFailure $ show result
 
 -- let x = x in x ==> let y = x in y
@@ -370,13 +372,13 @@ unit_tryReduce_let_self_capture = do
     Right (expr', LetRename detail) -> do
       expr' ~= expectedResult
 
-      letRenameBefore detail @?= expr
-      letRenameAfter detail ~= expectedResult
-      letRenameBindingNameOld detail @?= "x"
-      letRenameBindingNameNew detail @?= "x0"
-      letRenameLetID detail @?= 0
-      letRenameBindingOccurrences detail @?= [1]
-      letRenameBodyID detail @?= 2
+      detail.before @?= expr
+      detail.after ~= expectedResult
+      detail.bindingNameOld @?= "x"
+      detail.bindingNameNew @?= "x0"
+      detail.letID @?= 0
+      detail.bindingOccurrences @?= [1]
+      detail.bodyID @?= 2
     _ -> assertFailure $ show result
 
 unit_tryReduce_lettype :: Assertion
@@ -388,11 +390,11 @@ unit_tryReduce_lettype = do
     Right (expr', LetRemoval detail) -> do
       expr' ~= expectedResult
 
-      letRemovalBefore detail @?= expr
-      letRemovalAfter detail ~= expectedResult
-      letRemovalBindingName detail @?= "x"
-      letRemovalLetID detail @?= 0
-      letRemovalBodyID detail @?= 2
+      detail.before @?= expr
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.letID @?= 0
+      detail.bodyID @?= 2
     _ -> assertFailure $ show result
 
 -- let type x = x in _ :: x ==> let y = x in _ :: y
@@ -405,13 +407,13 @@ unit_tryReduce_lettype_self_capture = do
     Right (expr', LetRename detail) -> do
       expr' ~= expectedResult
 
-      letRenameBefore detail @?= expr
-      letRenameAfter detail ~= expectedResult
-      letRenameBindingNameOld detail @?= "x"
-      letRenameBindingNameNew detail @?= "x0"
-      letRenameLetID detail @?= 0
-      letRenameBindingOccurrences detail @?= [1]
-      letRenameBodyID detail @?= 2
+      detail.before @?= expr
+      detail.after ~= expectedResult
+      detail.bindingNameOld @?= "x"
+      detail.bindingNameNew @?= "x0"
+      detail.letID @?= 0
+      detail.bindingOccurrences @?= [1]
+      detail.bodyID @?= 2
     _ -> assertFailure $ show result
 
 unit_tryReduce_letrec :: Assertion
@@ -423,11 +425,11 @@ unit_tryReduce_letrec = do
     Right (expr', LetRemoval detail) -> do
       expr' ~= expectedResult
 
-      letRemovalBefore detail @?= expr
-      letRemovalAfter detail ~= expectedResult
-      letRemovalBindingName detail @?= "x"
-      letRemovalLetID detail @?= 0
-      letRemovalBodyID detail @?= 3
+      detail.before @?= expr
+      detail.after ~= expectedResult
+      detail.bindingName @?= "x"
+      detail.letID @?= 0
+      detail.bodyID @?= 3
     _ -> assertFailure $ show result
 
 --     (letrec f = λx. x : T in λx. f x) D
@@ -446,13 +448,13 @@ unit_tryReduce_letrec_app = do
     Right (expr', PushAppIntoLetrec detail) -> do
       expr' ~= expectedResult
 
-      pushAppIntoLetrecBefore detail ~= expr
-      pushAppIntoLetrecAfter detail ~= expectedResult
-      pushAppIntoLetrecArgID detail @?= arg ^. _id
-      pushAppIntoLetrecLamID detail @?= lambda ^. _id
-      pushAppIntoLetrecLetrecID detail @?= letrec_ ^. _id
-      pushAppIntoLetrecLetBindingName detail @?= "f"
-      pushAppIntoLetrecIsTypeApplication detail @?= False
+      detail.before ~= expr
+      detail.after ~= expectedResult
+      detail.argID @?= arg ^. _id
+      detail.lamID @?= lambda ^. _id
+      detail.letrecID @?= letrec_ ^. _id
+      detail.letBindingName @?= "f"
+      detail.isTypeApplication @?= False
     _ -> assertFailure $ show result
 
 --     (letrec f = Λx. A : T in Λx. f x) B
@@ -471,13 +473,13 @@ unit_tryReduce_letrec_APP = do
     Right (expr', PushAppIntoLetrec detail) -> do
       expr' ~= expectedResult
 
-      pushAppIntoLetrecBefore detail ~= expr
-      pushAppIntoLetrecAfter detail ~= expectedResult
-      pushAppIntoLetrecArgID detail @?= arg ^. _id
-      pushAppIntoLetrecLamID detail @?= lambda ^. _id
-      pushAppIntoLetrecLetrecID detail @?= letrec_ ^. _id
-      pushAppIntoLetrecLetBindingName detail @?= "f"
-      pushAppIntoLetrecIsTypeApplication detail @?= True
+      detail.before ~= expr
+      detail.after ~= expectedResult
+      detail.argID @?= arg ^. _id
+      detail.lamID @?= lambda ^. _id
+      detail.letrecID @?= letrec_ ^. _id
+      detail.letBindingName @?= "f"
+      detail.isTypeApplication @?= True
     _ -> assertFailure $ show result
 
 -- let f = D in (letrec f = λx. x : T in λx. f x) f
@@ -507,15 +509,15 @@ unit_tryReduce_case_1 = do
     Right (expr', CaseReduction detail) -> do
       expr' ~= expectedResult
 
-      caseBefore detail ~= expr
-      caseAfter detail ~= expectedResult
-      caseTargetID detail @?= 1
-      caseTargetCtorID detail @?= 1
-      caseCtorName detail @?= vcn ["M"] "C"
-      caseTargetArgIDs detail @?= []
-      caseBranchBindingIDs detail @?= []
-      caseBranchRhsID detail @?= 4
-      caseLetIDs detail @?= []
+      detail.before ~= expr
+      detail.after ~= expectedResult
+      detail.targetID @?= 1
+      detail.targetCtorID @?= 1
+      detail.ctorName @?= vcn ["M"] "C"
+      detail.targetArgIDs @?= []
+      detail.branchBindingIDs @?= []
+      detail.branchRhsID @?= 4
+      detail.letIDs @?= []
     _ -> assertFailure $ show result
 
 unit_tryReduce_case_2 :: Assertion
@@ -533,15 +535,15 @@ unit_tryReduce_case_2 = do
     Right (expr', CaseReduction detail) -> do
       expr' ~= expectedResult
 
-      caseBefore detail ~= expr
-      caseAfter detail ~= expectedResult
-      caseTargetID detail @?= 1
-      caseTargetCtorID detail @?= 4
-      caseCtorName detail @?= vcn ["M"] "C"
-      caseTargetArgIDs detail @?= [5, 7, 8]
-      caseBranchBindingIDs detail @?= [11, 12, 13]
-      caseBranchRhsID detail @?= 14
-      caseLetIDs detail @?= [17, 16, 15]
+      detail.before ~= expr
+      detail.after ~= expectedResult
+      detail.targetID @?= 1
+      detail.targetCtorID @?= 4
+      detail.ctorName @?= vcn ["M"] "C"
+      detail.targetArgIDs @?= [5, 7, 8]
+      detail.branchBindingIDs @?= [11, 12, 13]
+      detail.branchRhsID @?= 14
+      detail.letIDs @?= [17, 16, 15]
     _ -> assertFailure $ show result
 
 unit_tryReduce_case_3 :: Assertion
@@ -559,15 +561,15 @@ unit_tryReduce_case_3 = do
     Right (expr', CaseReduction detail) -> do
       expr' ~= expectedResult
 
-      caseBefore detail ~= expr
-      caseAfter detail ~= expectedResult
-      caseTargetID detail @?= 1
-      caseTargetCtorID detail @?= 3
-      caseCtorName detail @?= vcn ["M"] "C"
-      caseTargetArgIDs detail @?= [5]
-      caseBranchBindingIDs detail @?= [8]
-      caseBranchRhsID detail @?= 9
-      caseLetIDs detail @?= [10]
+      detail.before ~= expr
+      detail.after ~= expectedResult
+      detail.targetID @?= 1
+      detail.targetCtorID @?= 3
+      detail.ctorName @?= vcn ["M"] "C"
+      detail.targetArgIDs @?= [5]
+      detail.branchBindingIDs @?= [8]
+      detail.branchRhsID @?= 9
+      detail.letIDs @?= [10]
     _ -> assertFailure $ show result
 
 unit_tryReduce_case_name_clash :: Assertion
@@ -586,15 +588,15 @@ unit_tryReduce_case_name_clash = do
     Right (expr', CaseReduction detail) -> do
       expr' ~= expectedResult
 
-      caseBefore detail ~= expr
-      caseAfter detail ~= expectedResult
-      caseTargetID detail @?= 1
-      caseTargetCtorID detail @?= 3
-      caseCtorName detail @?= vcn ["M"] "C"
-      caseTargetArgIDs detail @?= [4, 5]
-      caseBranchBindingIDs detail @?= [6, 7]
-      caseBranchRhsID detail @?= 8
-      caseLetIDs detail @?= [10, 9]
+      detail.before ~= expr
+      detail.after ~= expectedResult
+      detail.targetID @?= 1
+      detail.targetCtorID @?= 3
+      detail.ctorName @?= vcn ["M"] "C"
+      detail.targetArgIDs @?= [4, 5]
+      detail.branchBindingIDs @?= [6, 7]
+      detail.branchRhsID @?= 8
+      detail.letIDs @?= [10, 9]
     _ -> assertFailure $ show result
 
 unit_tryReduce_case_too_many_bindings :: Assertion
@@ -636,10 +638,10 @@ unit_tryReduce_prim = do
     Right (expr', ApplyPrimFun detail) -> do
       expr' ~= expectedResult
 
-      applyPrimFunBefore detail ~= expr
-      applyPrimFunAfter detail ~= expr'
-      applyPrimFunName detail @?= primitiveGVar "eqChar"
-      applyPrimFunArgIDs detail @?= [101, 102]
+      detail.before ~= expr
+      detail.after ~= expr'
+      detail.name @?= primitiveGVar "eqChar"
+      detail.argIDs @?= [101, 102]
     _ -> assertFailure $ show result
 
 unit_tryReduce_prim_fail_unsaturated :: Assertion

--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -46,14 +46,14 @@ import Primer.Core (
 import Primer.Eval (
   BetaReductionDetail (
     BetaReductionDetail,
-    betaAfter,
-    betaArgID,
-    betaBefore,
-    betaBindingName,
-    betaBodyID,
-    betaLambdaID,
-    betaLetID,
-    betaTypes
+    after,
+    argID,
+    before,
+    bindingName,
+    bodyID,
+    lambdaID,
+    letID,
+    types
   ),
   EvalDetail (BetaReduction),
  )
@@ -61,7 +61,7 @@ import Primer.Module (Module (Module, moduleDefs, moduleTypes), moduleName)
 import Primer.Name (Name, unsafeMkName)
 import Primer.Typecheck (SmartHoles (SmartHoles))
 import System.FilePath (takeBaseName)
-import Test.Tasty
+import Test.Tasty hiding (after)
 import Test.Tasty.Golden
 import Test.Tasty.HUnit
 import TestUtils (gvn, vcn)
@@ -152,14 +152,14 @@ fixtures =
       reductionDetail =
         BetaReduction $
           BetaReductionDetail
-            { betaBefore = expr
-            , betaAfter = expr
-            , betaBindingName = "x"
-            , betaLambdaID = id0
-            , betaLetID = id0
-            , betaArgID = id0
-            , betaBodyID = id0
-            , betaTypes =
+            { before = expr
+            , after = expr
+            , bindingName = "x"
+            , lambdaID = id0
+            , letID = id0
+            , argID = id0
+            , bodyID = id0
+            , types =
                 Just (TEmptyHole typeMeta, TEmptyHole typeMeta)
             }
    in [ mkFixture "id" id0


### PR DESCRIPTION
This obviates the need for `PrimerJSONPrefix`, as well.