### PR TITLE
chore(hackage): Bump index.state and a few upper bounds; upgrade uuid.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2022-09-10T00:00:00Z
+index-state: 2022-10-15T00:00:00Z
 
 packages:
   primer

--- a/primer-rel8/primer-rel8.cabal
+++ b/primer-rel8/primer-rel8.cabal
@@ -32,7 +32,7 @@ library
     -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
 
   build-depends:
-    , aeson           >=2.0      && <2.1.0
+    , aeson           >=2.0      && <2.2
     , base            >=4.12     && <4.17.0
     , bytestring      >=0.10.8.2 && <0.12.0
     , containers      >=0.6.0.1  && <0.7.0
@@ -43,8 +43,8 @@ library
     , mtl             >=2.2.2    && <2.4.0
     , primer          ^>=0.7.2
     , rel8            ^>=1.4
-    , text            >=1.2.3.2  && <1.3.0
-    , uuid            ^>=1.3
+    , text            >=1.2.3.2  && <2.1
+    , uuid            ^>=1.3.15
 
 test-suite primer-rel8-test
   type:               exitcode-stdio-1.0
@@ -96,7 +96,7 @@ test-suite primer-rel8-test
       , temporary         ^>=1.3
       , text
       , tmp-postgres      ^>=1.34.1.0
-      , typed-process     ^>=0.2.8
+      , typed-process     >=0.2.8     && <0.2.11
       , utf8-string       ^>=1.0
       , uuid
 

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -36,7 +36,7 @@ library
     -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
 
   build-depends:
-    , aeson                      >=2.0      && <2.1.0
+    , aeson                      >=2.0      && <2.2
     , base                       >=4.12     && <4.17.0
     , containers                 >=0.6.0.1  && <0.7
     , deriving-aeson             >=0.2      && <0.3.0
@@ -56,9 +56,9 @@ library
     , stm                        ^>=2.5
     , stm-containers             >=1.1      && <1.3.0
     , streaming-commons          ^>=0.2.2.4
-    , text                       >=1.2.3.2  && <1.3.0
+    , text                       >=1.2.3.2  && <2.1
     , transformers               >=0.5.6.2  && <0.7.0
-    , uuid                       ^>=1.3
+    , uuid                       ^>=1.3.15
     , wai                        ^>=3.2
     , wai-app-static             ^>=3.1
     , wai-cors                   ^>=0.2.7
@@ -185,7 +185,7 @@ test-suite service-test
     , hedgehog-quickcheck               ^>=0.1.1
     , hspec                             ^>=2.9.4
     , logging-effect
-    , openapi3                          >=3.2       && <3.3.0
+    , openapi3
     , postgres-options                  ^>=0.2
     , pretty-simple                     ^>=4.0.0
     , primer-rel8
@@ -193,7 +193,7 @@ test-suite service-test
     , primer:{primer, primer-hedgehog}
     , QuickCheck                        ^>=2.14.2
     , rel8                              ^>=1.4
-    , servant-openapi3                  ^>=2.0.1.2
+    , servant-openapi3
     , tasty                             ^>=1.4.1
     , tasty-discover                    ^>=4.2.4
     , tasty-golden                      ^>=2.3.5
@@ -204,7 +204,7 @@ test-suite service-test
     , text
     , tmp-postgres                      ^>=1.34.1.0
     , typed-process                     ^>=0.2.8
-    , uuid                              ^>=1.3
+    , uuid
 
 --TODO This currently breaks with haskell.nix, so we manually add it to `flake.nix` instead.
 -- See: https://github.com/input-output-hk/haskell.nix/issues/839

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -99,7 +99,7 @@ library
     -Wcompat -Widentities -Wredundant-constraints -fhide-source-paths
 
   build-depends:
-    , aeson                        >=2.0      && <2.1.0
+    , aeson                        >=2.0      && <2.2
     , base                         >=4.12     && <4.17.0
     , bytestring                   >=0.10.8.2 && <0.12.0
     , containers                   >=0.6.0.1  && <0.7.0
@@ -122,7 +122,7 @@ library
     , text                         >=1.2.3.2  && <2.1.0
     , transformers                 >=0.5.6.2  && <0.7.0
     , uniplate                     >=1.6      && <1.7.0
-    , uuid                         >=1.3      && <1.4.0
+    , uuid                         ^>=1.3.15
 
 library primer-hedgehog
   visibility:         public
@@ -230,26 +230,26 @@ test-suite primer-test
       , extra
       , filepath
       , generic-optics
-      , hedgehog                     ^>=1.1.1
+      , hedgehog
       , hedgehog-classes             ^>=0.2.5.3
       , hspec                        ^>=2.9.4
       , hspec-megaparsec             ^>=2.2.0
-      , logging-effect               ^>=1.3.13
-      , mmorph                       ^>=1.2.0
+      , logging-effect
+      , mmorph
       , mtl
       , optics
       , pretty-simple                ^>=4.0.0
-      , prettyprinter                >=1.7.1    && <1.8.0
-      , prettyprinter-ansi-terminal  >=1.1.3    && <1.2.0
+      , prettyprinter
+      , prettyprinter-ansi-terminal
       , primer
       , primer-hedgehog
       , protolude
       , stm
       , stm-containers
       , tasty                        ^>=1.4.2.1
-      , tasty-discover               ^>=4.2.4
+      , tasty-discover
       , tasty-golden                 ^>=2.3.5
-      , tasty-hedgehog               ^>=1.2.0
+      , tasty-hedgehog
       , tasty-hunit                  ^>=0.10.0
       , text
       , transformers


### PR DESCRIPTION
Specifically:

* Upgrade uuid to at least 1.3.15, as 1.3.14 has some fairly
significant memory savings.

* Allow aeson 2.1.x and typed-process 0.2.10.

* Fix a few inconsistent upper bounds cross-project (e.g., text <2.1).

* Ensure bounds are only specified once per package per Cabal file.
