### PR TITLE
fix: renameTyVarExpr cares about type/term var capture

### DIFF
--- a/primer/src/Primer/Core/Transform.hs
+++ b/primer/src/Primer/Core/Transform.hs
@@ -188,7 +188,12 @@ renameTyVarExpr x y expr = case expr of
         | any (sameVar y) $ bindingNames b = Nothing
         | otherwise = CaseBranch con termargs <$> renameTyVarExpr x y rhs
       bindingNames (CaseBranch _ bs _) = map bindName bs
-  Var{} -> substAllChildren
+  -- Since term and type variables are in the same namespace, we need
+  -- to worry about references to the term var y since we do not want
+  -- to capture such a y.
+  Var _ v
+    | sameVarRef y v -> Nothing
+    | otherwise -> pure expr
   Hole{} -> substAllChildren
   EmptyHole{} -> substAllChildren
   Ann{} -> substAllChildren

--- a/primer/test/Tests/Action.hs
+++ b/primer/test/Tests/Action.hs
@@ -13,7 +13,7 @@ import Hedgehog hiding (
  )
 import Primer.Action (
   Action (..),
-  ActionError (CaseBindsClash, RefineError),
+  ActionError (CaseBindsClash, NameCapture, RefineError),
   Movement (..),
   applyActionsToExpr,
  )
@@ -352,6 +352,17 @@ unit_rename_LAM_2 =
     NoSmartHoles
     (ann (lAM "b" (lAM "a" (aPP (con cNil) (tvar "b")))) tEmptyHole)
     [Move Child1, Move Child1, RenameLAM "b"]
+
+unit_rename_LAM_3 :: Assertion
+unit_rename_LAM_3 =
+  actionTestExpectFail
+    ( \case
+        NameCapture -> True
+        _ -> False
+    )
+    NoSmartHoles
+    (lam "x" (lAM "y" $ lvar "x") `ann` tEmptyHole)
+    [Move Child1, Move Child1, RenameLAM "x"]
 
 unit_convert_let_to_letrec :: Assertion
 unit_convert_let_to_letrec =


### PR DESCRIPTION
Since type and term variables are in the same namespace, when renaming a type variable we may capture a usage of a term variable. This leads to actions which do this renaming failing with a
`TypeError (TmVarWrongSort "x")` error, rather than a `NameCapture` error.