### PR TITLE
chore(benchmarks): Add cpuTime benchmarks to the benchmark output.

### DIFF
--- a/nix/pkgs/benchmarks/default.nix
+++ b/nix/pkgs/benchmarks/default.nix
@@ -13,7 +13,7 @@ let
     ''
       ${coreutils}/bin/mkdir -p $out
       cp ${lastEnvChangeFile} $out/lastEnvChange
-      ${primer-benchmark}/bin/primer-benchmark --output $out/results.html --regress allocated:iters --regress numGcs:iters +RTS -T
+      ${primer-benchmark}/bin/primer-benchmark --output $out/results.html --regress cpuTime:iters --regress allocated:iters --regress numGcs:iters +RTS -T
     ''
   ).overrideAttrs
     (drv: {
@@ -25,7 +25,7 @@ let
     ''
       ${coreutils}/bin/mkdir -p $out
       cp ${lastEnvChangeFile} $out/lastEnvChange
-      ${primer-benchmark}/bin/primer-benchmark --template json --output $out/results.json --regress allocated:iters --regress numGcs:iters +RTS -T
+      ${primer-benchmark}/bin/primer-benchmark --template json --output $out/results.json --regress cpuTime:iters --regress allocated:iters --regress numGcs:iters +RTS -T
     ''
   ).overrideAttrs
     (drv: {


### PR DESCRIPTION
Turns out Criterion has supported this feature all along, and I just wasn't aware: we can now output benchmark times as measured by the time the benchmarking process spent running on the CPU, as opposed to the wall clock time. CPU times should be much more stable than wall clock times, especially in noisy benchmarking environments.

Note that we still output the wall clock times, as in a perfect benchmarking environment, that is the true performance metric. Parallelized algorithms and concurrent threads, for example, will report the sum of all CPU times across all cores, and would not reflect the fact that, in real time, the computations had overlapped.