### PR TITLE
feat: Type holes can act as higher-kinded foralls

### DIFF
--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -760,12 +760,10 @@ matchArrowType _ = Nothing
 
 -- | Checks if a type can be hole-refined to a forall, and if so returns the
 -- forall'd version.
--- NB: holes can behave as ∀(a:KType). ..., but not of any higher kind
--- (We may revisit this later)
 matchForallType :: MonadFresh NameCounter m => Type -> m (Maybe (TyVarName, Kind, Type))
 -- These names will never enter the program, so we don't need to avoid shadowing
-matchForallType (TEmptyHole _) = (\n -> Just (n, KType, TEmptyHole ())) <$> freshLocalName mempty
-matchForallType (THole _ _) = (\n -> Just (n, KType, TEmptyHole ())) <$> freshLocalName mempty
+matchForallType (TEmptyHole _) = (\n -> Just (n, KHole, TEmptyHole ())) <$> freshLocalName mempty
+matchForallType (THole _ _) = (\n -> Just (n, KHole, TEmptyHole ())) <$> freshLocalName mempty
 matchForallType (TForall _ a k t) = pure $ Just (a, k, t)
 matchForallType _ = pure Nothing
 

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -425,6 +425,13 @@ unit_poly_head_Nat =
       )
       ((tcon tList `tapp` tcon tNat) `tfun` tcon tNat)
 
+-- ? ∋ Λa . (? : (a ?))
+-- note that this requires 'a' to be higher-kinded, a : Type -> Type.
+-- and thus requires that a type hole can act as a higher-kinded forall.
+unit_higher_kinded_match_forall :: Assertion
+unit_higher_kinded_match_forall =
+  expectTyped $ lAM "a" (emptyHole `ann` (tvar "a" `tapp` tEmptyHole)) `ann` tEmptyHole
+
 unit_type_hole_1 :: Assertion
 unit_type_hole_1 = tEmptyHole `expectKinded` KHole
 


### PR DESCRIPTION
The status quo is that type holes can act only as foralls whose bound
variable has kind Type. This means that there are some valid judgements
which become false when replacing a forall by a type hole. For instance
∀a:Type -> Type . a Bool ∋ Λa. ? : a Bool   typechecks, but
                       ? ∋ Λa. ? : a Bool   does not,
since the type can only act as  ∀a:Type. ?, but the RHS requires 'a' to
be higher-kinded.
