### PR TITLE
feat: EvalFull renames foralls small-step style

### DIFF
--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -133,7 +133,7 @@ unit_3 =
         expect <- emptyHole `ann` (tcon' ["M"] "T" `tapp` tvar "b" `tapp` tforall "a" KType (tvar "a") `tapp` tforall b' KType (tcon' ["M"] "S" `tapp` tvar "b" `tapp` tvar b'))
         pure (e, expect)
    in do
-        s <- evalFullTest maxID mempty mempty 5 Syn expr
+        s <- evalFullTest maxID mempty mempty 7 Syn expr
         s <~==> Right expected
 
 -- Check we don't have shadowing issues in terms


### PR DESCRIPTION
This is consistent with how we rename binders in expressions. It is now possible since we have support for 'let's in types.