### PR TITLE
fix: Remove the Primer static file service.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -327,7 +327,7 @@
               text = ''
                 DATABASE_URL="${final.lib.primer.postgres-dev-primer-url}"
                 export DATABASE_URL
-                primer-service serve . ${version} "$@"
+                primer-service serve ${version} "$@"
               '';
             };
 

--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -205,7 +205,7 @@ in
         exit 1
       fi
       primer-sqitch verify db:"$DATABASE_URL"
-      exec primer-service serve . "${version}" --port ${toString lib.primer.defaultServicePort}
+      exec primer-service serve "${version}" --port ${toString lib.primer.defaultServicePort}
     '';
   };
 }

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -123,7 +123,6 @@ import Servant (
   Put,
   QueryFlag,
   QueryParam',
-  Raw,
   ReqBody,
   Required,
   Server,
@@ -140,9 +139,6 @@ import Servant (
 import Servant qualified (serve)
 import Servant.OpenApi (toOpenApi)
 import Servant.OpenApi.OperationId (OpId)
-import Servant.Server.StaticFiles (serveDirectoryWith)
-import WaiAppStatic.Storage.Filesystem (defaultWebAppSettings)
-import WaiAppStatic.Types (MaxAge (NoMaxAge), StaticSettings (ssIndices, ssMaxAge, ssRedirectToIndex), unsafeToPiece)
 
 -- | The API.
 --
@@ -209,10 +205,6 @@ type PrimerLegacyAPI =
     --   (All state will be preserved in the persistent database. This is a
     --   non-destructive operation.)
   :<|> "admin" :> ("flush-sessions" :> Put '[JSON] NoContent)
-
-    -- GET /any-path
-    --   Get the static file at any-path, if it exists
-  :<|> Raw
 
 -- | The session-specific bits of the api
 type SOpenAPI = (
@@ -318,20 +310,6 @@ openAPIInfo =
     & #info % #description ?~ "A backend service implementing a pedagogic functional programming language."
     & #info % #version .~ "0.7"
 
-serveStaticFiles :: ServerT Raw PrimerIO
-serveStaticFiles =
-  -- Static file settings. Sane defaults, plus:
-  -- - if the user requests a directory (like /), look for an index.html
-  --   file in that directory and redirect to it.
-  -- - disable caching, because it's unhelpful during development.
-  let settings =
-        (defaultWebAppSettings ".")
-          { ssIndices = [unsafeToPiece "index.html"]
-          , ssRedirectToIndex = True
-          , ssMaxAge = NoMaxAge
-          }
-   in serveDirectoryWith settings
-
 -- These endpoints (de)serialize different types in the API, to help
 -- with testing (de)serialization code.
 testEndpoints :: ServerT TestAPI PrimerIO
@@ -414,7 +392,6 @@ primerServer = openAPIServer :<|> legacyServer
                )
       )
         :<|> flushSessions'
-        :<|> serveStaticFiles
     -- We need to convert '()' from the API to 'NoContent'
     flushSessions' = flushSessions >> pure NoContent
 


### PR DESCRIPTION
We don't use this to distribute frontend assets anymore, and leaving
it around is just a security issue waiting to happen.
