### PR TITLE
fix: Re-generate `hie.yaml`.

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,2 +1,40 @@
 cradle:
   cabal:
+    - path: "primer/src"
+      component: "lib:primer"
+
+    - path: "primer/gen"
+      component: "primer:lib:primer-hedgehog"
+
+    - path: "primer/testlib"
+      component: "primer:lib:primer-testlib"
+
+    - path: "primer/test"
+      component: "primer:test:primer-test"
+
+    - path: "primer-benchmark/src/Main.hs"
+      component: "primer-benchmark:bench:primer-benchmark"
+
+    - path: "primer-rel8/src"
+      component: "lib:primer-rel8"
+
+    - path: "primer-rel8/testlib"
+      component: "primer-rel8:lib:primer-rel8-testlib"
+
+    - path: "primer-rel8/test"
+      component: "primer-rel8:test:primer-rel8-test"
+
+    - path: "primer-service/src"
+      component: "lib:primer-service"
+
+    - path: "primer-service/exe-server/Main.hs"
+      component: "primer-service:exe:primer-service"
+
+    - path: "primer-service/exe-client/Main.hs"
+      component: "primer-service:exe:primer-client"
+
+    - path: "primer-service/exe-openapi/Main.hs"
+      component: "primer-service:exe:primer-openapi"
+
+    - path: "primer-service/test"
+      component: "primer-service:test:service-test"


### PR DESCRIPTION
This file was inadvertently gutted in
b4d4dbd8301f3b35117bd3a0d52119bfaeba08ee, when we started using
`implicit-hie` from haskell.nix's tools.
