### PR TITLE
feat!: Add a session name parameter to the `createSession` API.

### DIFF
--- a/primer-service/src/Primer/Client.hs
+++ b/primer-service/src/Primer/Client.hs
@@ -86,8 +86,8 @@ flushSessions :: ClientM ()
 flushSessions = void $ apiClient // API.adminAPI // API.flushSessions
 
 -- | As 'Primer.API.createSession'.
-createSession :: ClientM SessionId
-createSession = apiClient // API.sessionsAPI // API.createSession
+createSession :: Text -> ClientM SessionId
+createSession name = apiClient // API.sessionsAPI // API.createSession /: name
 
 -- | As 'Primer.API.listSessions'.
 listSessions :: Bool -> Pagination -> ClientM (Paginated Session)

--- a/primer-service/src/Primer/Servant/Types.hs
+++ b/primer-service/src/Primer/Servant/Types.hs
@@ -63,6 +63,12 @@ type GetVersion mode =
 type CreateSession mode =
   mode
     :- Summary "Create a new session and return its ID"
+      :> Description
+          "Create a new session with the name provided in the request body, \
+          \and return the new session's ID. Note that the new session's actual \
+          \name may differ from the name provided in the body, if the requested \
+          \name is invalid."
+      :> ReqBody '[JSON] Text
       :> OperationId "createSession"
       :> Post '[JSON] SessionId
 

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -656,7 +656,17 @@
                 "summary": "Get the list of sessions"
             },
             "post": {
+                "description": "Create a new session with the name provided in the request body, and return the new session's ID. Note that the new session's actual name may differ from the name provided in the body, if the requested name is invalid.",
                 "operationId": "createSession",
+                "requestBody": {
+                    "content": {
+                        "application/json;charset=utf-8": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
                         "content": {
@@ -667,6 +677,9 @@
                             }
                         },
                         "description": ""
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
                     }
                 },
                 "summary": "Create a new session and return its ID"

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -163,7 +163,6 @@ import Primer.Database (
   SessionName,
   Sessions,
   Version,
-  defaultSessionName,
   fromSessionName,
   getCurrentTime,
   newSessionId,
@@ -400,11 +399,17 @@ leftResultError :: (ReqResp a (Either e b) -> APILog) -> ReqResp a (Either e b) 
 leftResultError c r@(Resp (Left _)) = (Warning, c r)
 leftResultError c r = (Informational, c r)
 
--- | Create a new session and return the session ID.
+-- | Create a new session with the proposed session name as 'Text',
+-- and return the session ID.
 --
 -- The session's initial program is 'newApp'.
-newSession :: (MonadIO m, MonadAPILog l m) => PrimerM m SessionId
-newSession = logAPI' NewSession $ addSession' defaultSessionName newApp
+--
+-- If the given session name is invalid, it will be replaced iwth a
+-- default session name. However, no indication is given to teh caller
+-- when this occurs. Query the returned session ID to determine the
+-- actual session name that was assigned.
+newSession :: (MonadIO m, MonadAPILog l m) => Text -> PrimerM m SessionId
+newSession n = logAPI' NewSession $ addSession n newApp
 
 -- | Given an 'App' and a proposed session name as 'Text', create a
 -- new session with the given app and name, and return the session ID.


### PR DESCRIPTION
This saves a silly round-trip in almost every scenario, as it's extremely likely that the first thing you'll want to do after creating a default-named session is to rename it.

This is an API-breaking change.