### PR TITLE
feat: log start of each request

### DIFF
--- a/primer-service/exe-server/Main.hs
+++ b/primer-service/exe-server/Main.hs
@@ -64,7 +64,7 @@ import Primer.Log (
   logNotice,
   textWithSeverity,
  )
-import Primer.Server (ConvertServerLogs)
+import Primer.Server (ConvertServerLogs, ServantLog)
 import Primer.Server qualified as Server
 import Prometheus qualified as P
 import Prometheus.Metric.GHC qualified as P
@@ -174,6 +174,7 @@ serve ::
   , ConvertLogMessage Text l
   , ConvertLogMessage PrimerErr l
   , ConvertServerLogs l
+  , ConvertLogMessage ServantLog l
   ) =>
   Database ->
   Version ->
@@ -270,4 +271,7 @@ instance ConvertLogMessage APILog LogMsg where
   convert = LogMsg . show
 
 instance ConvertLogMessage EvalLog LogMsg where
+  convert = LogMsg . show
+
+instance ConvertLogMessage ServantLog LogMsg where
   convert = LogMsg . show

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -6,6 +6,7 @@
 -- | An HTTP service for the Primer API.
 module Primer.Server (
   serve,
+  ServantLog,
   ConvertServerLogs,
   openAPIInfo,
 ) where
@@ -80,7 +81,7 @@ import Primer.Database qualified as Database (
  )
 import Primer.Eval (EvalLog)
 import Primer.Finite (getFinite)
-import Primer.Log (ConvertLogMessage, logWarning)
+import Primer.Log (ConvertLogMessage, logInfo, logWarning)
 import Primer.Name (unsafeMkName)
 import Primer.Pagination (pagedDefault)
 import Primer.Servant.API qualified as S
@@ -283,9 +284,16 @@ apiCors =
     , corsRequestHeaders = simpleHeaders <> [hAuthorization]
     }
 
+data ServantLog
+  = RequestStart
+  deriving stock (Show)
+
 serve ::
   forall l.
-  (ConvertLogMessage PrimerErr l, ConvertServerLogs l) =>
+  ( ConvertLogMessage PrimerErr l
+  , ConvertServerLogs l
+  , ConvertLogMessage ServantLog l
+  ) =>
   Sessions ->
   TBQueue Database.Op ->
   Version ->
@@ -317,7 +325,10 @@ serve ss q v port logger = do
     nt m =
       Handler $
         ExceptT $
-          flip runLoggingT logger $
+          flip runLoggingT logger $ do
+            -- This is not guaranteed to be consecutive with the logs from the action in the case of concurrent actions
+            -- (unlikely in a dev environment, except perhaps a getProgram&getActions request)
+            logInfo RequestStart
             catch (Right <$> runPrimerM m (Env ss q v)) handler
 
     -- Catch exceptions from the API and convert them to Servant


### PR DESCRIPTION
We now emit `RequestStart` log lines, to aid in extracting test/benchmark cases.

When looking at the generated logs, note that:
- log messages from multiple simultaneous interactions may be interleaved
- we log some internal high-level requests, so one API request can generate many log lines.
- each group is preceeded by a `RequestStart` line -- this shows where a new request was started, and the following messages will be various stages of handling it.
- we will have at most one `Edit` per request, but it will probably be after some `ApplyAction*` and `GetProgram` lines, which correspond to the actual API request made by your frontend and an internal implemetation detail.
- technically, there is no guarantee that the `RequestStart` line is actually consecutive with its generated logs, but it is normally the case for a single-user session.
---
This was split out of #863, as it no longer makes sense as part of that PR. I am opening this PR mostly to save the code in case anyone thinks it will be useful -- I have no particular desire to merge it at the current time.