### PR TITLE
fix: Another fix for `benchmark-action.yaml` workflow.

### DIFF
--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
       deployments: write
 


### PR DESCRIPTION
The `contents` permission needs to be `write` to enable this to push to the `gh-pages` branch of the repo.