### PR TITLE
feat: Expose undo via the Primer API & Servant endpoints.

### DIFF
--- a/primer-service/src/Primer/Client.hs
+++ b/primer-service/src/Primer/Client.hs
@@ -16,6 +16,7 @@ module Primer.Client (
   getSessionName,
   renameSession,
   edit,
+  undo,
   variablesInScope,
   generateNames,
   evalStep,
@@ -144,6 +145,10 @@ renameSession sid name = apiClient // API.sessionsAPI // API.sessionAPI /: sid /
 -- | As 'Primer.API.edit'.
 edit :: SessionId -> MutationRequest -> ClientM (Either ProgError Prog)
 edit sid req = apiClient // API.sessionsAPI // API.sessionAPI /: sid // API.editSession /: req
+
+-- | As 'Primer.API.undo'.
+undo :: SessionId -> MutationRequest -> ClientM (Either ProgError Prog)
+undo sid req = apiClient // API.sessionsAPI // API.sessionAPI /: sid // API.undoSession /: req
 
 -- | As 'Primer.API.variablesInScope'.
 variablesInScope ::

--- a/primer-service/src/Primer/Servant/API.hs
+++ b/primer-service/src/Primer/Servant/API.hs
@@ -133,7 +133,24 @@ data SessionAPI mode = SessionAPI
       mode
         :- "edit"
           :> Summary "Edit the program"
-          :> Description "Submit an action, returning the updated program state."
+          :> Description
+              "Edit the program. If successful, append the edit \
+              \to the action log, so that it can potentially be undone \
+              \later, and return the new program state. If not, \
+              \return an error, in which case the program state and \
+              \the action log are unchanged."
+          :> ReqBody '[JSON] MutationRequest
+          :> Post '[JSON] (Either ProgError Prog)
+  , undoSession ::
+      mode
+        :- "undo"
+          :> Summary "Undo the previous edit"
+          :> Description
+              "Undo the last edit. If successful, this effectively \
+              \pops the tail of the action log, restores the program \
+              \state to that of the new tail, and returns that \
+              \program state. If not, it returns an error, in which \
+              \case the program state and the action log are unchanged."
           :> ReqBody '[JSON] MutationRequest
           :> Post '[JSON] (Either ProgError Prog)
   , questionAPI ::

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -67,6 +67,7 @@ import Primer.API (
   newSession,
   renameSession,
   runPrimerM,
+  undo,
  )
 import Primer.API qualified as API
 import Primer.Action.Available (InputAction, NoInputAction)
@@ -227,6 +228,7 @@ sessionAPIServer sid =
     , S.getSessionName = API.getSessionName sid
     , S.setSessionName = renameSession sid
     , S.editSession = edit sid
+    , S.undoSession = undo sid
     , S.questionAPI = questionAPIServer sid
     , S.evalStep = API.evalStep sid
     , S.evalFull = API.evalFull sid

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -42,6 +42,7 @@ module Primer.API (
   getSessionName,
   renameSession,
   edit,
+  undo,
   variablesInScope,
   generateNames,
   evalStep,
@@ -366,6 +367,7 @@ data APILog
   | GetProgram' (ReqResp (ExprTreeOpts, SessionId) Prog)
   | GetProgram (ReqResp SessionId App.Prog)
   | Edit (ReqResp (SessionId, MutationRequest) (Either ProgError App.Prog))
+  | Undo (ReqResp (SessionId, MutationRequest) (Either ProgError App.Prog))
   | VariablesInScope (ReqResp (SessionId, (GVarName, ID)) (Either ProgError (([(TyVarName, Kind)], [(LVarName, Type' ())]), [(GVarName, Type' ())])))
   | GenerateNames (ReqResp (SessionId, ((GVarName, ID), Either (Maybe (Type' ())) (Maybe Kind))) (Either ProgError [Name.Name]))
   | EvalStep (ReqResp (SessionId, EvalReq) (Either ProgError EvalResp))
@@ -936,12 +938,34 @@ globalName n = Name{qualifiedModule = Just $ Core.qualifiedModule n, baseName = 
 localName :: LocalName k -> Name
 localName n = Name{qualifiedModule = Nothing, baseName = unLocalName n}
 
+-- | Edit the program.
+--
+-- If successful, append the edit to the action log, so that it can
+-- potentially be undone later, and return the new program state.
+--
+-- If not, return a 'ProgError', in which case the program state and
+-- the action log are unchanged.
 edit ::
   (MonadIO m, MonadThrow m, MonadAPILog l m) =>
   SessionId ->
   MutationRequest ->
   PrimerM m (Either ProgError App.Prog)
 edit = curry $ logAPI (leftResultError Edit) $ \(sid, req) -> liftEditAppM (handleMutationRequest req) sid
+
+-- | Undo the last edit.
+--
+-- If sucessful, this effectively pops the tail of the action log,
+-- restores the program state to that the new tail, and returns that
+-- new program state.
+--
+-- If not, return a 'ProgError', in which case the program state and
+-- the action log are unchanged.
+undo ::
+  (MonadIO m, MonadThrow m, MonadAPILog l m) =>
+  SessionId ->
+  MutationRequest ->
+  PrimerM m (Either ProgError App.Prog)
+undo = curry $ logAPI (leftResultError Undo) $ \(sid, req) -> liftEditAppM (handleMutationRequest req) sid
 
 variablesInScope ::
   (MonadIO m, MonadThrow m, MonadAPILog l m) =>


### PR DESCRIPTION
This is straightforward. We do not yet expose undo via the OpenAPI
API, because that is slightly less so. That will come in a subsequent
commit.
