### PR TITLE
fix: Add `coreutils` to Docker entrypoint's `runtimeInputs`.

### DIFF
--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -80,6 +80,7 @@ let
   primer-service-entrypoint = writeShellApplication {
     name = "primer-service-entrypoint";
     runtimeInputs = [
+      coreutils
       primer-service
       primer-sqitch
     ];


### PR DESCRIPTION
The entrypoint script now relies on `cat` and `basename`.
