### PR TITLE
chore: remove some unneeded pragmas

### DIFF
--- a/primer/src/Primer/Prelude/Logic.hs
+++ b/primer/src/Primer/Prelude/Logic.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{-# HLINT ignore "Use tuple-section" #-}
 module Primer.Prelude.Logic (not, notDef, and, andDef, or, orDef, xor, xorDef, implies, impliesDef) where
 
 import Foreword hiding (and, not, or, xor)

--- a/primer/test/Tests/Prelude/Logic.hs
+++ b/primer/test/Tests/Prelude/Logic.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 module Tests.Prelude.Logic where
 
 import Foreword hiding (exp)

--- a/primer/test/Tests/Prelude/TypeCheck.hs
+++ b/primer/test/Tests/Prelude/TypeCheck.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 module Tests.Prelude.TypeCheck where
 
 import Foreword


### PR DESCRIPTION
I expect these were accidentally added by a "smart" editor action.