### PR TITLE
fix: Resurrect the docker-image NixOS test.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -642,6 +642,7 @@
               lib = (prev.lib or { }) // {
                 primer = (prev.lib.primer or { }) // {
                   defaultServicePort = 8081;
+                  inherit version;
                   inherit postgres-dev-password;
                   inherit postgres-dev-base-url;
                   inherit postgres-dev-primer-url;
@@ -686,7 +687,7 @@
           );
 
           nixosModules.default = {
-            nixpkgs.overlays = [ inputs.self.overlays.default ];
+            nixpkgs.overlays = allOverlays;
           };
 
           hydraJobs = {


### PR DESCRIPTION
Note: for some reason, we need to use `hostPkgs` in the NixOS config
wherever we want to use a Primer package (e.g., the Docker image), for
some reason I don't understand. It seems to have something to do with
the haskell.nix overlay, because other packages that are in our
overlay, but that don't rely on haskell.nix (e.g., `primer-sqitch`),
work fine from the `pkgs` set.
