### PR TITLE
feat!: bound pageSize, rather than clamp

### DIFF
--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -13,6 +13,7 @@ category:      Web
 library
   exposed-modules:
     Primer.Client
+    Primer.Finite
     Primer.OpenAPI
     Primer.Pagination
     Primer.Servant.API
@@ -41,6 +42,7 @@ library
     , containers                 >=0.6.0.1  && <0.7
     , deriving-aeson             >=0.2      && <0.3.0
     , exceptions                 >=0.10.4   && <0.11.0
+    , extra                      >=1.7.10   && <1.8.0
     , http-client                ^>=0.7.13
     , http-media                 >=0.8      && <0.9.0
     , logging-effect             ^>=1.3.13
@@ -48,6 +50,7 @@ library
     , openapi3                   >=3.2      && <3.3.0
     , optics                     >=0.4      && <0.5.0
     , primer                     ^>=0.7.2
+    , refined                    ^>=0.8
     , servant                    >=0.18     && <0.20.0
     , servant-client             >=0.18     && <0.20.0
     , servant-client-core        >=0.18     && <0.20.0

--- a/primer-service/src/Primer/Finite.hs
+++ b/primer-service/src/Primer/Finite.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module Primer.Finite (Finite, getFinite, packFinite) where
+
+import Foreword
+
+import Data.Either.Extra (eitherToMaybe)
+import Data.OpenApi (ToParamSchema (toParamSchema))
+import GHC.TypeLits (type (<=))
+import Numeric.Natural (Natural)
+import Optics ((?~))
+import Refined (FromTo, Refined, refine, unrefine)
+import Servant (FromHttpApiData (parseUrlPiece), ToHttpApiData (toUrlPiece))
+
+newtype Finite l u = Finite {unFinite :: Refined (FromTo l u) Natural}
+
+getFinite :: Finite l u -> Natural
+getFinite = unrefine . unFinite
+
+packFinite :: (KnownNat l, KnownNat u, l <= u) => Natural -> Maybe (Finite l u)
+packFinite = fmap Finite . eitherToMaybe . refine
+
+instance (KnownNat l, KnownNat u) => ToParamSchema (Finite l u) where
+  toParamSchema _ =
+    toParamSchema (Proxy @Natural)
+      & #minimum ?~ fromIntegral (natVal $ Proxy @l)
+      & #exclusiveMinimum ?~ False
+      & #maximum ?~ fromIntegral (natVal $ Proxy @u)
+      & #exclusiveMaximum ?~ False
+
+instance (KnownNat l, KnownNat u, l <= u) => FromHttpApiData (Finite l u) where
+  parseUrlPiece x = do
+    y <- parseUrlPiece x
+    let z = packFinite y
+    let r = "[" <> show (natVal $ Proxy @l) <> "," <> show (natVal $ Proxy @u) <> "]"
+    maybeToEither ("Value outside the range " <> r <> ": " <> x) z
+
+instance ToHttpApiData (Finite l u) where
+  toUrlPiece = toUrlPiece . getFinite

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -67,7 +67,7 @@ import Primer.Database qualified as Database (
  )
 import Primer.Eval (EvalLog)
 import Primer.Log (ConvertLogMessage, logWarning)
