### PR TITLE
fix: copy/paste scoping for shadowing in inputs

### DIFF
--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -59,7 +59,6 @@ import Foreword hiding (mod)
 
 import Control.Monad.Fresh (MonadFresh (..))
 import Control.Monad.NestedError (MonadNestedError)
-import Data.Bitraversable (bimapM)
 import Data.Data (Data)
 import Data.Generics.Uniplate.Operations (descendM, transform, transformM)
 import Data.Generics.Uniplate.Zipper (
@@ -187,22 +186,20 @@ import Primer.Zipper (
   Loc' (InBind, InExpr, InType),
   TypeZ,
   TypeZip,
-  bindersAbove,
-  bindersAboveTy,
-  bindersAboveTypeZ,
   current,
   focusOn,
   focusOnTy,
   focusOnlyType,
   foldAbove,
+  foldAboveTypeZ,
   getBoundHere,
   getBoundHereTy,
+  getBoundHereUp,
   locToEither,
   replace,
   target,
   unfocusExpr,
   unfocusType,
-  up,
   _target,
  )
 
@@ -1230,60 +1227,44 @@ copyPasteSig p (fromDefName, fromTyId) toDefName setup = do
 -- We cannot use bindersAbove as that works on names only, and different scopes
 -- may reuse the same names. However, we want to detect that as non-shared.
 -- Instead, we rely on fact that IDs are unique.
--- We get the scope from the second argument, as that is where we are pasting.
 -- NB: we assume that both arguments belong in the same definition (and thus
 -- only require that IDs are unique within one definition -- this is a narrower
 -- uniqueness assumption than we currently enforce, see Note [Modules]).
 getSharedScopeTy :: Either TypeZ TypeZip -> Either TypeZ TypeZip -> Set.Set Name
-getSharedScopeTy l r =
-  let idsR = case r of
-        Right r' -> getID r' : foldAbove ((: []) . getID . current) r'
-        Left r' -> getID r' : foldAbove ((: []) . getID . current) (focusOnlyType r') <> (getID (unfocusType r') : foldAbove ((: []) . getID . current) r')
-      -- Replae use of `unsafeHead` here. See:
-      -- https://github.com/hackworthltd/primer/issues/147
-      rID = unsafeHead idsR
-      idsL = case l of
-        Right l' -> getID l' : foldAbove ((: []) . getID . current) l'
-        Left l' -> getID l' : foldAbove ((: []) . getID . current) (focusOnlyType l') <> (getID (unfocusType l') : foldAbove ((: []) . getID . current) l')
-      commonAncestor = getLast $ foldMap (\(il, ir) -> Last $ if il == ir then Just il else Nothing) $ zip (reverse idsL) (reverse idsR)
-      rAncestor = do
-        a <- commonAncestor
-        flip loopM r $ \r' -> if either getID getID r' == a then pure $ Right r' else Left <$> bimapM up up r'
-      -- we need to pick up bindings that happen at the ancestor iff it
-      -- is an actual ancestor (rather than l being a decendent of r)
-      inScope =
-        rAncestor <&> \case
-          Left ra -> mwhen (rID /= getID ra) (Set.map unLocalName $ getBoundHereTy $ target ra) <> bindersAboveTypeZ ra
-          Right ra -> Set.map unLocalName $ mwhen (rID /= getID ra) (getBoundHereTy $ target ra) <> bindersAboveTy ra
-   in fromMaybe mempty inScope
+getSharedScopeTy = getSharedScope' bindersLocAbove
+  where
+    bindersLocAbove = either bindersLocAboveTypeZ bindersLocAboveTy
+    bindersLocAboveTy :: TypeZip -> Set.Set (ID, Name)
+    bindersLocAboveTy = foldAbove ((\t -> Set.map ((getID t,) . unLocalName) $ getBoundHereTy t) . current)
+    bindersLocAboveTypeZ :: TypeZ -> Set.Set (ID, Name)
+    bindersLocAboveTypeZ =
+      foldAboveTypeZ
+        ((\t -> Set.map ((getID t,) . unLocalName) $ getBoundHereTy t) . current)
+        ((\e -> Set.map (getID e,) $ getBoundHere e Nothing) . current)
+        (\x -> Set.map (getID $ current x,) $ getBoundHereUp x)
 
 -- TODO: there is a lot of duplicated code for copy/paste, often due to types/terms being different...
 getSharedScope :: ExprZ -> ExprZ -> Set.Set Name
-getSharedScope l r =
-  let idsR = getID r : foldAbove ((: []) . getID . current) r
-      idsL = getID l : foldAbove ((: []) . getID . current) l
-      commonAncestor = getLast $ foldMap (\(il, ir) -> Last $ if il == ir then Just il else Nothing) $ zip (reverse idsL) (reverse idsR)
-      rAncestorAndPenultimate = do
-        a <- commonAncestor
-        flip loopM (r, Nothing) $ \(r', p) -> if getID r' == a then pure $ Right (r', p) else Left . (,Just r') <$> up r'
-      -- we need to pick up bindings that happen at the ancestor iff it
-      -- is an actual ancestor (rather than l being a decendent of r)
-      inScope =
-        rAncestorAndPenultimate <&> \(ra, rp) ->
-          let hereBound = maybe mempty (getBoundHere (target ra) . Just . target) rp -- we have a Just exactly when ra/=r
-           in hereBound <> bindersAbove ra
-   in fromMaybe mempty inScope
+getSharedScope = getSharedScope' bindersLocAbove
+  where
+    bindersLocAbove :: ExprZ -> Set.Set (ID, Name)
+    bindersLocAbove = foldAbove (\x -> Set.map (getID $ current x,) $ getBoundHereUp x)
 
--- | A generalisation of 'when'
-mwhen :: Monoid m => Bool -> m -> m
-mwhen b m = if b then m else mempty
-
--- | Iterate until we get a 'Right'
-loopM :: Monad m => (a -> m (Either a b)) -> a -> m b
-loopM f a =
-  f a >>= \case
-    Left a' -> loopM f a'
-    Right b -> pure b
+getSharedScope' :: (a -> Set.Set (ID, Name)) -> a -> a -> Set.Set Name
+getSharedScope' bindersLocAbove l r =
+  let lBinds = bindersLocAbove l
+      rBinds = bindersLocAbove r
+      common = names $ Set.intersection lBinds rBinds
+      onlyLeft = names $ lBinds Set.\\ rBinds
+      onlyRight = names $ rBinds Set.\\ lBinds
+   in -- NB: 'names' is not injective, thus there can be elements in
+      -- both 'common' and 'onlyLeft'/'onlyRight'
+      -- We must filter these out since any reference to such a name
+      -- would either escape its scope (left) or be captured (right)
+      (common Set.\\ onlyLeft) Set.\\ onlyRight
+  where
+    names :: Set.Set (ID, Name) -> Set.Set Name
+    names = Set.map snd
 
 -- | Checks every term and type definition in the editable modules.
 -- Does not check imported modules.

--- a/primer/src/Primer/ZipperCxt.hs
+++ b/primer/src/Primer/ZipperCxt.hs
@@ -32,12 +32,13 @@ import Primer.Core.Utils (forgetTypeMetadata)
 import Primer.Typecheck (maybeTypeOf)
 import Primer.Zipper (
   ExprZ,
-  FoldAbove (current, prior),
+  FoldAbove,
   TypeZ,
   TypeZip,
   asZipper,
   current,
   foldAbove,
+  prior,
   unfocusType,
  )
 

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -546,33 +546,42 @@ unit_copy_paste_duplicate = do
             assertBool "equal to toDef" $ src /= lookupASTDef' "blank" r
             clearIDs src @?= clearIDs (lookupASTDef' "blank" r)
 
--- ∀a . (∀b,c . a -> b -> ∀d. c -> d)  -> ∀c. ?
--- copy         ^------------------^
--- paste                                      ^
+-- ∀a,d,f . (∀b,c,d . a -> b -> ∀e. c -> d -> e -> f)  -> ∀c,f. ?
+-- copy               ^----------------------------^
+-- paste                                                        ^
 -- should result in
--- ∀a . (∀b,c . a -> b -> ∀d. c -> d)  -> ∀c. a -> ? -> ∀d. ? -> d
+-- ∀a,d,f . (∀b,c,d . a -> b -> ∀e. c -> d -> e -> f)  -> ∀c,f. a -> ? -> ∀e. ? -> ? -> e -> ?
 --
 -- This tests that we handle scoping correctly:
 -- - The a is in-scope: so copied
 -- - The b is out-of-scope, so replaced with a hole
 -- - The c is out-of-scope (even though the target has a 'c' in-scope, it is a
 --   different binder), so replace with a hole
--- - The d is bound within the copied subtree, so it is in-scope
+-- - The d is out-of-scope (even though a different 'd' is in scope in the common
+--   ancestor of the source and target), so replaced with a hole
+-- - The e is bound within the copied subtree, so it is in-scope
+-- - The f would be captured, so replace with a hole
 unit_copy_paste_type_scoping :: Assertion
 unit_copy_paste_type_scoping = do
   let mainName = gvn "main"
       ((pInitial, srcID, pExpected), maxID) = create $ do
-        toCopy <- tvar "a" `tfun` tvar "b" `tfun` tforall "d" KType (tvar "c" `tfun` tvar "d")
-        let skel r = tforall "a" KType $ tfun (tforall "b" KType $ tforall "c" KType $ pure toCopy) $ tforall "c" KType r
+        toCopy <- tvar "a" `tfun` tvar "b" `tfun` tforall "e" KType (tvar "c" `tfun` tvar "d" `tfun` tvar "e" `tfun` tvar "f")
+        let skel r =
+              tforall "a" KType $
+                tforall "d" KType $
+                  tforall "f" KType $
+                    tfun (tforall "b" KType $ tforall "c" KType $ tforall "d" KType $ pure toCopy) $
+                      tforall "c" KType $
+                        tforall "f" KType r
         defInitial <- ASTDef <$> emptyHole <*> skel tEmptyHole
-        expected <- ASTDef <$> emptyHole <*> skel (tvar "a" `tfun` tEmptyHole `tfun` tforall "d" KType (tEmptyHole `tfun` tvar "d"))
+        expected <- ASTDef <$> emptyHole <*> skel (tvar "a" `tfun` tEmptyHole `tfun` tforall "e" KType (tEmptyHole `tfun` tEmptyHole `tfun` tvar "e" `tfun` tEmptyHole))
         pure
           ( newEmptyProg' & #progModules % _head % #moduleDefs .~ Map.fromList [("main", DefAST defInitial)]
           , getID toCopy
           , newEmptyProg' & #progModules % _head % #moduleDefs .~ Map.fromList [("main", DefAST expected)]
           )
   let a = mkEmptyTestApp pInitial
-      actions = [MoveToDef mainName, CopyPasteSig (mainName, srcID) [Move Child1, Move Child2, Move Child1]]
+      actions = [MoveToDef mainName, CopyPasteSig (mainName, srcID) [Move Child1, Move Child1, Move Child1, Move Child2, Move Child1, Move Child1]]
       (result, _) = runAppTestM maxID a $ (,) <$> tcWholeProg pExpected <*> handleEditRequest actions
   case result of
     Left e -> assertFailure $ show e


### PR DESCRIPTION
We now take care to handle the case where there are binders in the input
which shadow each other, rather than naively comparing names. Note that
identity of binders is controlled by ID, whereas shadowing is controlled
by Name; whilst there is a mapping ID -> Name, it is not injective.