### PR TITLE
refactor!: generalise {Let -> Bind}RenameDetail

### DIFF
--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -68,6 +68,7 @@ library
     Primer.Core.Type
     Primer.Core.Type.Utils
     Primer.Eval.Beta
+    Primer.Eval.Bind
     Primer.Eval.Case
     Primer.Eval.Detail
     Primer.Eval.EvalError

--- a/primer/src/Primer/Eval/Bind.hs
+++ b/primer/src/Primer/Eval/Bind.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Primer.Eval.Bind (BindRenameDetail (..)) where
+
+import Foreword
+
+import Primer.Core (
+  ID,
+ )
+import Primer.JSON (CustomJSON (CustomJSON), FromJSON, PrimerJSON, ToJSON)
+import Primer.Name (Name)
+
+-- | Detailed information about a renaming of a binding.
+-- If term-level: t ~ Expr; if type-level: t ~ Type
+data BindRenameDetail t = BindRenameDetail
+  { before :: t
+  -- ^ the expression before reduction
+  , after :: t
+  -- ^ the resulting expression after reduction
+  , bindingNamesOld :: [Name]
+  -- ^ the old names of the bound variables
+  , bindingNamesNew :: [Name]
+  -- ^ the new names of the bound variables
+  , bindersOld :: [ID]
+  -- ^ the old binders
+  , bindersNew :: [ID]
+  -- ^ the new binders
+  , bindingOccurrences :: [ID]
+  -- ^ where the old name occurred inside the bound expression
+  , bodyID :: ID
+  -- ^ the right hand side of the binders
+  }
+  deriving (Eq, Show, Generic)
+  deriving (FromJSON, ToJSON) via PrimerJSON (BindRenameDetail t)

--- a/primer/src/Primer/Eval/Detail.hs
+++ b/primer/src/Primer/Eval/Detail.hs
@@ -3,6 +3,7 @@
 module Primer.Eval.Detail (
   EvalDetail (..),
   module Beta,
+  module Bind,
   module Inline,
   module Case,
   module Let,
@@ -16,6 +17,7 @@ import Primer.Core (Expr)
 import Primer.Core.Meta (LocalNameKind (..))
 import Primer.Core.Type (Kind, Type)
 import Primer.Eval.Beta as Beta
+import Primer.Eval.Bind as Bind
 import Primer.Eval.Case as Case
 import Primer.Eval.Inline as Inline
 import Primer.Eval.Let as Let
@@ -38,9 +40,10 @@ data EvalDetail
   | -- | ID of let(rec)
     LetRemoval (LetRemovalDetail Expr)
   | TLetRemoval (LetRemovalDetail Type)
-  | -- | Renaming of binding in let x = ...x... in ...x...x...
-    LetRename (LetRenameDetail Expr)
-  | TLetRename (LetRenameDetail Type)
+  | -- | Renaming of binding
+    BindRename (BindRenameDetail Expr)
+  | -- | Renaming of binding in a type
+    TBindRename (BindRenameDetail Type)
   | -- | TODO: some details here
     CaseReduction CaseReductionDetail
   | -- | Push the argument of an application inside a letrec

--- a/primer/test/Tests/Eval.hs
+++ b/primer/test/Tests/Eval.hs
@@ -38,12 +38,12 @@ import Primer.Def (ASTDef (..), Def (..), DefMap, defPrim)
 import Primer.Eval (
   ApplyPrimFunDetail (..),
   BetaReductionDetail (..),
+  BindRenameDetail (..),
   CaseReductionDetail (..),
   EvalDetail (..),
   EvalError (..),
   GlobalVarInlineDetail (..),
   LetRemovalDetail (..),
-  LetRenameDetail (..),
   LocalLet (LLet, LLetRec, LLetType),
   LocalVarInlineDetail (..),
   Locals,
@@ -317,14 +317,15 @@ unit_tryReduce_let_self_capture = do
       result = runTryReduce mempty mempty (expr, i)
       expectedResult = create' $ let_ "x0" (lvar "x") (lvar "x0")
   case result of
-    Right (expr', LetRename detail) -> do
+    Right (expr', BindRename detail) -> do
       expr' ~= expectedResult
 
       detail.before @?= expr
       detail.after ~= expectedResult
-      detail.bindingNameOld @?= "x"
-      detail.bindingNameNew @?= "x0"
-      detail.letID @?= 0
+      detail.bindingNamesOld @?= ["x"]
+      detail.bindingNamesNew @?= ["x0"]
+      detail.bindersOld @?= [0]
+      detail.bindersNew @?= [3]
       detail.bindingOccurrences @?= [1]
       detail.bodyID @?= 2
     _ -> assertFailure $ show result
@@ -352,14 +353,15 @@ unit_tryReduce_lettype_self_capture = do
       result = runTryReduce mempty mempty (expr, i)
       expectedResult = create' $ letType "x0" (tvar "x") (emptyHole `ann` tvar "x0")
   case result of
-    Right (expr', LetRename detail) -> do
+    Right (expr', BindRename detail) -> do
       expr' ~= expectedResult
 
       detail.before @?= expr
       detail.after ~= expectedResult
-      detail.bindingNameOld @?= "x"
-      detail.bindingNameNew @?= "x0"
-      detail.letID @?= 0
+      detail.bindingNamesOld @?= ["x"]
+      detail.bindingNamesNew @?= ["x0"]
+      detail.bindersOld @?= [0]
+      detail.bindersNew @?= [5]
       detail.bindingOccurrences @?= [1]
       detail.bodyID @?= 2
     _ -> assertFailure $ show result
@@ -388,14 +390,15 @@ unit_tryReduce_tlet_self_capture = do
       result = runTryReduceType mempty mempty (ty, i)
       expectedResult = create' $ tlet "x0" (tvar "x") (tvar "x0")
   case result of
-    Right (ty', TLetRename detail) -> do
+    Right (ty', TBindRename detail) -> do
       ty' ~~= expectedResult
 
       detail.before @?= ty
       detail.after ~~= expectedResult
-      detail.bindingNameOld @?= "x"
-      detail.bindingNameNew @?= "x0"
-      detail.letID @?= 0
+      detail.bindingNamesOld @?= ["x"]
+      detail.bindingNamesNew @?= ["x0"]
+      detail.bindersOld @?= [0]
+      detail.bindersNew @?= [3]
       detail.bindingOccurrences @?= [1]
       detail.bodyID @?= 2
     _ -> assertFailure $ show result


### PR DESCRIPTION
This is in preparation for merging the two evaluators. EvalFull currently does a variety of renamings, but Eval only does renamings of lets. This will change when the merge happens.