### PR TITLE
chore: Upgrade to GHC 9.4.5.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -503,6 +503,23 @@
         "type": "github"
       }
     },
+    "haskell-language-server": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682523907,
+        "narHash": "sha256-2iLUGL4l9gIFmdRZpmnnUmGe14N8eDf7Ytq8zuwk2X0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "cda1325241365896f24d1a09899b8e8e787f9c7b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "cda1325241365896f24d1a09899b8e8e787f9c7b",
+        "type": "github"
+      }
+    },
     "haskell-nix": {
       "inputs": {
         "HTTP": "HTTP",
@@ -1211,6 +1228,7 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "hacknix": "hacknix",
+        "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix",
         "nixpkgs": [
           "haskell-nix",

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -6,3 +6,5 @@ diff-friendly-import-export: true
 respectful: true
 haddock-style: single-line
 newlines-between-decls: 1
+single-constraint-parens: auto
+

--- a/primer-benchmark/primer-benchmark.cabal
+++ b/primer-benchmark/primer-benchmark.cabal
@@ -41,7 +41,7 @@ library
   exposed-modules: Benchmarks
   build-depends:
     , aeson                            >=2.0      && <2.2
-    , base                             >=4.12     && <4.17.0
+    , base                             >=4.12     && <4.18
     , containers                       >=0.6.0.1  && <0.7.0
     , criterion                        ^>=1.6.0.0
     , deepseq                          ^>=1.4.6.1

--- a/primer-rel8/primer-rel8.cabal
+++ b/primer-rel8/primer-rel8.cabal
@@ -35,7 +35,7 @@ library
 
   build-depends:
     , aeson           >=2.0      && <2.2
-    , base            >=4.12     && <4.17.0
+    , base            >=4.12     && <4.18
     , bytestring      >=0.10.8.2 && <0.12.0
     , containers      >=0.6.0.1  && <0.7.0
     , exceptions      >=0.10.4   && <0.11.0

--- a/primer-selda/primer-selda.cabal
+++ b/primer-selda/primer-selda.cabal
@@ -33,7 +33,7 @@ library
 
   build-depends:
     , aeson           >=2.0      && <2.2
-    , base            >=4.12     && <4.17.0
+    , base            >=4.12     && <4.18
     , bytestring      >=0.10.8.2 && <0.12.0
     , containers      >=0.6.0.1  && <0.7.0
     , logging-effect  ^>=1.4

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -40,7 +40,7 @@ library
 
   build-depends:
     , aeson                      >=2.0      && <2.2
-    , base                       >=4.12     && <4.17.0
+    , base                       >=4.12     && <4.18
     , containers                 >=0.6.0.1  && <0.7
     , deriving-aeson             >=0.2      && <0.3.0
     , exceptions                 >=0.10.4   && <0.11.0

--- a/primer-service/src/Primer/Finite.hs
+++ b/primer-service/src/Primer/Finite.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Primer.Finite (Finite, getFinite, packFinite) where

--- a/primer-service/src/Servant/OpenApi/OperationId.hs
+++ b/primer-service/src/Servant/OpenApi/OperationId.hs
@@ -54,5 +54,6 @@ instance
   where
   toOpenApi _ =
     toOpenApi (Proxy @api)
-      & traversalVL allOperations % #operationId
+      & traversalVL allOperations
+        % #operationId
         %~ (Just (pack (symbolVal (Proxy @id))) <>)

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -109,7 +109,7 @@ library
   build-depends:
     , aeson                        >=2.0      && <2.2
     , assoc                        ^>=1.1
-    , base                         >=4.12     && <4.17.0
+    , base                         >=4.12     && <4.18
     , bytestring                   >=0.10.8.2 && <0.12.0
     , containers                   >=0.6.0.1  && <0.7.0
     , deriving-aeson               >=0.2      && <0.3.0

--- a/primer/src/Foreword.hs
+++ b/primer/src/Foreword.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+
 module Foreword (
   module Protolude,
   module Unsafe,
   module Catch,
   module Foldable,
+  module TypeEquality,
   insertAt,
   adjustAt,
   adjustAtA,
@@ -86,6 +89,7 @@ import Protolude qualified as P
 import Protolude.Unsafe as Unsafe (unsafeHead)
 
 import Data.Foldable as Foldable (foldMap')
+import Data.Type.Equality as TypeEquality (type (~))
 
 -- We want @exceptions@ rather than @base@'s equivalents.
 import Control.Monad.Catch as Catch

--- a/primer/src/Primer/Action/Errors.hs
+++ b/primer/src/Primer/Action/Errors.hs
@@ -23,10 +23,10 @@ import Primer.Zipper (SomeNode)
 -- https://github.com/hackworthltd/primer/issues/8
 data ActionError
   = CustomFailure
+      -- | action that caused the error
       Action
-      -- ^ action that caused the error
+      -- | the error message
       Text
-      -- ^ the error message
   | InternalFailure Text
   | IDNotFound ID
   | MovementFailed (ID, Movement)

--- a/primer/src/Primer/Core.hs
+++ b/primer/src/Primer/Core.hs
@@ -151,33 +151,33 @@ data Expr' a b
   | Var a TmVarRef
   | Let
       a
+      -- | bound variable
       LVarName
-      -- ^ bound variable
+      -- | value the variable is bound to
       (Expr' a b)
-      -- ^ value the variable is bound to
+      -- | expression the binding scopes over
       (Expr' a b)
-      -- ^ expression the binding scopes over
   | -- | LetType binds a type to a name in some expression.
     -- It is currently only constructed automatically during evaluation -
     -- the student can't directly make it.
     LetType
       a
+      -- | bound variable
       TyVarName
-      -- ^ bound variable
+      -- | value the variable is bound to
       (Type' b)
-      -- ^ value the variable is bound to
+      -- | expression the binding scopes over
       (Expr' a b)
-      -- ^ expression the binding scopes over
   | Letrec
       a
+      -- | bound variable
       LVarName
-      -- ^ bound variable
+      -- | value the variable is bound to; the variable itself is in scope, as this is a recursive let
       (Expr' a b)
-      -- ^ value the variable is bound to; the variable itself is in scope, as this is a recursive let
+      -- | type of the bound variable (variable is not in scope in this type)
       (Type' b)
-      -- ^ type of the bound variable (variable is not in scope in this type)
+      -- | body of the let; binding scopes over this
       (Expr' a b)
-      -- ^ body of the let; binding scopes over this
   | Case a (Expr' a b) [CaseBranch' a b] -- See Note [Case]
   | PrimCon a PrimCon
   deriving stock (Eq, Show, Read, Data, Generic)
@@ -284,14 +284,14 @@ type CaseBranch = CaseBranch' ExprMeta TypeMeta
 
 data CaseBranch' a b
   = CaseBranch
+      -- | constructor
       ValConName
-      -- ^ constructor
-      [Bind' a]
-      -- ^ constructor parameters.
+      -- | constructor parameters.
       -- Ideally this would be '[Bind' (Meta TypeCache)]' since we always know the types of branch
       -- bindings. Unfortunately that breaks generic traversals like '_exprMeta'.
+      [Bind' a]
+      -- | right hand side
       (Expr' a b)
-      -- ^ right hand side
   deriving stock (Eq, Show, Read, Data, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON (CaseBranch' a b)
   deriving anyclass (NFData)

--- a/primer/src/Primer/Core/Type.hs
+++ b/primer/src/Primer/Core/Type.hs
@@ -50,12 +50,12 @@ data Type' a
     -- the student can't directly make it.
     TLet
       a
+      -- | bound variable
       TyVarName
-      -- ^ bound variable
+      -- | type the variable is bound to; the variable itself is not in scope, this is a non-recursive let
       (Type' a)
-      -- ^ type the variable is bound to; the variable itself is not in scope, this is a non-recursive let
+      -- | body of the let; binding scopes over this
       (Type' a)
-      -- ^ body of the let; binding scopes over this
   deriving stock (Eq, Show, Read, Data, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON (Type' a)
   deriving anyclass (NFData)

--- a/primer/src/Primer/Primitives.hs
+++ b/primer/src/Primer/Primitives.hs
@@ -58,8 +58,8 @@ data PrimFunError
   = -- | We have attempted to apply a primitive function to invalid args.
     PrimFunError
       PrimDef
+      -- | Arguments
       [Expr' () ()]
-      -- ^ Arguments
   deriving stock (Eq, Show, Data, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON PrimFunError
 

--- a/primer/src/Primer/ZipperCxt.hs
+++ b/primer/src/Primer/ZipperCxt.hs
@@ -51,12 +51,12 @@ import Primer.Zipper (
 -- globally-defined "main"]
 data ShadowedVarsExpr
   = M
+      -- | Local type variables
       [(TyVarName, Kind)]
-      -- ^ Local type variables
+      -- | Local term variables
       [(LVarName, Type' ())]
-      -- ^ Local term variables
+      -- | Global variables
       [(GVarName, Type' ())]
-      -- ^ Global variables
   deriving stock (Eq, Show)
 
 instance Semigroup ShadowedVarsExpr where

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -883,7 +883,7 @@ tasty_prim_hex_nat = withTests 20 . property $ do
                       )
                   ]
                 <*> con cJust [ne]
-                `ann` (tcon tMaybe `tapp` tcon tNat)
+                  `ann` (tcon tMaybe `tapp` tcon tNat)
             else
               (,)
                 <$> pfun NatToHex

--- a/primer/test/Tests/Gen/Core/Typed.hs
+++ b/primer/test/Tests/Gen/Core/Typed.hs
@@ -144,24 +144,24 @@ tasty_genCxtExtending_is_extension =
         tds1
           `M.isSubmapOf` tds2
           && lc1
-          == lc2 -- we don't extend the locals
+            == lc2 -- we don't extend the locals
           && lc1
-          == mempty -- and it doesn't make too much sense to do a global extension if already have locals in scope
+            == mempty -- and it doesn't make too much sense to do a global extension if already have locals in scope
           && gc1
-          `M.isSubmapOf` gc2
+            `M.isSubmapOf` gc2
           && sh1
-          == sh2
+            == sh2
     extendsLocal
       (Cxt{typeDefs = tds1, localCxt = lc1, globalCxt = gc1, smartHoles = sh1})
       (Cxt{typeDefs = tds2, localCxt = lc2, globalCxt = gc2, smartHoles = sh2}) =
         tds1
           == tds2
           && lc1
-          `M.isSubmapOf` lc2 -- we only extend the locals
+            `M.isSubmapOf` lc2 -- we only extend the locals
           && gc1
-          == gc2
+            == gc2
           && sh1
-          == sh2
+            == sh2
 
 tasty_genSyns :: Property
 tasty_genSyns = withTests 1000 $


### PR DESCRIPTION
Also, we do the following:

* Upgrade to fourmolu 0.12.0.0 and tell it not to put parens around
standalone unary constraints, for compatibility with hlint.

* Run a formatting pass to conform to fourmolu's new formatting.

* Build HLS from source. It doesn't currently build as a haskell.nix
tool with GHC 9.4.5, and we need to build it from git, anyway, in
order to get support for fourmolu 0.12.0.0.

* Disable weeder, which doesn't currently build as a haskell.nix tool
with GHC 9.4.5, and also fails to build on aarch64-darwin.

* Remove hie.yaml, as HLS once again seems able to operate without it.

Note: the definition of `type (<=)` changed in ghc-9.4 such that it
uses its arguments twice each. Thus `instance x <= y => C x y where
...` is rejected, since the constraint is a type synonym which expands
to something like `instance Assert (x <=? y) (LeErrMsg x y) => C x y
where` and this fails the Paterson Conditions:

https://downloads.haskell.org/ghc/9.4.4/docs/users_guide/exts/instances.html#instance-termination-rules

Using UndecidableInstances lifts these restrictions, satisfying GHC.
