### PR TITLE
feat!: Use structured text for names in trees, instead of hardcoding dot

### DIFF
--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -50,6 +50,7 @@ import Primer.API (
   Selection (..),
   Tree,
  )
+import Primer.API qualified as API
 import Primer.Action.Available qualified as Available
 import Primer.App (NodeType)
 import Primer.App.Base (Level)
@@ -59,6 +60,7 @@ import Primer.Core (
   ID (..),
   LVarName,
   ModuleName,
+  PrimCon,
  )
 import Primer.Database (
   LastModified,
@@ -121,6 +123,8 @@ deriving via GlobalName 'ADefName instance ToSchema (GlobalName 'AValCon)
 
 deriving via Name instance (ToSchema LVarName)
 deriving via PrimerJSON Tree instance ToSchema Tree
+deriving via PrimerJSON API.Name instance ToSchema API.Name
+deriving via PrimerJSON PrimCon instance ToSchema PrimCon
 deriving via PrimerJSON NodeBody instance ToSchema NodeBody
 deriving via PrimerJSON NodeFlavor instance ToSchema NodeFlavor
 deriving via PrimerJSON Def instance ToSchema Def

--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -48,6 +48,7 @@ import Primer.Database (
   safeMkSessionName,
  )
 import Primer.Gen.API (genExprTreeOpts)
+import Primer.Gen.API qualified as API
 import Primer.Gen.Core.Raw (
   ExprGen,
   evalExprGen,
@@ -171,7 +172,7 @@ tasty_NodeBody :: Property
 tasty_NodeBody =
   testToJSON $
     G.choice
-      [ TextBody <$> G.text (R.linear 1 20) G.unicode
+      [ TextBody <$> API.genName
       , BoxBody <$> genTree
       , pure NoBody
       ]

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -232,6 +232,24 @@
                 ],
                 "type": "object"
             },
