### PR TITLE
chore: CI 'required' job depends on tests again

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -594,8 +594,8 @@
               checks.x86_64-linux
               checks.aarch64-linux
               checks.aarch64-darwin
-              # tests.x86_64-linux
-              # tests.aarch64-linux
+              tests.x86_64-linux
+              tests.aarch64-linux
               devShell
             ]);
             meta.description = "Required CI builds";


### PR DESCRIPTION
This was accidentally removed via the merge
78c023798f5c74a9e93f8a5678d40545ad532761