### PR TITLE
chore: rename Questions test module for consistency

### DIFF
--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -181,7 +181,7 @@ test-suite primer-test
     Tests.Pretty
     Tests.Primitives
     Tests.Prog
-    Tests.Question
+    Tests.Questions
     Tests.Refine
     Tests.Serialization
     Tests.Subst

--- a/primer/test/Tests/Questions.hs
+++ b/primer/test/Tests/Questions.hs
@@ -1,5 +1,5 @@
 -- | Tests for Question logic
-module Tests.Question where
+module Tests.Questions where
 
 import Foreword hiding (diff)
 


### PR DESCRIPTION
Every other test module is named after the source module that it tests.
However we had Primer.Questions and Tests.Question which differ in
pluralisation.