-import Primer.Pagination (pagedDefaultClamp)
+import Primer.Pagination (pagedDefault)
 import Primer.Servant.API qualified as S
 import Primer.Servant.OpenAPI qualified as OpenAPI
 import Servant (
@@ -109,7 +109,7 @@ openAPISessionsServer :: ConvertServerLogs l => OpenAPI.SessionsAPI (AsServerT (
 openAPISessionsServer =
   OpenAPI.SessionsAPI
     { OpenAPI.createSession = newSession
-    , OpenAPI.getSessionList = \b p -> pagedDefaultClamp 100 p $ listSessions b
+    , OpenAPI.getSessionList = \b p -> pagedDefault 100 p $ listSessions b
     , OpenAPI.sessionAPI = openAPISessionServer
     }
 
@@ -148,7 +148,7 @@ sessionsAPIServer :: ConvertServerLogs l => S.SessionsAPI (AsServerT (Primer l))
 sessionsAPIServer =
   S.SessionsAPI
     { S.createSession = newSession
-    , S.getSessionList = \b p -> pagedDefaultClamp 100 p $ listSessions b
+    , S.getSessionList = \b p -> pagedDefault 100 p $ listSessions b
     , S.addSession = API.addSession
     , S.sessionAPI = sessionAPIServer
     }

--- a/primer-service/test/Tests/Pagination.hs
+++ b/primer-service/test/Tests/Pagination.hs
@@ -18,6 +18,7 @@ import Primer.Database.Rel8.Test.Util (
   mkSessionRow,
   runTmpDb,
  )
+import Primer.Finite (packFinite)
 import Primer.Pagination (
   Pagination (Pagination, page, size),
   firstPage,
@@ -29,7 +30,7 @@ import Primer.Pagination (
   mkPositive,
   nextPage,
   pageSize,
-  pagedDefaultClamp,
+  pagedDefault,
   prevPage,
   thisPage,
   totalItems,
@@ -53,21 +54,21 @@ test_pagination = testCaseSteps "pagination" $ \step' ->
     let expectedRows = map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
     step "Get all, paged"
     onePos <- maybe (assertFailure "1 is positive") pure $ mkPositive 1
-    pAllPaged <- pagedDefaultClamp (m + 2) (Pagination{page = onePos, size = Nothing}) listSessions
+    pAllPaged <- pagedDefault (m + 2) (Pagination{page = onePos, size = Nothing}) listSessions
     getMeta pAllPaged @?= (m, m + 2, 1, Nothing, 1, Nothing, 1)
     items pAllPaged @?= expectedRows
     step "Get 25, paged"
-    p25Paged <- pagedDefaultClamp (m + 2) (Pagination{page = onePos, size = mkPositive 25}) listSessions
+    p25Paged <- pagedDefault (m + 2) (Pagination{page = onePos, size = packFinite 25}) listSessions
     getMeta p25Paged @?= (m, 25, 1, Nothing, 1, Just 2, 14)
     items p25Paged @?= take 25 expectedRows
     step "Get 76-100, paged"
     fourPos <- maybe (assertFailure "4 is positive") pure $ mkPositive 4
-    p75Paged <- pagedDefaultClamp (m + 2) (Pagination{page = fourPos, size = mkPositive 25}) listSessions
+    p75Paged <- pagedDefault (m + 2) (Pagination{page = fourPos, size = packFinite 25}) listSessions
     getMeta p75Paged @?= (m, 25, 1, Just 3, 4, Just 5, 14)
     items p75Paged @?= take 25 (drop 75 expectedRows)
     step "Get crossing end, paged"
     fourteenPos <- maybe (assertFailure "14 is positive") pure $ mkPositive 14
-    pLastPaged <- pagedDefaultClamp (m + 2) (Pagination{page = fourteenPos, size = mkPositive 25}) listSessions
+    pLastPaged <- pagedDefault (m + 2) (Pagination{page = fourteenPos, size = packFinite 25}) listSessions
     getMeta pLastPaged @?= (m, 25, 1, Just 13, 14, Nothing, 14)
     items pLastPaged @?= drop 325 expectedRows
   where

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -575,9 +575,10 @@
                         "name": "pageSize",
                         "required": false,
                         "schema": {
-                            "exclusiveMinimum": true,
-                            "maximum": 9223372036854775807,
-                            "minimum": 0,
+                            "exclusiveMaximum": false,
+                            "exclusiveMinimum": false,
+                            "maximum": 100,
+                            "minimum": 1,
                             "type": "integer"
                         }
                     }


### PR DESCRIPTION
We enforce that the requested page size is between 1 and 100 (inclusive), rather than clamping the upper bound of this range.

BREAKING CHANGE: this modifies the api to accept fewer requests, and changes the OpenAPI schema accordingly.