### PR TITLE
chore: Migrate to `mtl-2.3.1`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,7 +19,8 @@ package primer
 package primer-service
   test-options: "--size-cutoff=32768"
 
-allow-newer: logging-effect:text
+allow-newer:
+  logging-effect:text, *:mtl
 
 -- We need a newer version of Selda than what's been released to Hackage.
 source-repository-package

--- a/primer-rel8/primer-rel8.cabal
+++ b/primer-rel8/primer-rel8.cabal
@@ -42,7 +42,7 @@ library
     , hasql           ^>=1.6
     , hasql-pool      ^>=0.8.0.3
     , logging-effect  ^>=1.3.13
-    , mtl             >=2.2.2    && <2.4.0
+    , mtl             ^>=2.3.1
     , optics          >=0.4      && <0.5.0
     , primer          ^>=0.7.2
     , rel8            ^>=1.4

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -50,7 +50,7 @@ library
     , http-types                 ^>=0.12.3
     , insert-ordered-containers  ^>=0.2.5.1
     , logging-effect             ^>=1.3.13
-    , mtl                        >=2.2.2    && <2.4.0
+    , mtl                        ^>=2.3.1
     , openapi3                   >=3.2      && <3.3.0
     , optics                     >=0.4      && <0.5.0
     , primer                     ^>=0.7.2
@@ -224,7 +224,7 @@ test-suite service-test
     , aeson-pretty
     , base
     , bytestring
-    , hedgehog                                          ^>=1.1.1
+    , hedgehog                                          ^>=1.2
     , hedgehog-quickcheck                               ^>=0.1.1
     , hspec                                             ^>=2.9.4
     , openapi3
@@ -239,7 +239,7 @@ test-suite service-test
     , tasty                                             ^>=1.4.1
     , tasty-discover                                    ^>=4.2.4
     , tasty-golden                                      ^>=2.3.5
-    , tasty-hedgehog                                    ^>=1.2.0
+    , tasty-hedgehog                                    ^>=1.4
     , tasty-hspec                                       ^>=1.2.0.1
     , tasty-hunit                                       ^>=0.10.0
     , text

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -119,7 +119,7 @@ library
     , logging-effect               ^>=1.3.13
     , megaparsec                   >=8.0.0    && <9.3.0
     , mmorph                       ^>=1.2.0
-    , mtl                          >=2.2.2    && <2.4.0
+    , mtl                          ^>=2.3.1
     , optics                       >=0.4      && <0.5.0
     , prettyprinter                >=1.7.1    && <1.8.0
     , prettyprinter-ansi-terminal  >=1.1.3    && <1.2.0
@@ -162,13 +162,13 @@ library primer-hedgehog
   build-depends:
     , base
     , containers
-    , hedgehog        ^>=1.1.1
+    , hedgehog        ^>=1.2
     , mmorph          ^>=1.2.0
     , mtl
     , primer
     , primer-testlib
     , tasty-discover  ^>=4.2.4
-    , tasty-hedgehog  ^>=1.2.0
+    , tasty-hedgehog  ^>=1.4
 
 library primer-testlib
   visibility:         public

--- a/primer/src/Foreword.hs
+++ b/primer/src/Foreword.hs
@@ -91,6 +91,8 @@ import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 
 import Control.Monad.Trans.Accum (AccumT (AccumT))
 
+import Control.Monad.Except (modifyError)
+
 -- | Insert an element at some index, returning `Nothing` if it is out of bounds.
 insertAt :: Int -> a -> [a] -> Maybe [a]
 insertAt n y xs =
@@ -118,10 +120,6 @@ findAndAdjustA :: Applicative m => (a -> Bool) -> (a -> m a) -> [a] -> m (Maybe 
 findAndAdjustA p f = \case
   [] -> pure Nothing
   x : xs -> if p x then Just . (: xs) <$> f x else (x :) <<$>> findAndAdjustA p f xs
-
--- | Change the type of an error.
-modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
-modifyError f = runExceptT >=> either (throwError . f) pure
 
 -- | @munless b x@ is `x` if `b` is 'False', otherwise it is 'mempty'.
 -- It's like 'Control.Monad.unless' but for Monoids rather than Applicatives.


### PR DESCRIPTION
Currently blocked on (at least):

* https://github.com/haskell-servant/servant/issues/1636
