### PR TITLE
fix: Avoid duplicated path component in available actions API

### DIFF
--- a/primer-service/src/Primer/Servant/OpenAPI.hs
+++ b/primer-service/src/Primer/Servant/OpenAPI.hs
@@ -91,7 +91,6 @@ data SessionAPI mode = SessionAPI
   , actions ::
       mode
         :- "action"
-          :> "available"
           :> NamedRoutes ActionAPI
   }
   deriving (Generic)

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -518,7 +518,7 @@
                 "summary": "Create a new session and return its ID"
             }
         },
-        "/openapi/sessions/{sessionId}/action/available/available": {
+        "/openapi/sessions/{sessionId}/action/available": {
             "post": {
                 "operationId": "getAvailableActions",
                 "parameters": [


### PR DESCRIPTION
This fixes a trivial error in #165.