### PR TITLE
fix: Wrap new session name in a record.

### DIFF
--- a/primer-service/src/Primer/Client.hs
+++ b/primer-service/src/Primer/Client.hs
@@ -25,6 +25,9 @@ module Primer.Client (
 import Foreword
 
 import Data.String (String)
+import Primer.API (
+  NewSessionReq,
+ )
 import Primer.App (
   App,
   EvalFullReq,
@@ -86,8 +89,8 @@ flushSessions :: ClientM ()
 flushSessions = void $ apiClient // API.adminAPI // API.flushSessions
 
 -- | As 'Primer.API.createSession'.
-createSession :: Text -> ClientM SessionId
-createSession name = apiClient // API.sessionsAPI // API.createSession /: name
+createSession :: NewSessionReq -> ClientM SessionId
+createSession req = apiClient // API.sessionsAPI // API.createSession /: req
 
 -- | As 'Primer.API.listSessions'.
 listSessions :: Bool -> Pagination -> ClientM (Paginated Session)

--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -42,6 +42,7 @@ import Primer.API (
   EvalFullResp,
   ExprTreeOpts,
   Module,
+  NewSessionReq,
   NodeBody,
   NodeFlavor,
   NodeSelection (..),
@@ -138,6 +139,8 @@ deriving via PrimerJSON Selection instance ToSchema Selection
 deriving via PrimerJSON NodeSelection instance ToSchema NodeSelection
 deriving via PrimerJSON NodeType instance ToSchema NodeType
 deriving via PrimerJSON Level instance ToSchema Level
+deriving via PrimerJSON NewSessionReq instance ToSchema NewSessionReq
+
 deriving instance ToParamSchema Available.NoInputAction
 instance FromHttpApiData Available.NoInputAction where
   parseQueryParam = parseQueryParamRead "action"

--- a/primer-service/src/Primer/Servant/Types.hs
+++ b/primer-service/src/Primer/Servant/Types.hs
@@ -11,6 +11,9 @@ module Primer.Servant.Types (
 
 import Foreword
 
+import Primer.API (
+  NewSessionReq,
+ )
 import Primer.Database (
   Session,
   SessionId,
@@ -68,7 +71,7 @@ type CreateSession mode =
           \and return the new session's ID. Note that the new session's actual \
           \name may differ from the name provided in the body, if the requested \
           \name is invalid."
-      :> ReqBody '[JSON] Text
+      :> ReqBody '[JSON] NewSessionReq
       :> OperationId "createSession"
       :> Post '[JSON] SessionId
 

--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -28,6 +28,7 @@ import Primer.API (
   Def (Def),
   EvalFullResp (EvalFullRespNormal, EvalFullRespTimedOut),
   Module (Module),
+  NewSessionReq (..),
   NodeBody (BoxBody, NoBody, TextBody),
   NodeFlavor,
   NodeSelection (..),
@@ -300,3 +301,5 @@ instance Arbitrary EvalFullResp where
   arbitrary = elements [EvalFullRespNormal, EvalFullRespTimedOut] <*> hedgehog (evalExprGen 0 genExprTree)
 instance Arbitrary CreateTypeDefBody where
   arbitrary = CreateTypeDefBody <$> arbitrary <*> arbitrary <*> arbitrary
+instance Arbitrary NewSessionReq where
+  arbitrary = NewSessionReq <$> arbitrary

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -232,6 +232,17 @@
                 ],
                 "type": "object"
             },
+            "NewSessionReq": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "type": "object"
+            },
             "NoInputAction": {
                 "enum": [
                     "MakeCase",
@@ -662,7 +673,7 @@
                     "content": {
                         "application/json;charset=utf-8": {
                             "schema": {
-                                "type": "string"
+                                "$ref": "#/components/schemas/NewSessionReq"
                             }
                         }
                     }

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -23,6 +23,7 @@ module Primer.API (
   APILog (..),
   MonadAPILog,
   PrimerErr (..),
+  NewSessionReq (..),
   newSession,
   addSession,
   copySession,
@@ -399,8 +400,19 @@ leftResultError :: (ReqResp a (Either e b) -> APILog) -> ReqResp a (Either e b) 
 leftResultError c r@(Resp (Left _)) = (Warning, c r)
 leftResultError c r = (Informational, c r)
 
--- | Create a new session with the proposed session name as 'Text',
--- and return the session ID.
+-- | A new session request.
+
+{- HLINT ignore NewSessionReq "Use newtype instead of data" -}
+data NewSessionReq = NewSessionReq
+  { name :: Text
+  -- ^ The name of the new session. Note that this field is just a
+  -- hint: the API may choose a different name if the given name is
+  -- invalid.
+  }
+  deriving (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON) via PrimerJSON NewSessionReq
+
+-- | Create a new session and return its ID.
 --
 -- The session's initial program is 'newApp'.
 --
@@ -408,8 +420,8 @@ leftResultError c r = (Informational, c r)
 -- default session name. However, no indication is given to teh caller
 -- when this occurs. Query the returned session ID to determine the
 -- actual session name that was assigned.
-newSession :: (MonadIO m, MonadAPILog l m) => Text -> PrimerM m SessionId
-newSession n = logAPI' NewSession $ addSession n newApp
+newSession :: (MonadIO m, MonadAPILog l m) => NewSessionReq -> PrimerM m SessionId
+newSession (NewSessionReq n) = logAPI' NewSession $ addSession n newApp
 
 -- | Given an 'App' and a proposed session name as 'Text', create a
 -- new session with the given app and name, and return the session ID.


### PR DESCRIPTION
This fixes an Axios issue when making requests against our HTTP API.

Prior to this change, the Servant type for this endpoint specified
`ReqBody '[JSON] Text`, but per RFC4627, this is an invalid JSON
encoding. Servant doesn't care, nor does Orval when it generates API
bindings from our OpenAPI spec, but in my testing, Axios always
specifies `Content-Type: application/x-www-form-urlencoded` and
ignores Orval's JSON encoding request. This, in turn, results in "415
Unsupported media type" responses from our service, which is expecting
`Content-Type: application/json`.

I believe we could also have fixed this issue by using `PlainText`
rather than `JSON` in the Servant type, but we'll eventually want to
add additional session creation parameters (e.g., whether to include
builtin types and functions), so we might as well keep using `JSON`.

ref:
https://stackoverflow.com/questions/13318420/is-a-single-string-value-considered-valid-json