+            "Name": {
+                "properties": {
+                    "baseName": {
+                        "type": "string"
+                    },
+                    "qualifiedModule": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "baseName"
+                ],
+                "type": "object"
+            },
             "NewSessionReq": {
                 "properties": {
                     "name": {
@@ -270,11 +288,29 @@
                     {
                         "properties": {
                             "contents": {
-                                "type": "string"
+                                "$ref": "#/components/schemas/Name"
                             },
                             "tag": {
                                 "enum": [
                                     "TextBody"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/PrimCon"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "PrimBody"
                                 ],
                                 "type": "string"
                             }
@@ -481,6 +517,50 @@
                 "required": [
                     "meta",
                     "items"
+                ],
+                "type": "object"
+            },
+            "PrimCon": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "contents": {
+                                "example": "?",
+                                "maxLength": 1,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "PrimChar"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "type": "integer"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "PrimInt"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
+                    }
                 ],
                 "type": "object"
             },

--- a/primer/gen/Primer/Gen/API.hs
+++ b/primer/gen/Primer/Gen/API.hs
@@ -1,14 +1,27 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Primer.Gen.API (
   genExprTreeOpts,
+  genName,
 ) where
 
 import Foreword
 
 import Hedgehog (MonadGen)
+import Hedgehog.Gen qualified as G
 import Hedgehog.Gen qualified as Gen
-import Primer.API (ExprTreeOpts (..))
+import Hedgehog.Range qualified as R
+import Primer.API (ExprTreeOpts (..), Name (..))
+import Primer.Gen.Core.Raw qualified as Raw
+import Primer.Name (unsafeMkName)
 
 genExprTreeOpts :: MonadGen m => m ExprTreeOpts
 genExprTreeOpts = do
   patternsUnder <- Gen.bool
   pure ExprTreeOpts{patternsUnder}
+
+genName :: MonadGen m => m Name
+genName = do
+  baseName <- unsafeMkName <$> G.text (R.linear 1 20) G.unicode
+  qualifiedModule <- G.maybe Raw.genModuleName
+  pure Name{..}

--- a/primer/test/outputs/APITree/Expr
+++ b/primer/test/outputs/APITree/Expr
@@ -1,19 +1,37 @@
 Tree
     { nodeId = "9"
     , flavor = FlavorLet
-    , body = TextBody "x"
+    , body = TextBody
+        ( Name
+            { qualifiedModule = Nothing
+            , baseName = "x"
+            }
+        )
     , childTrees =
         [ Tree
             { nodeId = "10"
             , flavor = FlavorCon
-            , body = TextBody "Builtins.True"
+            , body = TextBody
+                ( Name
+                    { qualifiedModule = Just
+                        ( ModuleName
+                            { unModuleName = "Builtins" :| [] }
+                        )
+                    , baseName = "True"
+                    }
+                )
             , childTrees = []
             , rightChild = Nothing
             }
         , Tree
             { nodeId = "11"
             , flavor = FlavorLetrec
-            , body = TextBody "y"
+            , body = TextBody
+                ( Name
+                    { qualifiedModule = Nothing
+                    , baseName = "y"
+                    }
+                )
             , childTrees =
                 [ Tree
                     { nodeId = "12"
@@ -28,7 +46,15 @@ Tree
                                 [ Tree
                                     { nodeId = "14"
                                     , flavor = FlavorCon
-                                    , body = TextBody "Builtins.Just"
+                                    , body = TextBody
+                                        ( Name
+                                            { qualifiedModule = Just
+                                                ( ModuleName
+                                                    { unModuleName = "Builtins" :| [] }
+                                                )
+                                            , baseName = "Just"
+                                            }
+                                        )
                                     , childTrees = []
                                     , rightChild = Nothing
                                     }
@@ -43,7 +69,15 @@ Tree
                                 [ Tree
                                     { nodeId = "16"
                                     , flavor = FlavorGlobalVar
-                                    , body = TextBody "M.unboundName"
+                                    , body = TextBody
+                                        ( Name
+                                            { qualifiedModule = Just
+                                                ( ModuleName
+                                                    { unModuleName = "M" :| [] }
+                                                )
+                                            , baseName = "unboundName"
+                                            }
+                                        )
                                     , childTrees = []
                                     , rightChild = Nothing
                                     }
@@ -61,7 +95,15 @@ Tree
                         [ Tree
                             { nodeId = "18"
                             , flavor = FlavorTCon
-                            , body = TextBody "Builtins.Maybe"
+                            , body = TextBody
+                                ( Name
+                                    { qualifiedModule = Just
+                                        ( ModuleName
+                                            { unModuleName = "Builtins" :| [] }
+                                        )
+                                    , baseName = "Maybe"
+                                    }
+                                )
                             , childTrees = []
                             , rightChild = Nothing
                             }
@@ -76,12 +118,22 @@ Tree
                         [ Tree
                             { nodeId = "20"
                             , flavor = FlavorLam
-                            , body = TextBody "i"
+                            , body = TextBody
+                                ( Name
+                                    { qualifiedModule = Nothing
+                                    , baseName = "i"
+                                    }
+                                )
                             , childTrees =
                                 [ Tree
                                     { nodeId = "21"
                                     , flavor = FlavorLAM
-                                    , body = TextBody "β"
+                                    , body = TextBody
+                                        ( Name
+                                            { qualifiedModule = Nothing
+                                            , baseName = "β"
+                                            }
+                                        )
                                     , childTrees =
                                         [ Tree
                                             { nodeId = "22"
@@ -96,7 +148,12 @@ Tree
                                                         [ Tree
                                                             { nodeId = "24"
                                                             , flavor = FlavorLetType
-                                                            , body = TextBody "b"
+                                                            , body = TextBody
+                                                                ( Name
+                                                                    { qualifiedModule = Nothing
+                                                                    , baseName = "b"
+                                                                    }
+                                                                )
                                                             , childTrees =
                                                                 [ Tree
                                                                     { nodeId = "26"
@@ -106,26 +163,49 @@ Tree
                                                                         [ Tree
                                                                             { nodeId = "27"
                                                                             , flavor = FlavorCon
-                                                                            , body = TextBody "Builtins.Left"
+                                                                            , body = TextBody
+                                                                                ( Name
+                                                                                    { qualifiedModule = Just
+                                                                                        ( ModuleName
+                                                                                            { unModuleName = "Builtins" :| [] }
+                                                                                        )
+                                                                                    , baseName = "Left"
+                                                                                    }
+                                                                                )
                                                                             , childTrees = []
                                                                             , rightChild = Nothing
                                                                             }
                                                                         , Tree
                                                                             { nodeId = "28"
                                                                             , flavor = FlavorTLet
-                                                                            , body = TextBody "c"
+                                                                            , body = TextBody
+                                                                                ( Name
+                                                                                    { qualifiedModule = Nothing
+                                                                                    , baseName = "c"
+                                                                                    }
+                                                                                )
                                                                             , childTrees =
                                                                                 [ Tree
                                                                                     { nodeId = "29"
                                                                                     , flavor = FlavorTVar
-                                                                                    , body = TextBody "b"
+                                                                                    , body = TextBody
+                                                                                        ( Name
+                                                                                            { qualifiedModule = Nothing
+                                                                                            , baseName = "b"
+                                                                                            }
+                                                                                        )
                                                                                     , childTrees = []
                                                                                     , rightChild = Nothing
                                                                                     }
                                                                                 , Tree
                                                                                     { nodeId = "30"
                                                                                     , flavor = FlavorTVar
-                                                                                    , body = TextBody "c"
+                                                                                    , body = TextBody
+                                                                                        ( Name
+                                                                                            { qualifiedModule = Nothing
+                                                                                            , baseName = "c"
+                                                                                            }
+                                                                                        )
                                                                                     , childTrees = []
                                                                                     , rightChild = Nothing
                                                                                     }
@@ -138,7 +218,15 @@ Tree
                                                                 , Tree
                                                                     { nodeId = "25"
                                                                     , flavor = FlavorTCon
-                                                                    , body = TextBody "Builtins.Bool"
+                                                                    , body = TextBody
+                                                                        ( Name
+                                                                            { qualifiedModule = Just
+                                                                                ( ModuleName
+                                                                                    { unModuleName = "Builtins" :| [] }
+                                                                                )
+                                                                            , baseName = "Bool"
+                                                                            }
+                                                                        )
                                                                     , childTrees = []
                                                                     , rightChild = Nothing
                                                                     }
@@ -148,7 +236,12 @@ Tree
                                                         , Tree
                                                             { nodeId = "31"
                                                             , flavor = FlavorTVar
-                                                            , body = TextBody "β"
+                                                            , body = TextBody
+                                                                ( Name
+                                                                    { qualifiedModule = Nothing
+                                                                    , baseName = "β"
+                                                                    }
+                                                                )
                                                             , childTrees = []
                                                             , rightChild = Nothing
                                                             }
@@ -163,7 +256,12 @@ Tree
                                                         [ Tree
                                                             { nodeId = "33"
                                                             , flavor = FlavorLocalVar
-                                                            , body = TextBody "i"
+                                                            , body = TextBody
+                                                                ( Name
+                                                                    { qualifiedModule = Nothing
+                                                                    , baseName = "i"
+                                                                    }
+                                                                )
                                                             , childTrees = []
                                                             , rightChild = Nothing
                                                             }
@@ -176,7 +274,15 @@ Tree
                                                                 ( Tree
                                                                     { nodeId = "32P0B"
                                                                     , flavor = FlavorPatternCon
-                                                                    , body = TextBody "Builtins.Zero"
+                                                                    , body = TextBody
+                                                                        ( Name
+                                                                            { qualifiedModule = Just
+                                                                                ( ModuleName
+                                                                                    { unModuleName = "Builtins" :| [] }
+                                                                                )
+                                                                            , baseName = "Zero"
+                                                                            }
+                                                                        )
                                                                     , childTrees = []
                                                                     , rightChild = Nothing
                                                                     }
@@ -185,7 +291,15 @@ Tree
                                                                 [ Tree
                                                                     { nodeId = "34"
                                                                     , flavor = FlavorCon
-                                                                    , body = TextBody "Builtins.False"
+                                                                    , body = TextBody
+                                                                        ( Name
+                                                                            { qualifiedModule = Just
+                                                                                ( ModuleName
+                                                                                    { unModuleName = "Builtins" :| [] }
+                                                                                )
+                                                                            , baseName = "False"
+                                                                            }
+                                                                        )
                                                                     , childTrees = []
                                                                     , rightChild = Nothing
                                                                     }
@@ -203,14 +317,27 @@ Tree
                                                                                 [ Tree
                                                                                     { nodeId = "32P1B"
                                                                                     , flavor = FlavorPatternCon
-                                                                                    , body = TextBody "Builtins.Succ"
+                                                                                    , body = TextBody
+                                                                                        ( Name
+                                                                                            { qualifiedModule = Just
+                                                                                                ( ModuleName
+                                                                                                    { unModuleName = "Builtins" :| [] }
+                                                                                                )
+                                                                                            , baseName = "Succ"
+                                                                                            }
+                                                                                        )
                                                                                     , childTrees = []
                                                                                     , rightChild = Nothing
                                                                                     }
                                                                                 , Tree
                                                                                     { nodeId = "35"
                                                                                     , flavor = FlavorPatternBind
-                                                                                    , body = TextBody "n"
+                                                                                    , body = TextBody
+                                                                                        ( Name
+                                                                                            { qualifiedModule = Nothing
+                                                                                            , baseName = "n"
+                                                                                            }
+                                                                                        )
                                                                                     , childTrees = []
                                                                                     , rightChild = Nothing
                                                                                     }
@@ -239,7 +366,12 @@ Tree
                                                                                         , Tree
                                                                                             { nodeId = "39"
                                                                                             , flavor = FlavorLocalVar
-                                                                                            , body = TextBody "x"
+                                                                                            , body = TextBody
+                                                                                                ( Name
+                                                                                                    { qualifiedModule = Nothing
+                                                                                                    , baseName = "x"
+                                                                                                    }
+                                                                                                )
                                                                                             , childTrees = []
                                                                                             , rightChild = Nothing
                                                                                             }
@@ -249,7 +381,12 @@ Tree
                                                                                 , Tree
                                                                                     { nodeId = "40"
                                                                                     , flavor = FlavorLocalVar
-                                                                                    , body = TextBody "y"
+                                                                                    , body = TextBody
+                                                                                        ( Name
+                                                                                            { qualifiedModule = Nothing
+                                                                                            , baseName = "y"
+                                                                                            }
+                                                                                        )
                                                                                     , childTrees = []
                                                                                     , rightChild = Nothing
                                                                                     }
@@ -280,14 +417,27 @@ Tree
                                 [ Tree
                                     { nodeId = "42"
                                     , flavor = FlavorTCon
-                                    , body = TextBody "Builtins.Nat"
+                                    , body = TextBody
+                                        ( Name
+                                            { qualifiedModule = Just
+                                                ( ModuleName
+                                                    { unModuleName = "Builtins" :| [] }
+                                                )
+                                            , baseName = "Nat"
+                                            }
+                                        )
                                     , childTrees = []
                                     , rightChild = Nothing
                                     }
                                 , Tree
                                     { nodeId = "43"
                                     , flavor = FlavorTForall
-                                    , body = TextBody "α"
+                                    , body = TextBody
+                                        ( Name
+                                            { qualifiedModule = Nothing
+                                            , baseName = "α"
+                                            }
+                                        )
                                     , childTrees =
                                         [ Tree
                                             { nodeId = "44"
@@ -302,14 +452,30 @@ Tree
                                                         [ Tree
                                                             { nodeId = "46"
                                                             , flavor = FlavorTCon
-                                                            , body = TextBody "Builtins.Either"
+                                                            , body = TextBody
+                                                                ( Name
+                                                                    { qualifiedModule = Just
+                                                                        ( ModuleName
+                                                                            { unModuleName = "Builtins" :| [] }
+                                                                        )
+                                                                    , baseName = "Either"
+                                                                    }
+                                                                )
                                                             , childTrees = []
                                                             , rightChild = Nothing
                                                             }
                                                         , Tree
                                                             { nodeId = "47"
                                                             , flavor = FlavorTCon
-                                                            , body = TextBody "Builtins.Bool"
+                                                            , body = TextBody
+                                                                ( Name
+                                                                    { qualifiedModule = Just
+                                                                        ( ModuleName
+                                                                            { unModuleName = "Builtins" :| [] }
+                                                                        )
+                                                                    , baseName = "Bool"
+                                                                    }
+                                                                )
                                                             , childTrees = []
                                                             , rightChild = Nothing
                                                             }
@@ -319,7 +485,12 @@ Tree
                                                 , Tree
                                                     { nodeId = "48"
                                                     , flavor = FlavorTVar
-                                                    , body = TextBody "α"
+                                                    , body = TextBody
+                                                        ( Name
+                                                            { qualifiedModule = Nothing
+                                                            , baseName = "α"
+                                                            }
+                                                        )
                                                     , childTrees = []
                                                     , rightChild = Nothing
                                                     }

--- a/primer/test/outputs/APITree/Type
+++ b/primer/test/outputs/APITree/Type
@@ -6,14 +6,27 @@ Tree
         [ Tree
             { nodeId = "1"
             , flavor = FlavorTCon
-            , body = TextBody "Builtins.Nat"
+            , body = TextBody
+                ( Name
+                    { qualifiedModule = Just
+                        ( ModuleName
+                            { unModuleName = "Builtins" :| [] }
+                        )
+                    , baseName = "Nat"
+                    }
+                )
             , childTrees = []
             , rightChild = Nothing
             }
         , Tree
             { nodeId = "2"
             , flavor = FlavorTForall
-            , body = TextBody "a"
+            , body = TextBody
+                ( Name
+                    { qualifiedModule = Nothing
+                    , baseName = "a"
+                    }
+                )
             , childTrees =
                 [ Tree
                     { nodeId = "3"
@@ -33,7 +46,15 @@ Tree
                                         [ Tree
                                             { nodeId = "6"
                                             , flavor = FlavorTCon
-                                            , body = TextBody "Builtins.List"
+                                            , body = TextBody
+                                                ( Name
+                                                    { qualifiedModule = Just
+                                                        ( ModuleName
+                                                            { unModuleName = "Builtins" :| [] }
+                                                        )
+                                                    , baseName = "List"
+                                                    }
+                                                )
                                             , childTrees = []
                                             , rightChild = Nothing
                                             }
@@ -53,7 +74,12 @@ Tree
                         , Tree
                             { nodeId = "8"
                             , flavor = FlavorTVar
-                            , body = TextBody "a"
+                            , body = TextBody
+                                ( Name
+                                    { qualifiedModule = Nothing
+                                    , baseName = "a"
+                                    }
+                                )
                             , childTrees = []
                             , rightChild = Nothing
                             }


### PR DESCRIPTION
As promised in https://github.com/hackworthltd/primer-app/pull/685#issuecomment-1348880849.

This brings us a small step towards being able to treat global names consistently in our frontend (https://github.com/hackworthltd/primer-app/issues/603). Though I have not even yet unified this new `API.Name` with other related data structures.