### PR TITLE
chore: Remove API test endpoints.

### DIFF
--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -54,49 +54,22 @@ import Primer.API (
   variablesInScope,
  )
 import Primer.API qualified as API
-import Primer.Action (
-  Action (Move),
-  ActionError (TypeError),
-  Movement (Child1),
- )
 import Primer.App (
   EvalFullReq (..),
   EvalFullResp (..),
   EvalReq (..),
   EvalResp (..),
-  Log (..),
   MutationRequest,
   Prog,
-  ProgAction (BodyAction, MoveToDef),
-  ProgError (NoDefSelected),
-  newProg',
+  ProgError,
  )
-import Primer.Builtins (boolDef)
 import Primer.Core (
-  ASTDef (..),
-  ASTTypeDef,
-  Def (..),
-  Expr,
   GVarName,
   ID,
-  Kind (KFun, KType),
+  Kind,
   LVarName,
   TyVarName,
-  Type,
-  Type' (TEmptyHole),
-  TypeCache (..),
-  TypeCacheBoth (..),
-  mkSimpleModuleName,
-  qualifyName,
- )
-import Primer.Core.DSL (
-  app,
-  branch',
-  case_,
-  create',
-  emptyHole,
-  tEmptyHole,
-  tfun,
+  Type',
  )
 import Primer.Database (
   Session,
@@ -107,12 +80,9 @@ import Primer.Database (
 import Primer.Database qualified as Database (
   Op,
  )
-import Primer.Eval (BetaReductionDetail (..), EvalDetail (..))
-import Primer.EvalFull (Dir (Syn))
 import Primer.Name (Name)
 import Primer.OpenAPI ()
 import Primer.Pagination (Paginated, PaginationParams, pagedDefaultClamp)
-import Primer.Typecheck (TypeError (TypeDoesNotMatchArrow))
 import Servant (
   Capture,
   Get,
@@ -217,7 +187,7 @@ type SOpenAPI = (
 
 -- | The session-specific bits of the api
 -- (legacy version)
-type SAPI = (
+type SAPI =
     -- GET /api/session-name
     --   Get the current session name.
        "session-name" :> Get '[JSON] Text
@@ -262,46 +232,7 @@ type SAPI = (
     --   Evaluate the given expression to normal form (or time out).
    :<|> "eval" :> ReqBody '[JSON] EvalFullReq :> Post '[JSON] (Either ProgError EvalFullResp)
 
-    -- GET /api/test/<type>
-    --   Get an arbitrary value of that type
-    -- POST /api/test/<type>
-    --   Post an arbitrary value of that type, responding with the value
-  :<|> "test" :> TestAPI
-  )
-
--- | API endpoints that we use for integration tests
-type TestAPI = (
-       "movement"      :> Test Movement
-  :<|> "action"        :> Test Action
-  :<|> "actionerror"   :> Test ActionError
-  :<|> "name"          :> Test Name
-  :<|> "type"          :> Test Type
-  :<|> "typecache"     :> Test TypeCache
-  :<|> "typecacheboth" :> Test TypeCacheBoth
-  :<|> "expr"          :> Test Expr
-  :<|> "exprCaseEmpty" :> Test Expr
-  :<|> "exprCaseFull"  :> Test Expr
-  :<|> "kind"          :> Test Kind
-  :<|> "id"            :> Test ID
-  :<|> "log"           :> Test Log
-  :<|> "program"       :> Test Prog
-  :<|> "progaction"    :> Test ProgAction
-  :<|> "progerror"     :> Test ProgError
-  :<|> "def"           :> Test Def
-  :<|> "typeDef"       :> Test ASTTypeDef
-  :<|> "evalReq"       :> Test EvalReq
-  :<|> "evalResp"      :> Test EvalResp
-  :<|> "evalFullReq"   :> Test EvalFullReq
-  :<|> "evalFullResp"  :> Test EvalFullResp
-  )
-
 {- ORMOLU_ENABLE -}
-
--- | A type for a pair of test endpoints.
--- The first endpoint returns a fixture of the given type.
--- The second endpoint accepts a value of the given type as JSON and
--- responds with the value it was given, re-encoded as JSON.
-type Test a = Get '[JSON] a :<|> (ReqBody '[JSON] a :> Post '[JSON] a)
 
 openAPIInfo :: OpenApi
 openAPIInfo =
@@ -309,49 +240,6 @@ openAPIInfo =
     & #info % #title .~ "Primer backend API"
     & #info % #description ?~ "A backend service implementing a pedagogic functional programming language."
     & #info % #version .~ "0.7"
-
--- These endpoints (de)serialize different types in the API, to help
--- with testing (de)serialization code.
-testEndpoints :: ServerT TestAPI PrimerIO
-testEndpoints =
-  mkTest Child1
-    :<|> mkTest (Move Child1)
-    :<|> mkTest (TypeError (TypeDoesNotMatchArrow (TEmptyHole ())))
-    :<|> mkTest "x"
-    :<|> mkTest (create' (tfun tEmptyHole tEmptyHole))
-    :<|> mkTest (TCSynthed $ TEmptyHole ())
-    :<|> mkTest (TCBoth (TEmptyHole ()) (TEmptyHole ()))
-    :<|> mkTest (create' (app emptyHole emptyHole))
-    :<|> mkTest (create' $ case_ emptyHole [])
-    :<|> mkTest (create' $ case_ emptyHole [branch' ("M" :| [], "C") [("x", Nothing)] emptyHole])
-    :<|> mkTest (KFun KType KType)
-    :<|> mkTest 0
-    :<|> mkTest (Log [[BodyAction [Move Child1]]])
-    :<|> mkTest newProg'
-    :<|> mkTest (MoveToDef $ qualifyName (mkSimpleModuleName "M") "main")
-    :<|> mkTest NoDefSelected
-    :<|> mkTest (DefAST $ ASTDef expr ty)
-    :<|> mkTest boolDef
-    :<|> mkTest EvalReq{evalReqExpr = expr, evalReqRedex = 0}
-    :<|> mkTest EvalResp{evalRespExpr = expr, evalRespRedexes = [0, 1], evalRespDetail = reductionDetail}
-    :<|> mkTest EvalFullReq{evalFullReqExpr = expr, evalFullMaxSteps = 10, evalFullCxtDir = Syn}
-    :<|> mkTest (EvalFullRespNormal expr)
-  where
-    mkTest x = pure x :<|> pure
-    expr = create' emptyHole
-    ty = create' tEmptyHole
-    reductionDetail =
-      BetaReduction
-        BetaReductionDetail
-          { before = expr
-          , after = expr
-          , bindingName = "x"
-          , lambdaID = 0
-          , letID = 0
-          , argID = 0
-          , bodyID = 0
-          , types = Just (ty, ty)
-          }
 
 primerApi :: Proxy PrimerAPI
 primerApi = Proxy
@@ -388,7 +276,6 @@ primerServer = openAPIServer :<|> legacyServer
                     :<|> (variablesInScope sid :<|> generateNames sid)
                     :<|> evalStep sid
                     :<|> evalFull sid
-                    :<|> testEndpoints
                )
       )
         :<|> flushSessions'


### PR DESCRIPTION
I believe we originally added these for Vonnegut integration testing,
when we had a complicated serialization mechanism for
Haskell<->PureScript interop. Things have changed: the types we're
serializing via these endpoints are not the same types we'll be using
for typical TypeScript frontends (we plan to implement simpler
versions of these types; see
https://github.com/hackworthltd/primer/issues/605), and for potential
Haskell HTTP API clients, we already have roundtrip JSON serialization
tests elsewhere. Therefore, these endpoints aren't particularly useful
anymore.
