### PR TITLE
ci!: Make a note of a benchmarking change, add table to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,19 @@ make openapi.json
 
 This will place the generated spec in a file named `openapi.json`.
 (Note: do not check this generated file into this repository.)
+
+# Benchmarking
+
+We run various benchmarks to track performance regressions. We try to
+ensure that the benchmarks are run in a repeatable, quiescent
+environment, but we may from time to time need to change the hardware
+on which the benchmarks are run, which will inevitably cause
+discontinuities in benchmark results. In the table below, we make a
+best-effort attempt to track the commits to `main` after which
+discontinuities may appear.
+
+| Last commit                              | Subsequent change
+|------------------------------------------|------------------
+| 031587e3a054ff77ef42ee3e97a3a3b34b1365d0 | Retired previous benchmark machine, a dedicated AMD Ryzen 5 3600 6-Core Processor host running only benchmark jobs, and moved subsequent benchmark jobs to a VM running other CI jobs, with an 8-core AMD Ryzen 9 5900HX with Radeon Graphics.
+
+


### PR DESCRIPTION
BREAKING CHANGE: with this commit, we have made a change to our
benchmarking hardware. See the comment in the new table in the README
for details. Previous benchmark results are no longer relevant to
subsequent results. Please ignore any protestations from our GitHub
benchmark action.

Going forward, we'll endeavor to document benchmarking changes in the
README, which will make it easier to compare results.
