### PR TITLE
feat: helper script to delete all sessions from local db

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -221,6 +221,7 @@
                   delete-local-db
                   dump-local-db
                   restore-local-db
+                  connect-local-db
                   delete-all-local-sessions
 
                   haskellPackages.implicit-hie
@@ -343,6 +344,7 @@
               restore-local-db
               primer-sqitch
               primer-pg-prove
+              connect-local-db
               delete-all-local-sessions;
 
             inherit primer;
@@ -515,6 +517,7 @@
             delete-local-db
             dump-local-db
             restore-local-db
+            connect-local-db
             delete-all-local-sessions
 
             sqitch
@@ -572,6 +575,7 @@
             delete-local-db
             dump-local-db
             restore-local-db
+            connect-local-db
             delete-all-local-sessions
 
             primer-sqitch

--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -205,6 +205,16 @@ in
     '';
   };
 
+  connect-local-db = writeShellApplication {
+    name = "connect-local-db";
+    runtimeInputs = [
+      postgresql
+    ];
+    text = ''
+      psql ${lib.primer.postgres-dev-primer-url} "$@"
+    '';
+  };
+
   delete-all-local-sessions = writeShellApplication {
     name = "delete-all-local-sessions";
     runtimeInputs = [


### PR DESCRIPTION
This is mainly intended as an aid for developers who are working on the "new session" workflow to be easily able to delete all their testing sessions. Note, however, that the script will simply delete all sessions (and not only the boring "testing" ones).

Included also is a script to open an interactive `psql` session.