### PR TITLE
fix: typed generator produces ill-scoped terms

### DIFF
--- a/primer/gen/Primer/Gen/Core/Typed.hs
+++ b/primer/gen/Primer/Gen/Core/Typed.hs
@@ -284,7 +284,7 @@ genSyns ty = do
                (lettype a = Nat -> Nat in λx.x : a), for instance
                See https://github.com/hackworthltd/primer/issues/5
             do
-              x <- genLVarNameAvoiding [ty]
+              x <- genTyVarNameAvoiding ty
               k <- genWTKind
               t <- genWTType k
               (e, eTy) <- local (extendLocalCxtTy (x, k)) $ genSyns ty
@@ -371,7 +371,7 @@ genChk ty = do
                (lettype a = Nat -> Nat in λx.x : a), for instance
                See https://github.com/hackworthltd/primer/issues/5
             do
-              x <- genLVarNameAvoiding [ty]
+              x <- genTyVarNameAvoiding ty
               k <- genWTKind
               LetType () x <$> genWTType k <*> local (extendLocalCxtTy (x, k)) (genChk ty)
             -}


### PR DESCRIPTION
There is a long-standing bug that the typed generator creates ill-scoped terms, leading to only-just-discovered testsuite failures #676 and #677.