### PR TITLE
Make Prog selection non-Maybe

### DIFF
--- a/primer/gen/Primer/Gen/App.hs
+++ b/primer/gen/Primer/Gen/App.hs
@@ -62,7 +62,7 @@ genProg sh initialImports = local (extendCxtByModules initialImports) $ do
     Prog
       { progImports = initialImports <> imports
       , progModules = home
-      , progSelection = Nothing
+      , progSelection = undefined
       , progSmartHoles = sh
       , progLog = defaultLog
       }

--- a/primer/src/Primer/Action/ProgError.hs
+++ b/primer/src/Primer/Action/ProgError.hs
@@ -10,8 +10,7 @@ import Primer.JSON (CustomJSON (..), PrimerJSON)
 import Primer.Name (Name)
 
 data ProgError
-  = NoDefSelected
-  | DefNotFound GVarName
+  = DefNotFound GVarName
   | DefAlreadyExists GVarName
   | DefInUse GVarName
   | TypeDefIsPrim TyConName

--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -19,7 +19,7 @@ import Primer.App (
   NodeType (..),
   Prog (..),
   ProgAction (BodyAction, MoveToDef),
-  ProgError (NoDefSelected),
+  ProgError (DefNotFound),
   Selection (..),
  )
 import Primer.Builtins (tNat)
@@ -125,7 +125,7 @@ fixtures =
             , astTypeDefNameHints = []
             }
       progerror :: ProgError
-      progerror = NoDefSelected
+      progerror = DefNotFound $ qualifyName modName defName
       progaction :: ProgAction
       progaction = MoveToDef $ gvn ["M"] "main"
       modName = ModuleName ["M"]
@@ -139,7 +139,7 @@ fixtures =
                   , moduleDefs = Map.singleton defName (DefAST def)
                   }
               ]
-          , progSelection = Just selection
+          , progSelection = selection
           , progSmartHoles = SmartHoles
           , progLog = log
           }

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -746,7 +746,7 @@ unit_tcWholeProg_notice_type_updates =
           { progImports = [builtinModule]
           , progModules = [Module (ModuleName ["M"]) mempty ds]
           , progSmartHoles = SmartHoles
-          , progSelection = Nothing
+          , progSelection = undefined
           , progLog = defaultLog
           }
       a0 = mkProg d0


### PR DESCRIPTION
We've been discussing what to display in our frontend's action panel when there's no selection (https://github.com/hackworthltd/primer-app/pull/617#discussion_r1019350047). But what if we just made it so that this couldn't happen?

The remaining `undefined`s here represent the places where this might be problematic. I'm sure it's possible to overcome them all, but _maybe_ not desirable. Let's discuss. I'll comment on the interesting ones. The rest are just tests.

This code was quickly hacked together, and I'm sure a few things need cleaning up if we do decide to use it. At least, there are some variables beginning with "m" which should be renamed now that their types have changed.