### PR TITLE
fix: viewCaseRedex must only accept one layer of annotation

### DIFF
--- a/primer/src/Primer/EvalFull.hs
+++ b/primer/src/Primer/EvalFull.hs
@@ -94,7 +94,7 @@ import Primer.Core (
   getID,
  )
 import Primer.Core.DSL (ann, letType, let_, letrec, lvar, tlet, tvar)
-import Primer.Core.Transform (removeAnn, unfoldAPP, unfoldApp)
+import Primer.Core.Transform (unfoldAPP, unfoldApp)
 import Primer.Core.Utils (
   concreteTy,
   forgetTypeMetadata,
@@ -358,7 +358,10 @@ viewCaseRedex tydefs = \case
   -- metadata correctly in this evaluator (for instance, substituting when we
   -- do a BETA reduction)!
   Case m expr brs -> do
-    (c, tyargs, args) <- extractCon (removeAnn expr)
+    let expr' = case expr of
+          Ann _ e _ -> e
+          _ -> expr
+    (c, tyargs, args) <- extractCon expr'
     ty <- case expr of
       Ann _ _ ty' -> pure $ forgetTypeMetadata ty'
       _ -> do


### PR DESCRIPTION
Otherwise, the following two expressions would be treated the same:
  case ((C : ?) : T) of ...
and
  case (C : T) of ...
even if (only) the second is ill-typed. This leads, at the very least, to situations where EvalFull will log warnings when it should quietly say 'NotRedex' (for instance, if 'C' is not a constructor of the type 'T').