### PR TITLE
feat(db)!: Add a last-modified timestamp to each session.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,12 @@ hacking on Primer.
   Note that this may not always be successful. You should generally
   only need to run this command if you're testing database schema
   migrations. You can specify which git commit to revert to by passing
-  the following flags: `-- --to <rev>`.
+  the following flags: `-- --to <rev>`. For example, to revert any
+  changes made since `HEAD`:
+
+```sh
+nix run .#revert-local-db -- --to @HEAD
+```
 
 ## A note about the Sqitch scripts
 

--- a/primer-rel8/primer-rel8.cabal
+++ b/primer-rel8/primer-rel8.cabal
@@ -41,9 +41,11 @@ library
     , hasql-pool      ^>=0.8.0.3
     , logging-effect  ^>=1.3.13
     , mtl             >=2.2.2    && <2.4.0
+    , optics          >=0.4      && <0.5.0
     , primer          ^>=0.7.2
     , rel8            ^>=1.4
     , text            >=1.2.3.2  && <2.1
+    , time            ^>=1.11
     , uuid            ^>=1.3.15
 
 test-suite primer-rel8-test
@@ -95,6 +97,7 @@ test-suite primer-rel8-test
       , tasty-hunit       ^>=0.10.0
       , temporary         ^>=1.3
       , text
+      , time
       , tmp-postgres      ^>=1.34.1.0
       , typed-process     >=0.2.8     && <0.2.11
       , utf8-string       ^>=1.0

