### PR TITLE
Revert "chore: Switch to upstream nix-buildkite plugin."

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@ steps:
   - command: nix-buildkite
     label: ":nixos: :buildkite:"
     plugins:
-      - circuithub/nix-buildkite:
+      - hackworthltd/nix-buildkite#c1cbc6770498383b6a1e74c023135de5b1a5e1ec:
           file: ci.nix
 
   - label: ":nixos: Archive Nix flake inputs"


### PR DESCRIPTION
This reverts commit bff85f5ae25bcbc69978d6b61a4070a337649592.

This change was an oversight on my part: I had forgotten that our
nix-buildkite-buildkite-plugin fork included some changes that make it
easier to read the Buildkite build status page.

We now have an upstream PR, but it might take awhile for upstream to
merge it, so let's restore our fork in the meantime.
