### PR TITLE
fix: Sqitch `deploy` in the container entrypoint when using SQLite.

### DIFF
--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -110,6 +110,11 @@ let
   # Run `primer-service` locally against a SQLite database. This
   # script sets the expected environment variables, deploys the
   # database, and execs `primer-service-entrypoint`.
+  #
+  # Note that, unlike the PostgreSQL equivalent script, this script
+  # does not need to perform a database deployment before running the
+  # entrypoint, because the entrypoint does that for us when running
+  # against a SQLite database.
   run-primer-sqlite = writeShellApplication {
     name = "run-primer-sqlite";
     runtimeInputs = [
@@ -123,7 +128,6 @@ let
         export SQLITE_DB="primer.sqlite3"
       fi
 
-      primer-sqitch deploy --verify "db:sqlite:$SQLITE_DB"
       primer-service-entrypoint
     '';
   };


### PR DESCRIPTION
It's safe to do this, as we assume that the container orchestrator
will only mount the SQLite volume on a single container instance, and
therefore we don't need to worry about atomicity in the deploy
scripts. The Docker container NixOS tests have been changed to reflect
this.

(Note that when running against a PostgreSQL database, the behavior of
the entrypoint is the same as before: it only runs `sqitch verify`,
and assumes that any deployment step has already been done by the time
the `primer-service` container has launched, as this is the only safe
way to do it in a multi-container environment: see
https://github.com/sqitchers/sqitch/discussions/646)
