### PR TITLE
refactor: extract modifyError and modifyError'

### DIFF
--- a/primer/src/Control/Monad/NestedError.hs
+++ b/primer/src/Control/Monad/NestedError.hs
@@ -44,7 +44,7 @@
 --     • The type Bool does not contain a constructor whose field is of type SpecificError
 --     • In the expression:
 --           throwError' SpecificError :: MonadError Bool m => m a
-module Control.Monad.NestedError (MonadNestedError (..)) where
+module Control.Monad.NestedError (MonadNestedError (..), modifyError') where
 
 import Foreword
 
@@ -72,3 +72,7 @@ instance
   where
   throwError' = throwError . injectTyped
   catchError' ma f = catchError ma $ \e -> maybe ma f (projectTyped e)
+
+-- | Change the type of a nested error.
+modifyError' :: MonadNestedError smaller larger m => (e -> smaller) -> ExceptT e m a -> m a
+modifyError' f = runExceptT >=> either (throwError' . f) pure

--- a/primer/src/Foreword.hs
+++ b/primer/src/Foreword.hs
@@ -6,6 +6,7 @@ module Foreword (
   adjustAt,
   findAndAdjust,
   findAndAdjustA,
+  modifyError,
 ) where
 
 -- In general, we should defer to "Protolude"'s exports and avoid name
@@ -97,3 +98,7 @@ findAndAdjustA :: Applicative m => (a -> Bool) -> (a -> m a) -> [a] -> m (Maybe 
 findAndAdjustA p f = \case
   [] -> pure Nothing
   x : xs -> if p x then Just . (: xs) <$> f x else (x :) <<$>> findAndAdjustA p f xs
+
+-- | Change the type of an error.
+modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
+modifyError f = runExceptT >=> either (throwError . f) pure

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -1469,7 +1469,7 @@ progCxt p = buildTypingContextFromModules (progAllModules p) (progSmartHoles p)
 
 -- | Run a computation in some context whose errors can be promoted to `ProgError`.
 liftError :: MonadError ProgError m => (e -> ProgError) -> ExceptT e m b -> m b
-liftError f = runExceptT >=> either (throwError . f) pure
+liftError = modifyError
 
 allConNames :: Prog -> [ValConName]
 allConNames =

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -62,7 +62,7 @@ module Primer.Typecheck (
 import Foreword
 
 import Control.Monad.Fresh (MonadFresh (..))
-import Control.Monad.NestedError (MonadNestedError (..))
+import Control.Monad.NestedError (MonadNestedError (..), modifyError')
 import Data.Map qualified as M
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as S
@@ -808,7 +808,4 @@ typeTtoType :: TypeT -> Type' TypeMeta
 typeTtoType = over _typeMeta (fmap Just)
 
 checkKind' :: TypeM e m => Kind -> Type' (Meta a) -> m TypeT
-checkKind' k t =
-  runExceptT (checkKind k t) >>= \case
-    Left err -> throwError' $ KindError err
-    Right t' -> pure t'
+checkKind' k t = modifyError' KindError (checkKind k t)


### PR DESCRIPTION
When we decide to drop support for mtl<2.3.1 we can drop the definition
of modifyError in Foreword in favor of the one provided by mtl (starting
from 2.3.1).