### PR TITLE
feat: Initial logging support.

### DIFF
--- a/primer-rel8/primer-rel8.cabal
+++ b/primer-rel8/primer-rel8.cabal
@@ -32,18 +32,19 @@ library
     -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
 
   build-depends:
-    , aeson       >=2.0      && <=2.1
-    , base        >=4.12     && <=4.17
-    , bytestring  >=0.10.8.2 && <=0.12
-    , containers  >=0.6.0.1  && <=0.7
-    , exceptions  >=0.10.4   && <=0.11
-    , hasql       ^>=1.6
-    , hasql-pool  ^>=0.8.0.3
-    , mtl         >=2.2.2    && <=2.4
-    , primer      ^>=0.7.2
-    , rel8        ^>=1.4
-    , text        >=1.2.3.2  && <=1.3
-    , uuid        ^>=1.3
+    , aeson           >=2.0      && <=2.1
+    , base            >=4.12     && <=4.17
+    , bytestring      >=0.10.8.2 && <=0.12
+    , containers      >=0.6.0.1  && <=0.7
+    , exceptions      >=0.10.4   && <=0.11
+    , hasql           ^>=1.6
+    , hasql-pool      ^>=0.8.0.3
+    , logging-effect  ^>=1.3.13
+    , mtl             >=2.2.2    && <=2.4
+    , primer          ^>=0.7.2
+    , rel8            ^>=1.4
+    , text            >=1.2.3.2  && <=1.3
+    , uuid            ^>=1.3
 
 test-suite primer-rel8-test
   type:               exitcode-stdio-1.0
@@ -83,6 +84,7 @@ test-suite primer-rel8-test
       , filepath
       , hasql
       , hasql-pool
+      , logging-effect
       , port-utils        ^>=0.2.1
       , postgres-options  ^>=0.2
       , primer

