### PR TITLE
feat: logs have trace ids

### DIFF
--- a/primer-rel8/test/Tests/InsertSession.hs
+++ b/primer-rel8/test/Tests/InsertSession.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Tests.InsertSession where
 
@@ -19,6 +20,7 @@ import Primer.Database (
 import Primer.Database.Rel8.Rel8Db (
   Rel8DbException (InsertError),
  )
+import Primer.Log (WithTraceId (discardTraceId))
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
 import TestUtils (
@@ -28,8 +30,8 @@ import TestUtils (
   (@?=),
  )
 
-expectedError :: SessionId -> Rel8DbException -> Bool
-expectedError id_ (InsertError s _) = s == id_
+expectedError :: SessionId -> WithTraceId Rel8DbException -> Bool
+expectedError id_ (discardTraceId -> InsertError s _) = s == id_
 expectedError _ _ = False
 
 test_insertSession_roundtrip :: TestTree

--- a/primer-rel8/test/Tests/UpdateSessionApp.hs
+++ b/primer-rel8/test/Tests/UpdateSessionApp.hs
@@ -20,6 +20,7 @@ import Primer.Database (
 import Primer.Database.Rel8 (
   Rel8DbException (UpdateAppNonExistentSession),
  )
+import Primer.Log (WithTraceId (discardTraceId))
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
 import TestUtils (
@@ -68,4 +69,4 @@ test_updateSessionApp_failure = testCaseSteps "updateSessionApp failure modes" $
     step "Attempt to update a session that hasn't yet been inserted"
     let version = "git123"
     sessionId <- liftIO newSessionId
-    assertException "updateSessionApp" (expectedError sessionId) $ updateSessionApp version sessionId newApp
+    assertException "updateSessionApp" (expectedError sessionId . discardTraceId) $ updateSessionApp version sessionId newApp

--- a/primer-rel8/test/Tests/UpdateSessionName.hs
+++ b/primer-rel8/test/Tests/UpdateSessionName.hs
@@ -19,6 +19,7 @@ import Primer.Database (
 import Primer.Database.Rel8 (
   Rel8DbException (UpdateNameNonExistentSession),
  )
+import Primer.Log (WithTraceId (discardTraceId))
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
 import TestUtils (
@@ -92,4 +93,4 @@ test_updateSessionName_failure = testCaseSteps "updateSessionName failure modes"
     let version = "git123"
     let name = safeMkSessionName "this session doesn't exist"
     sessionId <- liftIO newSessionId
-    assertException "updateSessionName" (expectedError sessionId) $ updateSessionName version sessionId name
+    assertException "updateSessionName" (expectedError sessionId . discardTraceId) $ updateSessionName version sessionId name

--- a/primer/test/TestUtils.hs
+++ b/primer/test/TestUtils.hs
@@ -60,6 +60,7 @@ import Primer.Database (
   serve,
  )
 import Primer.Def (DefMap)
+import Primer.Log (nextTraceId)
 import Primer.Module (Module (moduleDefs), primitiveModule)
 import Primer.Name (Name (unName))
 import Primer.Primitives (primitive)
@@ -149,4 +150,4 @@ runAPI action = do
   dbOpQueue <- newTBQueueIO 1
   initialSessions <- StmMap.newIO
   _ <- forkIO $ void $ runNullDb' $ serve (ServiceCfg dbOpQueue version)
-  runPrimerIO action $ Env initialSessions dbOpQueue version
+  runPrimerIO action . Env initialSessions dbOpQueue version =<< nextTraceId


### PR DESCRIPTION
Currently this is somewhat pointless, since we don't actually log anything other than from the db. However, this is set up so that when we do, we will automatically attach the correct trace id.