### PR TITLE
fix: Don't admit typedefs with an empty `baseName`

### DIFF
--- a/primer/src/Primer/Action/ProgError.hs
+++ b/primer/src/Primer/Action/ProgError.hs
@@ -14,6 +14,7 @@ data ProgError
   | DefNotFound GVarName
   | DefAlreadyExists GVarName
   | DefInUse GVarName
+  | EmptyDefName
   | TypeDefIsPrim TyConName
   | TypeDefNotFound TyConName
   | TypeDefAlreadyExists TyConName

--- a/primer/src/Primer/Typecheck/TypeError.hs
+++ b/primer/src/Primer/Typecheck/TypeError.hs
@@ -11,6 +11,7 @@ import Primer.Typecheck.KindError (KindError)
 
 data TypeError
   = InternalError Text
+  | EmptyTypeName
   | UnknownVariable TmVarRef
   | TmVarWrongSort Name -- type var instead of term var
   | UnknownConstructor ValConName


### PR DESCRIPTION
Fixes https://github.com/hackworthltd/primer/issues/832