### PR TITLE
fix: Fix `benchmark-action.yaml` workflow.

### DIFF
--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -1,4 +1,4 @@
-Name: Benchmark regression checks
+name: Benchmark regression checks
 
 on:
   push:


### PR DESCRIPTION
This is really disappointing: I had accidentally capitalized the `name` property of the workflow (as `Name`), and it failed, despite the fact that we run a GitHub Action linting step in `pre-commit-hooks`, and I think GitHub is supposed to lint these, as well.