### PR TITLE
refactor: Remove redundant `nodeId` field in `NodeSelection`

### DIFF
--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -122,6 +122,7 @@ import Primer.Core (
   TyVarName,
   Type,
   Type' (..),
+  getID,
   moduleNamePretty,
   unLocalName,
   _typeMeta,
@@ -848,4 +849,4 @@ data NodeSelection = NodeSelection
   deriving (FromJSON, ToJSON) via PrimerJSON NodeSelection
 
 convertNodeSelection :: App.NodeSelection -> NodeSelection
-convertNodeSelection App.NodeSelection{..} = NodeSelection{nodeType, id = nodeId}
+convertNodeSelection sel@App.NodeSelection{nodeType} = NodeSelection{nodeType, id = getID sel}

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -490,9 +490,9 @@ unit_construct_arrow_in_sig =
             TFun _ lhs _ ->
               -- Check that the selection is focused on the lhs, as we instructed
               case progSelection prog' of
-                Just (Selection d (Just NodeSelection{nodeType = SigNode, nodeId})) -> do
+                Just (Selection d (Just sel@NodeSelection{nodeType = SigNode})) -> do
                   d @?= qualifyName mainModuleName "other"
-                  nodeId @?= getID lhs
+                  getID sel @?= getID lhs
                 _ -> assertFailure "no selection"
             _ -> assertFailure "not a function"
         _ -> assertFailure "definition not found"
@@ -1463,8 +1463,8 @@ unit_sh_lost_id =
         Just def ->
           case astDefExpr <$> defAST def of
             Just (Var m (GlobalVarRef f)) | f == foo -> case progSelection prog' of
-              Just Selection{selectedDef, selectedNode = Just NodeSelection{nodeId}} ->
-                unless (selectedDef == foo && nodeId == getID m) $
+              Just Selection{selectedDef, selectedNode = Just sel} ->
+                unless (selectedDef == foo && getID sel == getID m) $
                   assertFailure "expected selection to point at the recursive reference"
               _ -> assertFailure "expected the selection to point at some node"
             _ -> assertFailure "expected foo"
@@ -1507,8 +1507,8 @@ unit_sh_lost_id_2 =
         Just def ->
           case astDefExpr <$> defAST def of
             Just (Hole _ (Ann _ (Lam _ "y" (Lam m "x" (EmptyHole _))) (TEmptyHole _))) -> case progSelection prog' of
-              Just Selection{selectedDef, selectedNode = Just NodeSelection{nodeId}} ->
-                unless (selectedDef == foo && nodeId == getID m) $
+              Just Selection{selectedDef, selectedNode = Just sel} ->
+                unless (selectedDef == foo && getID sel == getID m) $
                   assertFailure "expected selection to point at λx"
               _ -> assertFailure "expected the selection to point at some node"
             _ -> assertFailure "expected {? (λy. λx.?) : ? ?}"
@@ -1550,7 +1550,6 @@ defaultEmptyProg = do
                   Just
                     NodeSelection
                       { nodeType = BodyNode
-                      , nodeId = 1
                       , meta = Left (Meta 1 Nothing Nothing)
                       }
           }

--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -149,7 +149,6 @@ fixtures =
           Just
             NodeSelection
               { nodeType = BodyNode
-              , nodeId = id0
               , meta = Left exprMeta
               }
       reductionDetail :: EvalDetail

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -661,8 +661,8 @@ instance Eq (TypeCacheAlpha [Module]) where
 instance Eq (TypeCacheAlpha ExprMeta) where
   (==) = tcaFunctorial
 instance Eq (TypeCacheAlpha App.NodeSelection) where
-  TypeCacheAlpha (App.NodeSelection t1 i1 m1) == TypeCacheAlpha (App.NodeSelection t2 i2 m2) =
-    t1 == t2 && i1 == i2 && ((==) `on` first TypeCacheAlpha) m1 m2
+  TypeCacheAlpha (App.NodeSelection t1 m1) == TypeCacheAlpha (App.NodeSelection t2 m2) =
+    t1 == t2 && ((==) `on` first TypeCacheAlpha) m1 m2
 instance Eq (TypeCacheAlpha App.Selection) where
   TypeCacheAlpha (App.Selection d1 n1) == TypeCacheAlpha (App.Selection d2 n2) =
     d1 == d2 && TypeCacheAlpha n1 == TypeCacheAlpha n2

--- a/primer/test/outputs/serialization/edit_response_2.json
+++ b/primer/test/outputs/serialization/edit_response_2.json
@@ -151,7 +151,6 @@
                         null
                     ]
                 },
-                "nodeId": 0,
                 "nodeType": "BodyNode"
             }
         },

--- a/primer/test/outputs/serialization/prog.json
+++ b/primer/test/outputs/serialization/prog.json
@@ -150,7 +150,6 @@
                     null
                 ]
             },
-            "nodeId": 0,
             "nodeType": "BodyNode"
         }
     },

--- a/primer/test/outputs/serialization/selection.json
+++ b/primer/test/outputs/serialization/selection.json
@@ -19,7 +19,6 @@
                 null
             ]
         },
-        "nodeId": 0,
         "nodeType": "BodyNode"
     }
 }


### PR DESCRIPTION
We instead extract the ID from the metadata when necessary.

This follow on from my comment in https://github.com/hackworthltd/primer/pull/692#discussion_r976535663:

> Side note: in App.NodeSelection, why do we even have a nodeId field? Isn't this the same ID that's in the always-present metadata?