### PR TITLE
fix: only offer DeleteDef action when not in use

### DIFF
--- a/primer/src/Primer/Core/Utils.hs
+++ b/primer/src/Primer/Core/Utils.hs
@@ -17,6 +17,7 @@ module Primer.Core.Utils (
   freeVars,
   _freeVarsTy,
   freeVarsTy,
+  freeGlobalVars,
   alphaEqTy,
   concreteTy,
 ) where
@@ -53,13 +54,14 @@ import Primer.Core (
   Def (..),
   Expr,
   Expr' (..),
+  GVarName,
   HasID (_id),
   ID,
   Kind (KHole),
   LVarName,
   LocalName (LocalName, unLocalName),
   PrimDef (..),
-  TmVarRef (LocalVarRef),
+  TmVarRef (GlobalVarRef, LocalVarRef),
   TyVarName,
   Type,
   Type' (..),
@@ -245,6 +247,9 @@ _freeTyVars = traversalVL $ go mempty
       t@PrimCon{} -> pure t
       where
         freeVarsBr (CaseBranch c binds e) = CaseBranch c binds <$> go bound f e -- case branches only bind term variables
+
+freeGlobalVars :: (Data a, Data b) => Expr' a b -> Set GVarName
+freeGlobalVars e = S.fromList [v | Var _ (GlobalVarRef v) <- universe e]
 
 concreteTy :: Data b => Type' b -> Bool
 concreteTy ty = hasn't (getting _freeVarsTy) ty && noHoles ty


### PR DESCRIPTION
We will refuse to run the action if the deleted definition is referred
to (other than a recursive reference by itself), since the resulting
program would not then be well-formed. We should not offer the action in
this case.