### PR TITLE
fix: colima finds qemu on linux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,6 +83,30 @@
         "type": "github"
       }
     },
+    "colimaOverride": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1658216109,
+        "narHash": "sha256-taE7tUuPKafhbbQlvyHKinTIbaYHwqqtA92kwtSJ+LI=",
+        "owner": "abiosoft",
+        "repo": "colima",
+        "rev": "355e01f67471461df8277f63d0dfac774448fbb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "abiosoft",
+        "repo": "colima",
+        "rev": "355e01f67471461df8277f63d0dfac774448fbb3",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -649,11 +673,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
         "type": "github"
       },
       "original": {
@@ -729,6 +753,7 @@
     },
     "root": {
       "inputs": {
+        "colimaOverride": "colimaOverride",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "hacknix": "hacknix",

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,11 @@
     hie-bios.flake = false;
     lsp.url = github:haskell/lsp/b0f8596887088b8ab65fc1015c773f45b47234ae;
     lsp.flake = false;
+
+    # Temporary fixes for colima on linux
+    colimaOverride.url = github:abiosoft/colima/355e01f67471461df8277f63d0dfac774448fbb3;
+    colimaOverride.inputs.nixpkgs.follows = "nixpkgs";
+    colimaOverride.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs =
@@ -40,6 +45,7 @@
     , flake-utils
     , pre-commit-hooks-nix
     , haskell-language-server
+    , colimaOverride
     , ...
     }@inputs:
     let
@@ -458,6 +464,9 @@
         inherit system;
         inherit (haskell-nix) config;
         overlays = [
+          (final: prev: {
+            colima = colimaOverride.packages.${system}.default;
+          })
           overlays.primer
         ];
       };


### PR DESCRIPTION
Before this commit, colima would fail to find qemu when executing nix run .#deploy-postgresql-container

This override can be reverted once colima has a new release which is picked up by nixpkgs.