### PR TITLE
fix(buildkite): Add the private agent tag again.

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,4 +1,5 @@
 agents:
+  private: "true"
   os: "linux"
 
 steps:


### PR DESCRIPTION
I'd forgotten that this tag is used to limit builds to only agents
with access to our private repos.
