### PR TITLE
feat!: Innards of non-empty holes should check against hole type

### DIFF
--- a/primer/gen/Primer/Gen/Core/Typed.hs
+++ b/primer/gen/Primer/Gen/Core/Typed.hs
@@ -222,8 +222,8 @@ genSyns ty = do
       t <- genChk ty
       pure (Ann () t ty, ty)
     genHole = do
-      (e, _) <- genSyn
-      pure (Hole () e, TEmptyHole ())
+      t <- genChk $ TEmptyHole ()
+      pure (Hole () t, TEmptyHole ())
     genSpine :: WT (Maybe (GenT WT (ExprG, TypeG)))
     genSpine = fmap (fmap Gen.justT) genSpineHeadFirst
     genSpineHeadFirst :: WT (Maybe (GenT WT (Maybe (ExprG, TypeG))))

--- a/primer/src/Primer/Core.hs
+++ b/primer/src/Primer/Core.hs
@@ -212,16 +212,33 @@ data Expr' a b
 --
 -- From the "inside" of a non-empty hole, there is a choice to be made
 -- about typing. How does one typecheck @{? e ?}@ since we have no
--- information about what type @e@ should have. The choice our system
--- makes (following Hazel) is to require @e@ to be synthesisable. Thus
--- one cannot put a lambda directly inside a hole: @{? λx. x ?}@ is
--- ill-typed. One would have to annotate this lambda (but could
--- annotate with a hole): @{? λx.x : ? ?}@. The other possible choice
--- is to require the wrapped expression to be checkable against the
--- hole type: this is mildly more permissive since a bare lambda is
--- now allowed inside a hole, but not much more so since anything that
--- checks against a hole type can be annotated with a hole type to
--- become synthesisable.
+-- information about what type @e@ should have?
+-- The choice our system makes is to require @e@ to check against a type
+-- hole. Note that since we do not require @e@ to synthesise a type, it
+-- is possible to put a lambda directly inside a hole: @{? λx. x ?}@ is
+-- well-typed.
+-- The other possible choice is to require the wrapped expression to be
+-- synthesisable (and ignore which particular type it synthesises).
+-- This second choice was taken by Hazel. This has the drawback of being
+-- slightly more restrictive, since one cannot put a lambda directly
+-- inside a hole, but would have to annotate it (with a hole):
+-- @{? λx.x : ? ?}@. (Note that this is generally applicable, so the
+-- restriction is mild.) However, it has the advantage of it being easier to
+-- tell whether a hole can be elided, i.e. in a checkable context with a
+-- synthesisable term in the hole, e.g. @Succ {? not True ?}@ or
+-- @Succ {? plus 2 2 ?}@ one only needs to check type equality between the
+-- context and the expression-inside-the-hole, whereas if there is a checkable
+-- term in the hole one would need to actually do the typechecking. Since our
+-- system just attempts to remove the hole and sees what happens (perhaps
+-- wrapping some subterm in a hole, like in @{? Just True ?} : Maybe Int@
+-- producing @Just {? True ?} : Maybe Int@), this is not actually a drawback
+-- in practice.
+-- The reason we made this choice is because the restriction, whilst being mild
+-- in theory is pretty annoying in practice, for a human using this system. It
+-- also slightly simplifies some cases in the implementation, since we sometimes
+-- (some actions, smartholes etc) need to do an edit and then wrap some
+-- previously (but no longer) well-typed subexpression in a hole, and with this
+-- choice we do not need to worry about directionality.
 
 -- Note [Checkable constructors]
 --

--- a/primer/test/Tests/Action.hs
+++ b/primer/test/Tests/Action.hs
@@ -444,16 +444,16 @@ unit_enter_emptyHole =
   actionTest
     NoSmartHoles
     emptyHole
-    [EnterHole, ConstructAnn, Move Child1, constructSaturatedCon cTrue]
-    (hole $ con0 cTrue `ann` tEmptyHole)
+    [EnterHole, constructSaturatedCon cTrue]
+    (hole $ con0 cTrue)
 
 unit_enter_nonEmptyHole :: Assertion
 unit_enter_nonEmptyHole =
   actionTest
     NoSmartHoles
     (hole emptyHole)
-    [Move Child1, ConstructAnn, Move Child1, constructSaturatedCon cTrue]
-    (hole $ con0 cTrue `ann` tEmptyHole)
+    [Move Child1, constructSaturatedCon cTrue]
+    (hole $ con0 cTrue)
 
 unit_bad_enter_hole :: Assertion
 unit_bad_enter_hole =
@@ -476,8 +476,6 @@ unit_case_create =
     , Move Child1
     , EnterHole
     , ConstructVar $ LocalVarRef "x"
-    , ConstructAnn
-    , Move Child1
     , ConstructCase
     , Move (Branch cTrue)
     , constructSaturatedCon cZero
@@ -485,12 +483,9 @@ unit_case_create =
     ( ann
         ( lam "x" $
             hole $
-              ann
-                ( case_
-                    (lvar "x")
-                    [branch cTrue [] (con0 cZero), branch cFalse [] emptyHole]
-                )
-                tEmptyHole
+              case_
+                (lvar "x")
+                [branch cTrue [] (con0 cZero), branch cFalse [] emptyHole]
         )
         (tfun (tcon tBool) (tcon tNat))
     )