--- a/primer-rel8/src/Primer/Database/Rel8/Schema.hs
+++ b/primer-rel8/src/Primer/Database/Rel8/Schema.hs
@@ -9,6 +9,7 @@ module Primer.Database.Rel8.Schema (
 import Foreword
 
 import Data.String (String)
+import Data.Time.Clock (UTCTime)
 import Data.UUID (UUID)
 import Primer.App (App)
 import Primer.Database (
@@ -32,12 +33,14 @@ data SessionRow f = SessionRow
   -- ^ The session's UUID.
   , gitversion :: Column f Version
   -- ^ Primer's git version. We would prefer that this were a git
-  -- rev, but for technical reasons, it may also be a last-modified
-  -- date.
+  -- rev, but for technical reasons, it may also be the last-modified
+  -- date of the project.
   , app :: Column f App
   -- ^ The session's 'App'.
   , name :: Column f Text
   -- ^ The session's name.
+  , lastmodified :: Column f UTCTime
+  -- ^ The session's last-modified time.
   }
   deriving stock (Generic)
   deriving anyclass (Rel8able)

--- a/primer-rel8/test/Tests/UpdateSessionName.hs
+++ b/primer-rel8/test/Tests/UpdateSessionName.hs
@@ -23,6 +23,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
 import TestUtils (
   assertException,
+  lowPrecisionCurrentTime,
   runTmpDb,
   (@?=),
  )
@@ -39,49 +40,56 @@ test_updateSessionName_roundtrip = testCaseSteps "updateSessionName database rou
     step "Insert a new session"
     let version = "git123"
     let name = safeMkSessionName "new app"
+    now <- lowPrecisionCurrentTime
     sessionId <- liftIO newSessionId
-    insertSession version sessionId newEmptyApp name
+    insertSession version sessionId newEmptyApp name now
 
     step "Update it with the same version and name"
-    updateSessionName version sessionId name
+    updateSessionName version sessionId name now
     r1 <- querySessionId sessionId
-    r1 @?= Right (SessionData newEmptyApp name)
+    r1 @?= Right (SessionData newEmptyApp name now)
 
     step "Update it with a new version, but the same name"
     let newVersion = "new-" <> version
-    updateSessionName newVersion sessionId name
+    updateSessionName newVersion sessionId name now
     r2 <- querySessionId sessionId
-    r2 @?= Right (SessionData newEmptyApp name)
+    r2 @?= Right (SessionData newEmptyApp name now)
 
     step "Update it with a new name"
     let newName = safeMkSessionName "new new app"
-    updateSessionName newVersion sessionId newName
+    updateSessionName newVersion sessionId newName now
     r3 <- querySessionId sessionId
-    r3 @?= Right (SessionData newEmptyApp newName)
+    r3 @?= Right (SessionData newEmptyApp newName now)
+
+    step "Update it with a new time"
+    now' <- lowPrecisionCurrentTime
+    updateSessionName newVersion sessionId newName now'
+    r4 <- querySessionId sessionId
+    r4 @?= Right (SessionData newEmptyApp newName now')
 
     step "Update it with a Japanese name"
     let jpName = safeMkSessionName "サンプルプログラム"
-    updateSessionName newVersion sessionId jpName
-    r4 <- querySessionId sessionId
-    r4 @?= Right (SessionData newEmptyApp jpName)
+    updateSessionName newVersion sessionId jpName now'
+    r5 <- querySessionId sessionId
+    r5 @?= Right (SessionData newEmptyApp jpName now')
 
     step "Update it with a simplified Chinese name"
     let cnName = safeMkSessionName "示例程序"
-    updateSessionName newVersion sessionId cnName
-    r5 <- querySessionId sessionId
-    r5 @?= Right (SessionData newEmptyApp cnName)
+    updateSessionName newVersion sessionId cnName now'
+    r6 <- querySessionId sessionId
+    r6 @?= Right (SessionData newEmptyApp cnName now')
 
     step "Update it with an Arabic name"
     let arName = safeMkSessionName "برنامج مثال"
-    updateSessionName newVersion sessionId arName
-    r6 <- querySessionId sessionId
-    r6 @?= Right (SessionData newEmptyApp arName)
+    updateSessionName newVersion sessionId arName now'
+    r7 <- querySessionId sessionId
+    r7 @?= Right (SessionData newEmptyApp arName now')
 
     step "Update it with an emoji name"
     let emName = safeMkSessionName "😄😂🤣🤗 🦊 🦈"
-    updateSessionName newVersion sessionId emName
-    r7 <- querySessionId sessionId
-    r7 @?= Right (SessionData newEmptyApp emName)
+    updateSessionName newVersion sessionId emName now'
+    r8 <- querySessionId sessionId
+    r8 @?= Right (SessionData newEmptyApp emName now')
 
 test_updateSessionName_failure :: TestTree
 test_updateSessionName_failure = testCaseSteps "updateSessionName failure modes" $ \step' ->
@@ -91,5 +99,6 @@ test_updateSessionName_failure = testCaseSteps "updateSessionName failure modes"
     step "Attempt to update a session that hasn't yet been inserted"
     let version = "git123"
     let name = safeMkSessionName "this session doesn't exist"
+    now <- lowPrecisionCurrentTime
     sessionId <- liftIO newSessionId
-    assertException "updateSessionName" (expectedError sessionId) $ updateSessionName version sessionId name
+    assertException "updateSessionName" (expectedError sessionId) $ updateSessionName version sessionId name now

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -202,6 +202,7 @@ test-suite service-test
     , tasty-hunit                       ^>=0.10.0
     , temporary                         ^>=1.3
     , text
+    , time                              ^>=1.11
     , tmp-postgres                      ^>=1.34.1.0
     , typed-process                     ^>=0.2.8
     , uuid

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -360,13 +360,17 @@
                     "id": {
                         "$ref": "#/components/schemas/UUID"
                     },
+                    "lastModified": {
+                        "$ref": "#/components/schemas/UTCTime"
+                    },
                     "name": {
                         "$ref": "#/components/schemas/SessionName"
                     }
                 },
                 "required": [
                     "id",
-                    "name"
+                    "name",
+                    "lastModified"
                 ],
                 "type": "object"
             },
@@ -401,6 +405,11 @@
                     "childTrees"
                 ],
                 "type": "object"
+            },
+            "UTCTime": {
+                "example": "2016-07-22T00:00:00Z",
+                "format": "yyyy-mm-ddThh:MM:ssZ",
+                "type": "string"
             },
             "UUID": {
                 "example": "00000000-0000-0000-0000-000000000000",

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -120,6 +120,7 @@ library
     , stm                          >=2.5      && <2.6.0
     , stm-containers               >=1.1      && <1.3.0
     , text                         >=1.2.3.2  && <2.1.0
+    , time                         ^>=1.11
     , transformers                 >=0.5.6.2  && <0.7.0
     , uniplate                     >=1.6      && <1.7.0
     , uuid                         ^>=1.3.15
@@ -252,6 +253,7 @@ test-suite primer-test
       , tasty-hedgehog
       , tasty-hunit                  ^>=0.10.0
       , text
+      , time
       , transformers
       , uniplate
       , uuid

--- a/primer/test/Tests/Database.hs
+++ b/primer/test/Tests/Database.hs
@@ -266,9 +266,9 @@ newtype FailDbException = FailDbException Text
 instance Exception FailDbException
 
 instance (MonadThrow m) => MonadDb (FailDbT m) where
-  insertSession _ _ _ _ = throwM $ FailDbException "insertSession"
-  updateSessionApp _ _ _ = throwM $ FailDbException "updateSessionApp"
-  updateSessionName _ _ _ = throwM $ FailDbException "updateSessionName"
+  insertSession _ _ _ _ _ = throwM $ FailDbException "insertSession"
+  updateSessionApp _ _ _ _ = throwM $ FailDbException "updateSessionApp"
+  updateSessionName _ _ _ _ = throwM $ FailDbException "updateSessionName"
   listSessions _ = throwM $ FailDbException "listSessions"
   querySessionId _ = throwM $ FailDbException "querySessionId"
 

--- a/primer/test/Tests/NullDb.hs
+++ b/primer/test/Tests/NullDb.hs
@@ -2,6 +2,7 @@ module Tests.NullDb where
 
 import Foreword
 
+import Data.Time.Clock (getCurrentTime)
 import Data.UUID.V4 (nextRandom)
 import Primer.App (
   newApp,
@@ -41,74 +42,85 @@ expectedError _ _ = True
 test_insertSession_roundtrip :: TestTree
 test_insertSession_roundtrip = testCaseSteps "insertSession database round-tripping" $ \step' ->
   runNullDb' $ do
+    now1 <- liftIO getCurrentTime
     let step = liftIO . step'
     step "Insert even3App"
     let version = "git123"
     let name = safeMkSessionName "even3App"
     sessionId <- liftIO newSessionId
-    insertSession version sessionId even3App name
+    insertSession version sessionId even3App name now1
 
     step "Retrieve it"
     result <- querySessionId sessionId
-    result @?= Right (SessionData even3App name)
+    result @?= Right (SessionData even3App name now1)
 
+    now2 <- liftIO getCurrentTime
     let jpName = safeMkSessionName "サンプルプログラム"
     step "Insert mapOddApp with Japanese name"
     sid1 <- liftIO newSessionId
-    insertSession version sid1 mapOddApp jpName
+    insertSession version sid1 mapOddApp jpName now2
     r1 <- querySessionId sid1
-    r1 @?= Right (SessionData mapOddApp jpName)
+    r1 @?= Right (SessionData mapOddApp jpName now2)
 
+    now3 <- liftIO getCurrentTime
     let cnName = safeMkSessionName "示例程序"
     step "Insert even3App with simplified Chinese name"
     sid2 <- liftIO newSessionId
-    insertSession version sid2 even3App cnName
+    insertSession version sid2 even3App cnName now3
     r2 <- querySessionId sid2
-    r2 @?= Right (SessionData even3App cnName)
+    r2 @?= Right (SessionData even3App cnName now3)
 
+    now4 <- liftIO getCurrentTime
     let arName = safeMkSessionName "برنامج مثال"
     step "Insert mapOddApp with Arabic name"
     sid3 <- liftIO newSessionId
-    insertSession version sid3 mapOddApp arName
+    insertSession version sid3 mapOddApp arName now4
     r3 <- querySessionId sid3
-    r3 @?= Right (SessionData mapOddApp arName)
+    r3 @?= Right (SessionData mapOddApp arName now4)
 
+    now5 <- liftIO getCurrentTime
     let emName = safeMkSessionName "😄😂🤣🤗 🦊 🦈"
     step "Insert even3App with emoji name"
     sid4 <- liftIO newSessionId
-    insertSession version sid4 even3App emName
+    insertSession version sid4 even3App emName now5
     r4 <- querySessionId sid4
-    r4 @?= Right (SessionData even3App emName)
+    r4 @?= Right (SessionData even3App emName now5)
 
 test_insertSession_failure :: TestTree
 test_insertSession_failure = testCaseSteps "insertSession failure modes" $ \step' ->
   runNullDb' $ do
+    now <- liftIO getCurrentTime
     let step = liftIO . step'
 
     step "Insert program"
     let version = "git123"
     let name = safeMkSessionName "testApp"
     sessionId <- liftIO newSessionId
-    insertSession version sessionId mapOddApp name
+    insertSession version sessionId mapOddApp name now
 
     step "Attempt to insert the same program and metadata again"
-    assertException "insertSession" (expectedError sessionId) $ insertSession version sessionId mapOddApp name
+    assertException "insertSession" (expectedError sessionId) $ insertSession version sessionId mapOddApp name now
 
     step "Attempt to insert a different program with the same metadata"
-    assertException "insertSession" (expectedError sessionId) $ insertSession version sessionId newEmptyApp name
+    assertException "insertSession" (expectedError sessionId) $ insertSession version sessionId newEmptyApp name now
 
     step "Attempt to insert the same program with a different version"
     let newVersion = "new-" <> version
-    assertException "insertSession" (expectedError sessionId) $ insertSession newVersion sessionId mapOddApp name
+    assertException "insertSession" (expectedError sessionId) $ insertSession newVersion sessionId mapOddApp name now
 
     step "Attempt to insert the same program with a different name"
     let newName = safeMkSessionName "new name"
-    assertException "insertSession" (expectedError sessionId) $ insertSession version sessionId mapOddApp newName
+    assertException "insertSession" (expectedError sessionId) $ insertSession version sessionId mapOddApp newName now
+
+    step "Attempt to insert the same program with a different timestamp"
+    now' <- liftIO getCurrentTime
+    assertException "insertSession" (expectedError sessionId) $ insertSession version sessionId mapOddApp name now'
 
 mkSession :: Int -> IO (SessionId, SessionData)
 mkSession n = do
   u <- nextRandom
-  pure (u, SessionData newApp $ safeMkSessionName $ "name-" <> show n)
+  now <- liftIO getCurrentTime
+  pure (u, SessionData newApp (safeMkSessionName $ "name-" <> show n) now)
 
 test_listSessions :: TestTree
 test_listSessions = testCaseSteps "listSessions" $ \step' ->
@@ -118,8 +130,8 @@ test_listSessions = testCaseSteps "listSessions" $ \step' ->
     let version = "git123"
     step "Insert all sessions"
     rows <- liftIO $ sortOn (sessionName . snd) <$> traverse mkSession [1 .. m]
-    forM_ rows (\(id_, SessionData app name) -> insertSession version id_ app name)
-    let expectedRows = map (\r -> Session (fst r) ((sessionName . snd) r)) rows
+    forM_ rows (\(id_, SessionData app name now) -> insertSession version id_ app name now)
+    let expectedRows = map (\(i, SessionData _ n t) -> Session i n t) rows
     step "Get all, offset+limit"
     pAll <- listSessions $ OL{offset = 0, limit = Nothing}
     total pAll @?= m
@@ -143,26 +155,33 @@ test_updateSessionApp_roundtrip = testCaseSteps "updateSessionApp database round
     let step = liftIO . step'
 
     step "Insert a new session"
+    now <- liftIO getCurrentTime
     let version = "git123"
     let name = safeMkSessionName "new app"
     sessionId <- liftIO newSessionId
-    insertSession version sessionId mapOddApp name
+    insertSession version sessionId mapOddApp name now
 
     step "Update it with the same version and app"
-    updateSessionApp version sessionId mapOddApp
+    updateSessionApp version sessionId mapOddApp now
     r1 <- querySessionId sessionId
-    r1 @?= Right (SessionData mapOddApp name)
+    r1 @?= Right (SessionData mapOddApp name now)
 
     step "Update it with a new version, but the same app"
     let newVersion = "new-" <> version
-    updateSessionApp newVersion sessionId mapOddApp
+    updateSessionApp newVersion sessionId mapOddApp now
     r2 <- querySessionId sessionId
-    r2 @?= Right (SessionData mapOddApp name)
+    r2 @?= Right (SessionData mapOddApp name now)
 
     step "Update it with a new app"
-    updateSessionApp newVersion sessionId even3App
+    updateSessionApp newVersion sessionId even3App now
     r3 <- querySessionId sessionId
-    r3 @?= Right (SessionData even3App name)
+    r3 @?= Right (SessionData even3App name now)
+
+    step "Update it with a new timestamp"
+    now' <- liftIO getCurrentTime
+    updateSessionApp newVersion sessionId even3App now'
+    r4 <- querySessionId sessionId
+    r4 @?= Right (SessionData even3App name now')
 
 test_updateSessionApp_failure :: TestTree
 test_updateSessionApp_failure = testCaseSteps "updateSessionApp failure modes" $ \step' ->
@@ -170,9 +189,10 @@ test_updateSessionApp_failure = testCaseSteps "updateSessionApp failure modes" $
     let step = liftIO . step'
 
     step "Attempt to update a session that hasn't yet been inserted"
+    now <- liftIO getCurrentTime
     let version = "git123"
     sessionId <- liftIO newSessionId
-    assertException "updateSessionApp" (expectedError sessionId) $ updateSessionApp version sessionId newApp
+    assertException "updateSessionApp" (expectedError sessionId) $ updateSessionApp version sessionId newApp now
 
 test_updateSessionName_roundtrip :: TestTree
 test_updateSessionName_roundtrip = testCaseSteps "updateSessionName database round-tripping" $ \step' ->
@@ -180,51 +200,58 @@ test_updateSessionName_roundtrip = testCaseSteps "updateSessionName database rou
     let step = liftIO . step'
 
     step "Insert a new session"
+    now <- liftIO getCurrentTime
     let version = "git123"
     let name = safeMkSessionName "new app"
     sessionId <- liftIO newSessionId
-    insertSession version sessionId mapOddApp name
+    insertSession version sessionId mapOddApp name now
 
     step "Update it with the same version and name"
-    updateSessionName version sessionId name
+    updateSessionName version sessionId name now
     r1 <- querySessionId sessionId
-    r1 @?= Right (SessionData mapOddApp name)
+    r1 @?= Right (SessionData mapOddApp name now)
 
     step "Update it with a new version, but the same name"
     let newVersion = "new-" <> version
-    updateSessionName newVersion sessionId name
+    updateSessionName newVersion sessionId name now
     r2 <- querySessionId sessionId
-    r2 @?= Right (SessionData mapOddApp name)
+    r2 @?= Right (SessionData mapOddApp name now)
 
     step "Update it with a new name"
     let newName = safeMkSessionName "new new app"
-    updateSessionName newVersion sessionId newName
+    updateSessionName newVersion sessionId newName now
     r3 <- querySessionId sessionId
-    r3 @?= Right (SessionData mapOddApp newName)
+    r3 @?= Right (SessionData mapOddApp newName now)
+
+    step "Update it with a new timestamp"
+    now' <- liftIO getCurrentTime
+    updateSessionName newVersion sessionId newName now'
+    r4 <- querySessionId sessionId
+    r4 @?= Right (SessionData mapOddApp newName now')
 
     step "Update it with a Japanese name"
     let jpName = safeMkSessionName "サンプルプログラム"
-    updateSessionName newVersion sessionId jpName
-    r4 <- querySessionId sessionId
-    r4 @?= Right (SessionData mapOddApp jpName)
+    updateSessionName newVersion sessionId jpName now'
+    r5 <- querySessionId sessionId
+    r5 @?= Right (SessionData mapOddApp jpName now')
 
     step "Update it with a simplified Chinese name"
     let cnName = safeMkSessionName "示例程序"
-    updateSessionName newVersion sessionId cnName
-    r5 <- querySessionId sessionId
-    r5 @?= Right (SessionData mapOddApp cnName)
+    updateSessionName newVersion sessionId cnName now'
+    r6 <- querySessionId sessionId
+    r6 @?= Right (SessionData mapOddApp cnName now')
 
     step "Update it with an Arabic name"
     let arName = safeMkSessionName "برنامج مثال"
-    updateSessionName newVersion sessionId arName
-    r6 <- querySessionId sessionId
-    r6 @?= Right (SessionData mapOddApp arName)
+    updateSessionName newVersion sessionId arName now'
+    r7 <- querySessionId sessionId
+    r7 @?= Right (SessionData mapOddApp arName now')
 
     step "Update it with an emoji name"
     let emName = safeMkSessionName "😄😂🤣🤗 🦊 🦈"
-    updateSessionName newVersion sessionId emName
-    r7 <- querySessionId sessionId
-    r7 @?= Right (SessionData mapOddApp emName)
+    updateSessionName newVersion sessionId emName now'
+    r8 <- querySessionId sessionId
+    r8 @?= Right (SessionData mapOddApp emName now')
 
 test_updateSessionName_failure :: TestTree
 test_updateSessionName_failure = testCaseSteps "updateSessionName failure modes" $ \step' ->
@@ -232,10 +259,11 @@ test_updateSessionName_failure = testCaseSteps "updateSessionName failure modes"
     let step = liftIO . step'
 
     step "Attempt to update a session that hasn't yet been inserted"
+    now <- liftIO getCurrentTime
     let version = "git123"
     let name = safeMkSessionName "this session doesn't exist"
     sessionId <- liftIO newSessionId
-    assertException "updateSessionName" (expectedError sessionId) $ updateSessionName version sessionId name
+    assertException "updateSessionName" (expectedError sessionId) $ updateSessionName version sessionId name now
 
 test_querySessionId :: TestTree
 test_querySessionId = testCaseSteps "querySessionId corner cases" $ \step' ->
@@ -243,10 +271,11 @@ test_querySessionId = testCaseSteps "querySessionId corner cases" $ \step' ->
     let step = liftIO . step'
 
     step "Insert program"
+    now <- liftIO getCurrentTime
     let version = "git123"
     let name = safeMkSessionName "test querySessionId"
     sessionId <- liftIO newSessionId
-    insertSession version sessionId newApp name
+    insertSession version sessionId newApp name now
 
     step "Attempt to look up a session that doesn't exist"
     nonexistentSessionId <- liftIO newSessionId

--- a/sqitch/deploy/session-timestamp.sql
+++ b/sqitch/deploy/session-timestamp.sql
@@ -1,0 +1,12 @@
+-- Deploy primer:session-timestamp to pg
+-- requires: sessions
+
+BEGIN;
+
+SET client_min_messages = warning;
+SET search_path TO primer;
+
+ALTER TABLE ONLY sessions
+    ADD COLUMN lastmodified timestamp with time zone NOT NULL DEFAULT now();
+
+COMMIT;

--- a/sqitch/revert/session-timestamp.sql
+++ b/sqitch/revert/session-timestamp.sql
@@ -1,0 +1,11 @@
+-- Revert primer:session-timestamp from pg
+
+BEGIN;
+
+SET client_min_messages = warning;
+SET search_path TO primer;
+
+ALTER TABLE ONLY sessions
+    DROP COLUMN lastmodified;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -8,3 +8,5 @@ sessions [appschema] 2022-02-08T15:03:26Z Drew Hess <dhess@hackworthltd.com> # C
 
 migrate-app-to-jsonb [sessions appschema] 2022-03-06T21:39:29Z Drew Hess <dhess@hackworthltd.com> # Convert the app encoding to jsonb.
 @v0.7.2.0 2022-03-07T00:35:02Z Drew Hess <dhess@hackworthltd.com> # Tag v0.7.2.0.
+
+session-timestamp [sessions] 2022-10-19T16:24:29Z Drew Hess <dhess@hackworthltd.com> # Add a last-modified timestamp to sessions.

--- a/sqitch/test/sessions.sql
+++ b/sqitch/test/sessions.sql
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 RESET client_min_messages;
 
 BEGIN;
-SELECT plan(27);
+SELECT plan(34);
 
 SET search_path TO primer,public;
 
@@ -39,6 +39,14 @@ SELECT col_not_null(      'sessions', 'name' );
 SELECT col_hasnt_default( 'sessions', 'name' );
 SELECT col_isnt_pk(       'sessions', 'name' );
 SELECT col_isnt_fk(       'sessions', 'name' );
+
+SELECT has_column(        'sessions', 'lastmodified' );
+SELECT col_type_is(       'sessions', 'lastmodified', 'timestamp with time zone' );
+SELECT col_not_null(      'sessions', 'lastmodified' );
+SELECT col_has_default(   'sessions', 'lastmodified' );
+SELECT col_default_is(    'sessions', 'lastmodified', 'now()' );
+SELECT col_isnt_pk(       'sessions', 'lastmodified' );
+SELECT col_isnt_fk(       'sessions', 'lastmodified' );
 
 SELECT finish();
 ROLLBACK;

--- a/sqitch/verify/session-timestamp.sql
+++ b/sqitch/verify/session-timestamp.sql
@@ -1,0 +1,12 @@
+-- Verify primer:session-timestamp on pg
+
+BEGIN;
+
+SET client_min_messages = warning;
+SET search_path TO primer;
+
+SELECT uuid, gitversion, app, name, lastmodified
+  FROM sessions
+WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
Note that "modified" here means any edit, including session name changes. Read-only session queries don't update the timestamp.

BREAKING CHANGE: this change requires a database migration. If you want to preserve your existing local PostgreSQL database, you must run the `deploy-local-db` script against it. Assuming your PostgreSQL Docker container is running, run this:

```sh
nix run .#deploy-local-db
```

Closes https://github.com/hackworthltd/primer/issues/247
Closes https://linear.app/hackworthltd/issue/PRIM-20
