### PR TITLE
chore: remove stale comment about undecidable instances

### DIFF
--- a/primer/src/Primer/Core.hs
+++ b/primer/src/Primer/Core.hs
@@ -405,9 +405,7 @@ data Kind = KHole | KType | KFun Kind Kind
 -- This makes it easier to change the underlying metadata representation without
 -- breaking code that needs to work with IDs, because they use this class
 -- instead of hardcoding paths to IDs or using chained 'HasType' instances,
--- which can lead to ambiguity errors. These instances are undecidable but
--- they're contained to this module at least (and are in reality not
--- problematic).
+-- which can lead to ambiguity errors.
 class HasID a where
   _id :: Lens' a ID
 


### PR DESCRIPTION
It was noted in d45015c2ca3643a65983386d7811480c97922405 that Core does
not need UndecidableInstances, after the design of HasID was changed in
b85521843eca623b096a2b23a083b2ac055483b5