@@ -503,16 +498,13 @@ unit_case_tidy =
     ( ann
         ( lam "x" $
             hole $
-              ann
-                ( case_
-                    (lvar "x")
-                    [branch cTrue [] (con0 cZero), branch cFalse [] emptyHole]
-                )
-                tEmptyHole
+              case_
+                (lvar "x")
+                [branch cTrue [] (con0 cZero), branch cFalse [] emptyHole]
         )
         (tfun (tcon tBool) (tcon tNat))
     )
-    [Move Child1, Move Child1, FinishHole, RemoveAnn]
+    [Move Child1, Move Child1, FinishHole]
     ( ann
         ( lam "x" $
             case_

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -388,7 +388,7 @@ unit_sat_con_1 =
     (emptyHole `ann` (tEmptyHole `tfun` tEmptyHole))
     (InExpr [Child1])
     (Right (MakeCon, Option "Cons" $ Just $ unName <$> unModuleName builtinModuleName))
-    (hole (con cCons [emptyHole, emptyHole] `ann` tEmptyHole) `ann` (tEmptyHole `tfun` tEmptyHole))
+    (hole (con cCons [emptyHole, emptyHole]) `ann` (tEmptyHole `tfun` tEmptyHole))
 
 unit_sat_con_2 :: Assertion
 unit_sat_con_2 =
@@ -398,7 +398,7 @@ unit_sat_con_2 =
     (emptyHole `ann` ((tcon tList `tapp` tcon tNat) `tfun` (tcon tList `tapp` tcon tNat)))
     (InExpr [Child1])
     (Right (MakeCon, Option "Cons" $ Just $ unName <$> unModuleName builtinModuleName))
-    (hole (con cCons [emptyHole, emptyHole] `ann` tEmptyHole) `ann` ((tcon tList `tapp` tcon tNat) `tfun` (tcon tList `tapp` tcon tNat)))
+    (hole (con cCons [emptyHole, emptyHole]) `ann` ((tcon tList `tapp` tcon tNat) `tfun` (tcon tList `tapp` tcon tNat)))
 
 -- The various @let@ constructs inherit the directionality of their body.
 -- This is a regression test, as in the past this was the case for @let@ but not @letrec@.

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -908,7 +908,6 @@ unit_RenameCon =
                     [ branch cA [("p", Nothing), ("q", Nothing), ("p1", Nothing)] emptyHole
                     , branch cB [("r", Nothing), ("x", Nothing)] emptyHole
                     ]
-                    `ann` tEmptyHole
               astDef "def" x <$> tEmptyHole
           ]
     )
@@ -937,7 +936,6 @@ unit_RenameCon =
                   [ branch (vcn "A'") [("p", Nothing), ("q", Nothing), ("p1", Nothing)] emptyHole
                   , branch cB [("r", Nothing), ("x", Nothing)] emptyHole
                   ]
-                  `ann` tEmptyHole
           )
 
 unit_RenameCon_clash :: Assertion
@@ -954,7 +952,6 @@ unit_RenameCon_clash =
                       , emptyHole
                       , emptyHole
                       ]
-                      `ann` (tcon tT `tapp` tEmptyHole `tapp` tEmptyHole)
                   )
               astDef "def" x <$> tEmptyHole
           ]
@@ -1048,7 +1045,7 @@ unit_SetConFieldType_con =
               con
                 cA
                 [ con0 (vcn "True")
-                , hole (con0 (vcn "True") `ann` tcon (tcn "Bool"))
+                , hole (con0 (vcn "True"))
                 , con0 (vcn "True")
                 ]
           )
@@ -1086,7 +1083,7 @@ unit_SetConFieldType_chk =
     (tcon (tcn "Nat") `tfun` tcon (tcn "Bool"))
     (lam "x" emptyHole)
     (tcon (tcn "Int"))
-    (hole (lam "x" emptyHole `ann` (tcon (tcn "Nat") `tfun` tcon (tcn "Bool"))))
+    (hole $ lam "x" emptyHole)
 
 -- change the type of a field which currently wraps a checkable term
 -- this result could have the hole elided, but we don't run smartholes
@@ -1097,7 +1094,7 @@ unit_SetConFieldType_match =
     (tEmptyHole `tfun` tcon (tcn "Bool"))
     (lam "x" emptyHole)
     (tcon (tcn "Int") `tfun` tEmptyHole)
-    (hole (lam "x" emptyHole `ann` (tEmptyHole `tfun` tcon (tcn "Bool"))))
+    (hole $ lam "x" emptyHole)
 
 -- change the type of a field which currently wraps a synthesisable argument
 unit_SetConFieldType_syn :: Assertion


### PR DESCRIPTION
Currently they must synthesise some type (and we don't care what), but there is no particular reason for this that I can recall, other than following Hazel. I think it may be nicer UX if we change this.

In particular, with checkable saturated constructors we would then be able to write a constructor directly inside a hole, without having to annotate it. Even without that, we could write a lambda directly inside a hole (currently it would need an annotation): `{? λx.t[x] ?}` would be valid, and synthesise a hole exactly when we have that `x : ? ⊢ ? ∋ t[x]`.

Essentially, whenever we now write `{? t : ? ?}`, we could drop the annotation. Whenever we currently have a more-specific annotation (currently this is only possible when a human explicitly writes it, I think), then we could still write it exactly the same as before (e.g. `{? λx.t[x] : Nat -> Bool ?}` would be fine exactly when `x : Nat ⊢ Bool ∋ t[x]`).