### PR TITLE
refactor: add `apps`/`apps'` to DSL

### DIFF
--- a/primer/src/Primer/Core/DSL.hs
+++ b/primer/src/Primer/Core/DSL.hs
@@ -36,6 +36,8 @@ module Primer.Core.DSL (
   con',
   gvar',
   branch',
+  apps,
+  apps',
 ) where
 
 import Foreword
@@ -91,6 +93,17 @@ setMeta m e = set _metadata (Just m) <$> e
 
 app :: MonadFresh ID m => m Expr -> m Expr -> m Expr
 app e1 e2 = App <$> meta <*> e1 <*> e2
+
+-- | `app` for multiple args
+apps :: MonadFresh ID m => m Expr -> [m Expr] -> m Expr
+apps e es = apps' e (map Left es)
+
+-- | `apps` for expressions and types
+apps' :: MonadFresh ID m => m Expr -> [Either (m Expr) (m Type)] -> m Expr
+apps' = foldl app'
+  where
+    app' e (Left e') = e `app` e'
+    app' e (Right t) = e `aPP` t
 
 aPP :: MonadFresh ID m => m Expr -> m Type -> m Expr
 aPP e t = APP <$> meta <*> e <*> t

--- a/primer/src/Primer/Prelude/Integer.hs
+++ b/primer/src/Primer/Prelude/Integer.hs
@@ -24,10 +24,10 @@ import Foreword (Applicative (pure), map, ($), (.))
 import Primer.Builtins (tBool)
 import Primer.Builtins qualified as B
 import Primer.Core (GVarName, ID, qualifyName)
-import Primer.Core.DSL (app, branch, case_, gvar, int, lam, let_, lvar, tcon, tfun)
+import Primer.Core.DSL (app, apps, branch, case_, gvar, int, lam, let_, lvar, tcon, tfun)
 import Primer.Def (ASTDef (..), Def (..))
 import Primer.Prelude.Logic (not)
-import Primer.Prelude.Utils (apps, modName)
+import Primer.Prelude.Utils (modName)
 import Primer.Primitives (PrimDef (..), primDefName, primitiveGVar, tInt)
 
 min :: GVarName

--- a/primer/src/Primer/Prelude/Logic.hs
+++ b/primer/src/Primer/Prelude/Logic.hs
@@ -15,6 +15,7 @@ import Primer.Core (
  )
 import Primer.Core.DSL (
   app,
+  apps,
   branch,
   case_,
   con,
@@ -28,7 +29,7 @@ import Primer.Def (
   ASTDef (ASTDef),
   Def (DefAST),
  )
-import Primer.Prelude.Utils (apps, modName)
+import Primer.Prelude.Utils (modName)
 
 not :: GVarName
 not = qualifyName modName "not"

--- a/primer/src/Primer/Prelude/Utils.hs
+++ b/primer/src/Primer/Prelude/Utils.hs
@@ -1,13 +1,6 @@
-module Primer.Prelude.Utils (apps, modName) where
+module Primer.Prelude.Utils (modName) where
 
-import Control.Monad.Fresh (MonadFresh)
-import Data.Foldable (foldl1)
-import Primer.Core (Expr, ID, ModuleName, mkSimpleModuleName)
-import Primer.Core.DSL (app)
-
--- | Helper function for functions with multiple arguments
-apps :: MonadFresh ID m => m Expr -> [m Expr] -> m Expr
-apps f args = foldl1 app (f : args)
+import Primer.Core (ModuleName, mkSimpleModuleName)
 
 modName :: ModuleName
 modName = mkSimpleModuleName "Prelude"

--- a/primer/test/Tests/Prelude/Integer.hs
+++ b/primer/test/Tests/Prelude/Integer.hs
@@ -8,12 +8,11 @@ import Hedgehog.Range qualified as Range
 import Optics (over)
 import Primer.Builtins.DSL (bool_)
 import Primer.Core (Expr, GVarName)
-import Primer.Core.DSL (create', gvar, int)
+import Primer.Core.DSL (apps, create', gvar, int)
 import Primer.EvalFull (Dir (Chk), EvalFullError, TerminationBound, evalFull)
 import Primer.Module (builtinModule, moduleDefsQualified, moduleTypesQualified, primitiveModule)
 import Primer.Prelude (prelude)
 import Primer.Prelude.Integer qualified as P
-import Primer.Prelude.Utils (apps)
 import Tasty (Property, property, withTests)
 import TestM (TestM, evalTestM)
 import TestUtils (zeroIDs)


### PR DESCRIPTION
Originally `apps` was in `Prelude/Utils.hs`, however this seems like it would belong better in the DSL.

Also, now the only code in `Prelude/Utils.hs` is the prelude module name. Does that still make sense?