--- a/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
+++ b/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 --Module      : Primer.Database.Rel8.Rel8Db
@@ -12,10 +13,13 @@
 --A "Rel8"- and @Hasql@-based implementation of 'MonadDb'.
 module Primer.Database.Rel8.Rel8Db (
   -- * The "Rel8" database adapter
+  MonadRel8Db,
   Rel8DbT (..),
   Rel8Db,
   runRel8DbT,
-  runRel8Db,
+
+  -- * Logging
+  Rel8DbLogMessage (..),
 
   -- * Exceptions
   Rel8DbException (..),
@@ -25,6 +29,10 @@ import Foreword hiding (filter)
 
 import Control.Monad.Cont (MonadCont)
 import Control.Monad.Fix (MonadFix)
+import Control.Monad.Log (
+  MonadLog,
+  WithSeverity (..),
+ )
 import Control.Monad.Trans (MonadTrans)
 import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Zip (MonadZip)
@@ -58,6 +66,10 @@ import Primer.Database.Rel8.Schema as Schema (
   SessionRow (..),
   sessionRowSchema,
  )
+import Primer.Log (
+  ConvertLogMessage (..),
+  logError,
+ )
 import Rel8 (
   Expr,
   Insert (Insert, into, onConflict, returning, rows),
@@ -83,7 +95,7 @@ import Rel8 (
 
 -- | A wrapper type for managing Rel8 operations.
 newtype Rel8DbT m a = Rel8DbT {unRel8DbT :: ReaderT Pool m a}
-  deriving
+  deriving newtype
     ( Functor
     , Applicative
     , Alternative
@@ -102,6 +114,7 @@ newtype Rel8DbT m a = Rel8DbT {unRel8DbT :: ReaderT Pool m a}
     , MonadWriter w
     , MonadZip
     , MonadCont
+    , MonadLog msg
     )
 
 -- | The 'Rel8DbT' monad transformer applied to 'IO'.
@@ -111,10 +124,10 @@ type Rel8Db a = Rel8DbT IO a
 runRel8DbT :: Rel8DbT m a -> Pool -> m a
 runRel8DbT m = runReaderT (unRel8DbT m)
 
--- | Run an 'IO' action in the 'Rel8Db' monad with the given
--- 'Pool'.
-runRel8Db :: Rel8DbT IO a -> Pool -> IO a
-runRel8Db = runRel8DbT
+-- | A convenient type alias.
+--
+-- Note that 'MonadLog' has a functional dependency from 'm' to 'l'.
+type MonadRel8Db m l = (ConvertLogMessage Rel8DbLogMessage l, MonadCatch m, MonadThrow m, MonadIO m, MonadLog (WithSeverity l) m)
 
 -- | A 'MonadDb' instance for 'Rel8DbT'.
 --
@@ -126,7 +139,7 @@ runRel8Db = runRel8DbT
 -- database. The latter sorts of exceptions are expressed via the
 -- types of the 'MonadDb' methods and are handled by Primer
 -- internally.
-instance (MonadThrow m, MonadIO m) => MonadDb (Rel8DbT m) where
+instance MonadRel8Db m l => MonadDb (Rel8DbT m) where
   insertSession v s a n =
     runStatement_ (InsertError s) $
       insert
@@ -214,24 +227,26 @@ instance (MonadThrow m, MonadIO m) => MonadDb (Rel8DbT m) where
     result <- runStatement (LoadSessionError sid) $ select $ sessionById sid
     case result of
       [] -> return $ Left $ SessionIdNotFound sid
-      (s : _) ->
+      (s : _) -> do
         -- Note that we have 2 choices here if the session name
         -- returned by the database is not a valid 'SessionName':
-        -- either we can return a failure, or we can convert it to
-        -- a valid 'SessionName', possibly including a helpful
-        -- message. This situation can only ever happen if we've
-        -- made a mistake (e.g., we've changed the rules on what's
-        -- a valid 'SessionName' and didn't run a migration), or
-        -- if someone has edited the database directly, without
-        -- going through the API. In either case, it would be bad
-        -- if a student can't load their session just because a
-        -- session name was invalid, so we opt for the "convert it
-        -- to a valid 'SessionName'" strategy. For now, we elide
-        -- the helpful message.
-        --
-        -- We should probably log an event when this occurs. See:
-        -- https://github.com/hackworthltd/primer/issues/179
-        pure $ Right (SessionData (Schema.app s) (safeMkSessionName $ Schema.name s))
+        -- either we can return a failure, or we can convert it to a
+        -- valid 'SessionName', possibly including a helpful message.
+        -- This situation can only ever happen if we've made a mistake
+        -- (e.g., we've changed the rules on what's a valid
+        -- 'SessionName' and didn't run a migration), or if someone
+        -- has edited the database directly, without going through the
+        -- API. In either case, it would be bad if a student can't
+        -- load their session just because a session name was invalid,
+        -- so we opt for the "convert it to a valid 'SessionName'"
+        -- strategy and log an error. For now, we elide the helpful
+        -- message.
+        let dbSessionName = Schema.name s
+            sessionName = safeMkSessionName dbSessionName
+        when (fromSessionName sessionName /= dbSessionName) $
+          logError $
+            IllegalSessionName sid dbSessionName
+        pure $ Right (SessionData (Schema.app s) sessionName)
 
 -- | Exceptions that can be thrown by 'Rel8DbT' computations.
 --
@@ -277,9 +292,20 @@ data Rel8DbException
     -- operation. This should never occur unless there's a bug in
     -- 'Rel8'.
     ListSessionsRel8Error
-  deriving (Eq, Show)
+  deriving stock (Eq, Show, Generic)
 
 instance Exception Rel8DbException
+
+-- | 'Rel8DbT'-related log messages.
+data Rel8DbLogMessage
+  = -- | An illegal session name was found in the database. This is
+    -- probably an indication that a database migration wasn't run
+    -- properly, but may also indicate that the database has been
+    -- modified outside the API.
+    IllegalSessionName SessionId Text
+  | -- | A 'Rel8DBException' occurred.
+    LogRel8DbException Rel8DbException
+  deriving stock (Eq, Show, Generic)
 
 -- Helpers to make dealing with "Hasql.Session" easier.
 --

--- a/primer-service/exe-server/Main.hs
+++ b/primer-service/exe-server/Main.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Main (main) where
 
-import Foreword
+import Foreword hiding (Handler)
 
 import Control.Concurrent.Async (
   concurrently_,
@@ -11,10 +12,18 @@ import Control.Concurrent.STM (
   newTBQueueIO,
  )
 import Control.Monad.Fail (fail)
+import Control.Monad.Log (
+  Handler,
+  WithSeverity (..),
+  defaultBatchingOptions,
+  runLoggingT,
+  withBatchedHandler,
+ )
 import Data.ByteString as BS
 import Data.ByteString.UTF8 (fromString)
 import Data.String (String)
 import Hasql.Pool (
+  Pool,
   acquire,
   release,
  )
@@ -38,18 +47,22 @@ import Options.Applicative (
   value,
  )
 import Primer.Database (Version)
-import Primer.Database qualified as Db (
-  ServiceCfg (..),
-  discardOp,
-  serve,
- )
+import Primer.Database qualified as Db
 import Primer.Database.Rel8 (
+  MonadRel8Db,
   Rel8DbException (..),
+  Rel8DbLogMessage (..),
   runRel8DbT,
  )
-import Primer.Server (
-  serve,
+import Primer.Log (
+  ConvertLogMessage (..),
+  logCritical,
+  logError,
+  logInfo,
+  logNotice,
+  textWithSeverity,
  )
+import Primer.Server qualified as Server
 import StmContainers.Map qualified as StmMap
 import System.Environment (lookupEnv)
 import System.IO (
@@ -58,9 +71,7 @@ import System.IO (
  )
 
 {- HLINT ignore GlobalOptions "Use newtype instead of data" -}
-data GlobalOptions = GlobalOptions
-  { cmd :: !Command
-  }
+data GlobalOptions = GlobalOptions !Command
 
 newtype Database = PostgreSQL BS.ByteString
 
@@ -100,38 +111,19 @@ defaultDb = do
     Nothing -> fail "You must provide a PostgreSQL connection URL either via the command line, or by setting the DATABASE_URL environment variable."
     Just uri -> pure $ PostgreSQL $ fromString uri
 
-runDb :: Db.ServiceCfg -> Database -> IO ()
-runDb cfg =
-  \case
-    PostgreSQL uri ->
-      bracket (acquire poolSize timeout uri) release start
+runDb :: MonadRel8Db m l => Db.ServiceCfg -> Pool -> m ()
+runDb cfg = start
   where
-    -- Note: pool size must be 1 in order to guarantee
-    -- read-after-write and write-after-write semantics for individual
-    -- sessions. See:
-    --
-    -- https://github.com/hackworthltd/primer/issues/640#issuecomment-1217290598
-    poolSize = 1
-
-    -- 1 second, which is pretty arbitrary.
-    timeout = Just $ 1 * 1000000
-
     justRel8DbException :: Rel8DbException -> Maybe Rel8DbException
     justRel8DbException = Just
 
-    -- The database computation server.
-    go = runRel8DbT $ Db.serve cfg
-
-    -- This action should log exceptions somewhere useful. For now, it
-    -- only outputs the exception to 'stderr'. See
-    -- https://github.com/hackworthltd/primer/issues/179.
-    logDbException e = putErrLn (show e :: Text)
+    logDbException = logError . LogRel8DbException
 
     -- The database computation exception handler.
     start pool =
       catchJust
         justRel8DbException
-        (go pool)
+        (flip runRel8DbT pool $ Db.serve cfg)
         $ \e -> do
           logDbException e
           case e of
@@ -157,37 +149,52 @@ runDb cfg =
               Db.discardOp (Db.opQueue cfg)
               start pool
 
-banner :: Text
+banner :: [Text]
 banner =
-  "                      ███                                    \n\
-  \                     ░░░                                     \n\
-  \ ████████  ████████  ████  █████████████    ██████  ████████ \n\
-  \░░███░░███░░███░░███░░███ ░░███░░███░░███  ███░░███░░███░░███\n\
-  \ ░███ ░███ ░███ ░░░  ░███  ░███ ░███ ░███ ░███████  ░███ ░░░ \n\
-  \ ░███ ░███ ░███      ░███  ░███ ░███ ░███ ░███░░░   ░███     \n\
-  \ ░███████  █████     █████ █████░███ █████░░██████  █████    \n\
-  \ ░███░░░  ░░░░░     ░░░░░ ░░░░░ ░░░ ░░░░░  ░░░░░░  ░░░░░     \n\
-  \ ░███                                                        \n\
-  \ █████                                                       \n\
-  \░░░░░                                                        "
+  [ "                      ███                                    "
+  , "                     ░░░                                     "
+  , " ████████  ████████  ████  █████████████    ██████  ████████ "
+  , "░░███░░███░░███░░███░░███ ░░███░░███░░███  ███░░███░░███░░███"
+  , " ░███ ░███ ░███ ░░░  ░███  ░███ ░███ ░███ ░███████  ░███ ░░░ "
+  , " ░███ ░███ ░███      ░███  ░███ ░███ ░███ ░███░░░   ░███     "
+  , " ░███████  █████     █████ █████░███ █████░░██████  █████    "
+  , " ░███░░░  ░░░░░     ░░░░░ ░░░░░ ░░░ ░░░░░  ░░░░░░  ░░░░░     "
+  , " ░███                                                        "
+  , " █████                                                       "
+  , "░░░░░                                                        "
+  ]
 
-run :: GlobalOptions -> IO ()
-run opts = case cmd opts of
-  Serve ver dbFlag port qsz ->
-    handleAll bye $ do
-      dbOpQueue <- newTBQueueIO qsz
-      initialSessions <- StmMap.newIO
-      putText banner
-      putText $ "primer-server version " <> ver
-      concurrently_
-        (serve initialSessions dbOpQueue ver port)
-        (maybe defaultDb pure dbFlag >>= runDb (Db.ServiceCfg dbOpQueue ver))
+serve ::
+  ( ConvertLogMessage Rel8DbLogMessage l
+  , ConvertLogMessage Text l
+  ) =>
+  Database ->
+  Version ->
+  Int ->
+  Natural ->
+  Handler IO (WithSeverity l) ->
+  IO ()
+serve (PostgreSQL uri) ver port qsz logger =
+  bracket (acquire poolSize timeout uri) release $ \pool -> do
+    dbOpQueue <- newTBQueueIO qsz
+    initialSessions <- StmMap.newIO
+    flip runLoggingT logger $ do
+      forM_ banner logInfo
+      logNotice $ "primer-server version " <> ver
+      logNotice ("Listening on port " <> show port :: Text)
+    concurrently_
+      (Server.serve initialSessions dbOpQueue ver port)
+      (flip runLoggingT logger $ runDb (Db.ServiceCfg dbOpQueue ver) pool)
   where
-    bye :: HasCallStack => SomeException -> IO ()
-    bye e = do
-      putErrText $ "Fatal exception: " <> show e
-      putErrLn $ prettyCallStack callStack
-      exitFailure
+    -- Note: pool size must be 1 in order to guarantee
+    -- read-after-write and write-after-write semantics for individual
+    -- sessions. See:
+    --
+    -- https://github.com/hackworthltd/primer/issues/640#issuecomment-1217290598
+    poolSize = 1
+
+    -- 1 second, which is pretty arbitrary.
+    timeout = Just $ 1 * 1000000
 
 main :: IO ()
 main = do
@@ -195,7 +202,13 @@ main = do
   -- it's line-buffered, as we can't guarantee what the GHC runtime
   -- will do by default.
   hSetBuffering stdout LineBuffering
-  execParser opts >>= run
+  withBatchedHandler defaultBatchingOptions flush $ \logToStdout ->
+    handleAll (bye (logToStdout . logMsgWithSeverity)) $ do
+      args <- execParser opts
+      case args of
+        GlobalOptions (Serve ver dbFlag port qsz) -> do
+          db <- maybe defaultDb pure dbFlag
+          serve db ver port qsz (logToStdout . logMsgWithSeverity)
   where
     opts =
       info
@@ -205,3 +218,24 @@ main = do
             <> header
               "primer-service - A web service for Primer."
         )
+    bye :: Handler IO (WithSeverity LogMsg) -> SomeException -> IO ()
+    bye logger e = do
+      flip runLoggingT logger $ logCritical e
+      exitFailure
+    flush :: (Foldable t, MonadIO m, Print a) => t a -> m ()
+    flush messages = forM_ messages putStrLn
+
+-- | Avoid orphan instances.
+newtype LogMsg = LogMsg {unLogMsg :: Text}
+
+logMsgWithSeverity :: WithSeverity LogMsg -> Text
+logMsgWithSeverity (WithSeverity s m) = textWithSeverity $ WithSeverity s (unLogMsg m)
+
+instance ConvertLogMessage Text LogMsg where
+  convert = LogMsg
+
+instance ConvertLogMessage Rel8DbLogMessage LogMsg where
+  convert = LogMsg . show
+
+instance ConvertLogMessage SomeException LogMsg where
+  convert = LogMsg . show

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -86,6 +86,7 @@ executable primer-service
     , directory             ^>=1.3
     , exceptions
     , hasql-pool            ^>=0.8.0.3
+    , logging-effect        ^>=1.3.13
     , optparse-applicative  ^>=0.17
     , primer
     , primer-rel8           ^>=0.7.2
@@ -178,6 +179,7 @@ test-suite service-test
     , hedgehog             ^>=1.1.1
     , hedgehog-quickcheck  ^>=0.1.1
     , hspec                ^>=2.9.4
+    , logging-effect
     , openapi3             >=3.2      && <=3.3
     , postgres-options     ^>=0.2
     , pretty-simple        ^>=4.0.0

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -184,7 +184,6 @@ apiCors =
 
 serve :: Sessions -> TBQueue Database.Op -> Version -> Int -> IO ()
 serve ss q v port = do
-  putText $ "Listening on port " <> show port
   Warp.runSettings warpSettings $
     noCache $
       cors (const $ Just apiCors) $

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -32,6 +32,7 @@ library
     Primer.EvalFull
     Primer.Examples
     Primer.JSON
+    Primer.Log
     Primer.Module
     Primer.Name
     Primer.Name.Fresh
@@ -107,6 +108,7 @@ library
     , extra                        >=1.7.10   && <=1.8
     , generic-optics               >=2.0      && <=2.3
     , list-t                       >=1.0      && <=1.1
+    , logging-effect               ^>=1.3.13
     , megaparsec                   >=8.0.0    && <=9.3
     , mtl                          >=2.2.2    && <=2.4
     , optics                       >=0.4      && <=0.5

--- a/primer/src/Primer/Log.hs
+++ b/primer/src/Primer/Log.hs
@@ -1,0 +1,69 @@
+module Primer.Log (
+  ConvertLogMessage (..),
+  logCritical,
+  logDebug,
+  logError,
+  logEmergency,
+  logInfo,
+  logNotice,
+  logWarning,
+  textWithSeverity,
+) where
+
+import Foreword
+
+import Control.Monad.Log (
+  MonadLog,
+  Severity (..),
+  WithSeverity (..),
+ )
+import Control.Monad.Log qualified as Log (
+  logCritical,
+  logDebug,
+  logEmergency,
+  logError,
+  logInfo,
+  logNotice,
+  logWarning,
+ )
+
+logSeverity :: Severity -> Text
+logSeverity Debug = "[DEBUG]     "
+logSeverity Informational = "[INFO]      "
+logSeverity Notice = "[NOTICE]    "
+logSeverity Warning = "[WARNING]   "
+logSeverity Error = "[ERROR]     "
+logSeverity Critical = "[CRITICAL]  "
+logSeverity Alert = "[ALERT]     "
+logSeverity Emergency = "[EMERGENCY] "
+
+class ConvertLogMessage source target where
+  convert :: source -> target
+
+logCritical :: (ConvertLogMessage source target, MonadLog (WithSeverity target) m) => source -> m ()
+logCritical = Log.logCritical . convert
+
+logDebug :: (ConvertLogMessage source target, MonadLog (WithSeverity target) m) => source -> m ()
+logDebug = Log.logDebug . convert
+
+logEmergency :: (ConvertLogMessage source target, MonadLog (WithSeverity target) m) => source -> m ()
+logEmergency = Log.logEmergency . convert
+
+logError :: (ConvertLogMessage source target, MonadLog (WithSeverity target) m) => source -> m ()
+logError = Log.logError . convert
+
+logInfo :: (ConvertLogMessage source target, MonadLog (WithSeverity target) m) => source -> m ()
+logInfo = Log.logInfo . convert
+
+logNotice :: (ConvertLogMessage source target, MonadLog (WithSeverity target) m) => source -> m ()
+logNotice = Log.logNotice . convert
+
+logWarning :: (ConvertLogMessage source target, MonadLog (WithSeverity target) m) => source -> m ()
+logWarning = Log.logWarning . convert
+
+textWithSeverity :: WithSeverity Text -> Text
+textWithSeverity (WithSeverity s m) = logSeverity s <> m
+
+-- | Convenient for discarding logging.
+instance ConvertLogMessage a () where
+  convert = pure ()

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -15,6 +15,9 @@ let
       , "^Primer.Pretty.prettyPrintExpr"
       , "^Primer.Pretty.prettyPrintType"
       , "^Primer.Client"
+      , "^Primer.Log.logDebug"
+      , "^Primer.Log.logEmergency"
+      , "^Primer.Log.logWarning"
       ]
 
 in  { roots = [ "^Main.main$" ] # tmpRoots # ignoreRoots, type-class-roots = True }


### PR DESCRIPTION
As we expect `primer-service` to run in some sort of container service, we're content for now just to log to stdout and let the container orchestration system handle shipping logs. This initial implementation does just that: output log messages to stdout with a severity tag.

For now, we're only logging database issues. Future work includes more logging and additional log output types (some form of structured logging via JSON, etc.).

Note that this commit drops the monomorphized `runRel8Db` runner, because it would require that we choose a specific logging implementation, and that doesn't seem in scope for a library function.