### PR TITLE
feat: Add GHC runtime metrics via a Prometheus endpoint.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -349,7 +349,7 @@
                 DATABASE_URL="${final.lib.primer.postgres-dev-primer-url}"
                 export DATABASE_URL
                 primer-sqitch deploy --verify db:$DATABASE_URL
-                primer-service serve ${version} "$@"
+                primer-service serve ${version} "$@" +RTS -T
               '';
             };
 

--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -205,7 +205,7 @@ in
         exit 1
       fi
       primer-sqitch verify db:"$DATABASE_URL"
-      exec primer-service serve "${version}" --port ${toString lib.primer.defaultServicePort}
+      exec primer-service serve "${version}" --port ${toString lib.primer.defaultServicePort} +RTS -T
     '';
   };
 }

--- a/primer-service/exe-server/Main.hs
+++ b/primer-service/exe-server/Main.hs
@@ -64,6 +64,8 @@ import Primer.Log (
   textWithSeverity,
  )
 import Primer.Server qualified as Server
+import Prometheus qualified as P
+import Prometheus.Metric.GHC qualified as P
 import StmContainers.Map qualified as StmMap
 import System.Environment (lookupEnv)
 import System.IO (
@@ -205,6 +207,10 @@ serve (PostgreSQL uri) ver port qsz logger =
 
 main :: IO ()
 main = do
+  -- Register GHC metrics with Prometheus. This needs to be done very
+  -- early in the program.
+  void $ P.register P.ghcMetrics
+
   -- It's common in Linux containers to log to stdout, so let's ensure
   -- it's line-buffered, as we can't guarantee what the GHC runtime
   -- will do by default.

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -36,33 +36,34 @@ library
     -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
 
   build-depends:
-    , aeson                >=2.0     && <=2.1
-    , base                 >=4.12    && <=4.17
-    , containers           >=0.6.0.1 && < 0.7
-    , deriving-aeson       >=0.2     && <=0.3
-    , exceptions           >=0.10.4  && <=0.11
-    , http-client          ^>=0.7.13
-    , http-media           >=0.8     && <=0.9
-    , logging-effect       ^>=1.3.13
-    , mtl                  >=2.2.2   && <=2.4
-    , openapi3             >=3.2     && <=3.3
-    , optics               >=0.4     && <=0.5
-    , primer               ^>=0.7.2
-    , servant              >=0.18    && <=0.20
-    , servant-client       >=0.18    && <=0.20
-    , servant-client-core  >=0.18    && <=0.20
-    , servant-openapi3     ^>=2.0.1.2
-    , servant-server       >=0.18    && <=0.20
-    , stm                  ^>=2.5
-    , stm-containers       >=1.1     && <=1.3
-    , streaming-commons    ^>=0.2.2.4
-    , text                 >=1.2.3.2 && <=1.3
-    , transformers         >=0.5.6.2 && <=0.7
-    , uuid                 ^>=1.3
-    , wai                  ^>=3.2
-    , wai-app-static       ^>=3.1
-    , wai-cors             ^>=0.2.7
-    , warp                 ^>=3.3
+    , aeson                      >=2.0      && <2.1.0
+    , base                       >=4.12     && <4.17.0
+    , containers                 >=0.6.0.1  && <0.7
+    , deriving-aeson             >=0.2      && <0.3.0
+    , exceptions                 >=0.10.4   && <0.11.0
+    , http-client                ^>=0.7.13
+    , http-media                 >=0.8      && <0.9.0
+    , logging-effect             ^>=1.3.13
+    , mtl                        >=2.2.2    && <2.4.0
+    , openapi3                   >=3.2      && <3.3.0
+    , optics                     >=0.4      && <0.5.0
+    , primer                     ^>=0.7.2
+    , servant                    >=0.18     && <0.20.0
+    , servant-client             >=0.18     && <0.20.0
+    , servant-client-core        >=0.18     && <0.20.0
+    , servant-openapi3           ^>=2.0.1.2
+    , servant-server             >=0.18     && <0.20.0
+    , stm                        ^>=2.5
+    , stm-containers             >=1.1      && <1.3.0
+    , streaming-commons          ^>=0.2.2.4
+    , text                       >=1.2.3.2  && <1.3.0
+    , transformers               >=0.5.6.2  && <0.7.0
+    , uuid                       ^>=1.3
+    , wai                        ^>=3.2
+    , wai-app-static             ^>=3.1
+    , wai-cors                   ^>=0.2.7
+    , wai-middleware-prometheus  ^>=1.0.0.1
+    , warp                       ^>=3.3
 
 executable primer-service
   main-is:            Main.hs
@@ -82,21 +83,23 @@ executable primer-service
     -threaded -rtsopts -with-rtsopts=-N
 
   build-depends:
-    , async                 ^>=2.2.4
+    , async                   ^>=2.2.4
     , base
-    , bytestring            >=0.10.8.2 && <=0.12
-    , directory             ^>=1.3
+    , bytestring              >=0.10.8.2 && <0.12.0
+    , directory               ^>=1.3
     , exceptions
-    , hasql-pool            ^>=0.8.0.3
-    , logging-effect        ^>=1.3.13
-    , optparse-applicative  ^>=0.17
+    , hasql-pool              ^>=0.8.0.3
+    , logging-effect          ^>=1.3.13
+    , optparse-applicative    ^>=0.17
     , primer
-    , primer-rel8           ^>=0.7.2
+    , primer-rel8             ^>=0.7.2
     , primer-service
+    , prometheus-client       ^>=1.1.0
+    , prometheus-metrics-ghc  ^>=1.0.1.2
     , stm
     , stm-containers
     , text
-    , utf8-string           ^>=1.0
+    , utf8-string             ^>=1.0
 
 executable primer-client
   main-is:            Main.hs
@@ -178,31 +181,30 @@ test-suite service-test
     , base
     , bytestring
     , hasql-pool
-    , hedgehog             ^>=1.1.1
-    , hedgehog-quickcheck  ^>=0.1.1
-    , hspec                ^>=2.9.4
+    , hedgehog                          ^>=1.1.1
+    , hedgehog-quickcheck               ^>=0.1.1
+    , hspec                             ^>=2.9.4
     , logging-effect
-    , openapi3             >=3.2      && <=3.3
-    , postgres-options     ^>=0.2
-    , pretty-simple        ^>=4.0.0
-    , primer
-    , primer:primer-hedgehog
+    , openapi3                          >=3.2       && <3.3.0
+    , postgres-options                  ^>=0.2
+    , pretty-simple                     ^>=4.0.0
     , primer-rel8
     , primer-service
-    , QuickCheck           ^>=2.14.2
-    , rel8                 ^>=1.4
-    , servant-openapi3     ^>=2.0.1.2
-    , tasty                ^>=1.4.1
-    , tasty-discover       ^>=4.2.4
-    , tasty-golden         ^>=2.3.5
-    , tasty-hedgehog       ^>=1.2.0
-    , tasty-hspec          ^>=1.2.0.1
-    , tasty-hunit          ^>=0.10.0
-    , temporary            ^>=1.3
+    , primer:{primer, primer-hedgehog}
+    , QuickCheck                        ^>=2.14.2
+    , rel8                              ^>=1.4
+    , servant-openapi3                  ^>=2.0.1.2
+    , tasty                             ^>=1.4.1
+    , tasty-discover                    ^>=4.2.4
+    , tasty-golden                      ^>=2.3.5
+    , tasty-hedgehog                    ^>=1.2.0
+    , tasty-hspec                       ^>=1.2.0.1
+    , tasty-hunit                       ^>=0.10.0
+    , temporary                         ^>=1.3
     , text
-    , tmp-postgres         ^>=1.34.1.0
-    , typed-process        ^>=0.2.8
-    , uuid                 ^>=1.3
+    , tmp-postgres                      ^>=1.34.1.0
+    , typed-process                     ^>=0.2.8
+    , uuid                              ^>=1.3
 
 --TODO This currently breaks with haskell.nix, so we manually add it to `flake.nix` instead.
 -- See: https://github.com/input-output-hk/haskell.nix/issues/839


### PR DESCRIPTION
These are available via HTTP on the `/metrics` endpoint.

Note that, unlike a typical Prometheus client that exposes metrics on
port 9091, this one uses the same port as the rest of the HTTP
service (which, in our case, defaults to 8081).
