### PR TITLE
refactor(server): Move OpenAPI base URL to `/openapi`.

### DIFF
--- a/primer-service/src/Primer/Servant/OpenAPI.hs
+++ b/primer-service/src/Primer/Servant/OpenAPI.hs
@@ -36,7 +36,7 @@ import Servant.OpenApi.OperationId (OpId)
 type Spec = "openapi.json" :> Get '[JSON] OpenApi
 
 -- | The Primer OpenAPI API.
-type API = "api" :> ("sessions" :> NamedRoutes SessionsAPI)
+type API = "openapi" :> ("sessions" :> NamedRoutes SessionsAPI)
 
 -- | The Primer OpenAPI sessions API.
 --

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -295,7 +295,7 @@
     },
     "openapi": "3.0.0",
     "paths": {
-        "/api/sessions": {
+        "/openapi/sessions": {
             "get": {
                 "description": "Get a list of all sessions and their human-readable names. By default, this method returns the list of all sessions in the persistent database, but optionally it can return just the list of all sessions in memory, which is mainly useful for testing. Note that in a production system, this endpoint should obviously be authentication-scoped and only return the list of sessions that the caller is authorized to see.",
                 "operationId": "getSessionList",
@@ -366,7 +366,7 @@
                 "summary": "Create a new session and return its ID"
             }
         },
-        "/api/sessions/{sessionId}/program": {
+        "/openapi/sessions/{sessionId}/program": {
             "get": {
                 "operationId": "getProgram",
                 "parameters": [


### PR DESCRIPTION
Now that we've decided to keep both the simplified OpenAPI API and the full Servant API, they should live at different base URLs.
