### PR TITLE
feat: Expose typedef edit actions in OpenAPI

### DIFF
--- a/primer-service/exe-server/Main.hs
+++ b/primer-service/exe-server/Main.hs
@@ -376,7 +376,9 @@ instance ConvertLogMessage SomeException LogMsg where
 instance ConvertLogMessage PrimerErr LogMsg where
   convert (DatabaseErr e) = LogMsg e
   convert (UnknownDef e) = LogMsg $ show e
+  convert (UnknownTypeDef e) = LogMsg $ show e
   convert (UnexpectedPrimDef e) = LogMsg $ show e
+  convert (UnexpectedPrimTypeDef e) = LogMsg $ show e
   convert (AddDefError m n e) = LogMsg $ show (m, n, e)
   convert (AddTypeDefError tc vcs e) = LogMsg $ show (tc, vcs, e)
   convert (ActionOptionsNoID e) = LogMsg $ show e

--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -52,6 +52,8 @@ import Primer.API (
   Prog,
   Selection,
   Tree,
+  TypeDef,
+  ValCon,
  )
 import Primer.API qualified as API
 import Primer.API.NodeFlavor (
@@ -71,6 +73,7 @@ import Primer.Core (
   LVarName,
   ModuleName,
   PrimCon,
+  TyVarName,
  )
 import Primer.Database (
   LastModified,
@@ -141,6 +144,7 @@ deriving via GlobalName 'ADefName instance ToSchema (GlobalName 'ATyCon)
 deriving via GlobalName 'ADefName instance ToSchema (GlobalName 'AValCon)
 
 deriving via Name instance (ToSchema LVarName)
+deriving via Name instance (ToSchema TyVarName)
 deriving via PrimerJSON (RecordPair a b) instance (ToSchema a, ToSchema b) => ToSchema (RecordPair a b)
 deriving via PrimerJSON Tree instance ToSchema Tree
 deriving via PrimerJSON API.Name instance ToSchema API.Name
@@ -150,6 +154,8 @@ deriving via PrimerJSON NodeFlavorTextBody instance ToSchema NodeFlavorTextBody
 deriving via PrimerJSON NodeFlavorPrimBody instance ToSchema NodeFlavorPrimBody
 deriving via PrimerJSON NodeFlavorBoxBody instance ToSchema NodeFlavorBoxBody
 deriving via PrimerJSON NodeFlavorNoBody instance ToSchema NodeFlavorNoBody
+deriving via PrimerJSON TypeDef instance ToSchema TypeDef
+deriving via PrimerJSON ValCon instance ToSchema ValCon
 deriving via PrimerJSON Def instance ToSchema Def
 deriving via NonEmpty Name instance ToSchema ModuleName
 deriving via PrimerJSON Module instance ToSchema Module

--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -64,8 +64,8 @@ import Primer.API.NodeFlavor (
  )
 import Primer.API.RecordPair (RecordPair)
 import Primer.Action.Available qualified as Available
-import Primer.App (NodeSelection, NodeType)
-import Primer.App.Base (Level)
+import Primer.App (DefSelection, NodeSelection, NodeType, TypeDefSelection)
+import Primer.App.Base (Level, TypeDefConsFieldSelection (..), TypeDefConsSelection (..), TypeDefNodeSelection)
 import Primer.Core (
   GlobalName,
   GlobalNameKind (ADefName, ATyCon, AValCon),
@@ -168,6 +168,11 @@ deriving via PrimerJSON Available.Options instance ToSchema Available.Options
 deriving via PrimerJSON Available.Action instance ToSchema Available.Action
 deriving via PrimerJSON ApplyActionBody instance ToSchema ApplyActionBody
 deriving via PrimerJSONNamed "Selection" Selection instance ToSchema Selection
+deriving via PrimerJSONNamed "TypeDefSelection" (TypeDefSelection ID) instance ToSchema (TypeDefSelection ID)
+deriving via PrimerJSONNamed "TypeDefNodeSelection" (TypeDefNodeSelection ID) instance ToSchema (TypeDefNodeSelection ID)
+deriving via PrimerJSONNamed "TypeDefConsSelection" (TypeDefConsSelection ID) instance ToSchema (TypeDefConsSelection ID)
+deriving via PrimerJSONNamed "TypeDefConsFieldSelection" (TypeDefConsFieldSelection ID) instance ToSchema (TypeDefConsFieldSelection ID)
+deriving via PrimerJSONNamed "DefSelection" (DefSelection ID) instance ToSchema (DefSelection ID)
 deriving via PrimerJSONNamed "NodeSelection" (NodeSelection ID) instance ToSchema (NodeSelection ID)
 deriving via PrimerJSON NodeType instance ToSchema NodeType
 deriving via PrimerJSON Level instance ToSchema Level

--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -136,8 +136,7 @@ deriving via Text instance (ToSchema Name)
 -- at the openapi level, so api consumers do not have to deal with
 -- three identical types. Note that our openapi interface is a
 -- simplified view, so this collapse is in the correct spirit.
-instance ToSchema (GlobalName 'ADefName) where
-  declareNamedSchema _ = rename (Just "GlobalName") <$> declareNamedSchema (Proxy @(PrimerJSON (GlobalName 'ADefName)))
+deriving via PrimerJSONNamed "GlobalName" (GlobalName 'ADefName) instance ToSchema (GlobalName 'ADefName)
 deriving via GlobalName 'ADefName instance ToSchema (GlobalName 'ATyCon)
 deriving via GlobalName 'ADefName instance ToSchema (GlobalName 'AValCon)
 

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -405,6 +405,8 @@ serve ss q v port origins logger = do
         DatabaseErr msg -> err500{errBody = encode msg}
         UnknownDef d -> err404{errBody = "Unknown definition: " <> encode (globalNamePretty d)}
         UnexpectedPrimDef d -> err400{errBody = "Unexpected primitive definition: " <> encode (globalNamePretty d)}
+        UnknownTypeDef d -> err404{errBody = "Unknown type definition: " <> encode (globalNamePretty d)}
+        UnexpectedPrimTypeDef d -> err400{errBody = "Unexpected primitive type definition: " <> encode (globalNamePretty d)}
         AddDefError m md pe -> err400{errBody = "Error while adding definition (" <> s <> "): " <> show pe}
           where
             s = encode $ case md of

--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -33,6 +33,8 @@ import Primer.API (
   Prog (Prog),
   Selection,
   Tree,
+  TypeDef (..),
+  ValCon (..),
   viewTreeExpr,
   viewTreeType,
  )
@@ -63,6 +65,7 @@ import Primer.Gen.Core.Raw (
   genModuleName,
   genName,
   genTyConName,
+  genTyVarName,
   genType,
   genValConName,
  )
@@ -206,6 +209,18 @@ tasty_NodeFlavorNoBody = testToJSON $ G.enumBounded @_ @NodeFlavorNoBody
 genDef :: ExprGen Def
 genDef = Def <$> genGVarName <*> genExprTree <*> G.maybe genTypeTree
 
+genTypeDef :: ExprGen TypeDef
+genTypeDef =
+  TypeDef
+    <$> genTyConName
+    <*> G.list (R.linear 0 3) genTyVarName
+    <*> G.list (R.linear 0 3) genName
+    <*> G.maybe
+      ( G.list
+          (R.linear 0 3)
+          (ValCon <$> genValConName <*> G.list (R.linear 0 3) genTypeTree)
+      )
+
 tasty_Def :: Property
 tasty_Def = testToJSON $ evalExprGen 0 genDef
 
@@ -214,7 +229,7 @@ genModule =
   Module
     <$> genModuleName
     <*> G.bool
-    <*> G.list (R.linear 0 3) genTyConName
+    <*> G.list (R.linear 0 3) genTypeDef
     <*> G.list (R.linear 0 3) genDef
 
 tasty_Module :: Property

--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -30,9 +30,8 @@ import Primer.API (
   Module (Module),
   NewSessionReq (..),
   NodeBody (BoxBody, NoBody, PrimBody, TextBody),
-  NodeSelection (..),
   Prog (Prog),
-  Selection (..),
+  Selection,
   Tree,
   viewTreeExpr,
   viewTreeType,
@@ -45,7 +44,7 @@ import Primer.API.NodeFlavor (
  )
 import Primer.API.RecordPair (RecordPair (RecordPair))
 import Primer.Action.Available qualified as Available
-import Primer.App (Level, NodeType)
+import Primer.App (Level, NodeSelection (NodeSelection), NodeType, Selection' (Selection))
 import Primer.Core (GVarName, ID (ID), ModuleName, PrimCon (PrimChar, PrimInt))
 import Primer.Database (
   LastModified (..),
@@ -224,7 +223,7 @@ tasty_Module = testToJSON $ evalExprGen 0 genModule
 genNodeType :: ExprGen NodeType
 genNodeType = G.enumBounded
 
-genNodeSelection :: ExprGen NodeSelection
+genNodeSelection :: ExprGen (NodeSelection ID)
 genNodeSelection = NodeSelection <$> genNodeType <*> genID
 
 genSelection :: ExprGen Selection
@@ -307,7 +306,7 @@ instance Arbitrary ApplyActionBody where
   arbitrary = ApplyActionBody <$> arbitrary <*> arbitrary
 instance Arbitrary Selection where
   arbitrary = hedgehog $ evalExprGen 0 genSelection
-instance Arbitrary NodeSelection where
+instance Arbitrary (NodeSelection ID) where
   arbitrary = hedgehog $ evalExprGen 0 genNodeSelection
 instance Arbitrary a => Arbitrary (NonEmpty a) where
   arbitrary = (:|) <$> arbitrary <*> arbitrary

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -413,7 +413,7 @@
             },
             "NodeSelection": {
                 "properties": {
-                    "id": {
+                    "meta": {
                         "maximum": 9223372036854775807,
                         "minimum": -9223372036854775808,
                         "type": "integer"
@@ -424,7 +424,7 @@
                 },
                 "required": [
                     "nodeType",
-                    "id"
+                    "meta"
                 ],
                 "type": "object"
             },

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -100,6 +100,20 @@
                 ],
                 "type": "object"
             },
+            "DefSelection": {
+                "properties": {
+                    "def": {
+                        "$ref": "#/components/schemas/GlobalName"
+                    },
+                    "node": {
+                        "$ref": "#/components/schemas/NodeSelection"
+                    }
+                },
+                "required": [
+                    "def"
+                ],
+                "type": "object"
+            },
             "EvalFullResp": {
                 "oneOf": [
                     {
@@ -187,7 +201,11 @@
                     "MakeTVar",
                     "MakeForall",
                     "RenameForall",
-                    "RenameDef"
+                    "RenameDef",
+                    "RenameType",
+                    "RenameCon",
+                    "RenameTypeParam",
+                    "AddCon"
                 ],
                 "type": "string"
             },
@@ -284,7 +302,8 @@
                     "RaiseType",
                     "DeleteType",
                     "DuplicateDef",
-                    "DeleteDef"
+                    "DeleteDef",
+                    "AddConField"
                 ],
                 "type": "string"
             },
@@ -656,18 +675,44 @@
                 "type": "object"
             },
             "Selection": {
-                "properties": {
-                    "def": {
-                        "$ref": "#/components/schemas/GlobalName"
+                "oneOf": [
+                    {
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/DefSelection"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "SelectionDef"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
                     },
-                    "node": {
-                        "$ref": "#/components/schemas/NodeSelection"
+                    {
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/TypeDefSelection"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "SelectionTypeDef"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
                     }
-                },
-                "required": [
-                    "def"
-                ],
-                "type": "object"
+                ]
             },
             "Session": {
                 "properties": {
@@ -744,6 +789,93 @@
                     "name",
                     "params",
                     "nameHints"
+                ],
+                "type": "object"
+            },
+            "TypeDefConsFieldSelection": {
+                "properties": {
+                    "index": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    },
+                    "meta": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "index",
+                    "meta"
+                ],
+                "type": "object"
+            },
+            "TypeDefConsSelection": {
+                "properties": {
+                    "con": {
+                        "$ref": "#/components/schemas/GlobalName"
+                    },
+                    "field": {
+                        "$ref": "#/components/schemas/TypeDefConsFieldSelection"
+                    }
+                },
+                "required": [
+                    "con"
+                ],
+                "type": "object"
+            },
+            "TypeDefNodeSelection": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "contents": {
+                                "type": "string"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "TypeDefParamNodeSelection"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/TypeDefConsSelection"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "TypeDefConsNodeSelection"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "TypeDefSelection": {
+                "properties": {
+                    "def": {
+                        "$ref": "#/components/schemas/GlobalName"
+                    },
+                    "node": {
+                        "$ref": "#/components/schemas/TypeDefNodeSelection"
+                    }
+                },
+                "required": [
+                    "def"
                 ],
                 "type": "object"
             },
@@ -1127,7 +1259,11 @@
                                 "MakeTVar",
                                 "MakeForall",
                                 "RenameForall",
-                                "RenameDef"
+                                "RenameDef",
+                                "RenameType",
+                                "RenameCon",
+                                "RenameTypeParam",
+                                "AddCon"
                             ],
                             "type": "string"
                         }

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -224,7 +224,7 @@
                     },
                     "types": {
                         "items": {
-                            "$ref": "#/components/schemas/GlobalName"
+                            "$ref": "#/components/schemas/TypeDef"
                         },
                         "type": "array"
                     }
@@ -716,10 +716,59 @@
                 ],
                 "type": "object"
             },
+            "TypeDef": {
+                "properties": {
+                    "constructors": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValCon"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/GlobalName"
+                    },
+                    "nameHints": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "params": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "name",
+                    "params",
+                    "nameHints"
+                ],
+                "type": "object"
+            },
             "UUID": {
                 "example": "00000000-0000-0000-0000-000000000000",
                 "format": "uuid",
                 "type": "string"
+            },
+            "ValCon": {
+                "properties": {
+                    "fields": {
+                        "items": {
+                            "$ref": "#/components/schemas/Tree"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/GlobalName"
+                    }
+                },
+                "required": [
+                    "name",
+                    "fields"
+                ],
+                "type": "object"
             }
         }
     },

--- a/primer/src/Foreword.hs
+++ b/primer/src/Foreword.hs
@@ -32,8 +32,6 @@ module Foreword (
   curry4,
   unsafeMaximum,
   spanMaybe,
-  adjustAtA',
-  findAndAdjustA',
 ) where
 
 -- In general, we should defer to "Protolude"'s exports and avoid name
@@ -132,11 +130,6 @@ adjustAtA n f xs = case splitAt n xs of
   (a, b : bs) -> f b <&> \b' -> Just $ a ++ [b'] ++ bs
   _ -> pure Nothing
 
-adjustAtA' :: Applicative f => Int -> (a -> f (a, z)) -> [a] -> f (Maybe ([a], z))
-adjustAtA' n f xs = case splitAt n xs of
-  (a, b : bs) -> f b <&> \(b', z) -> Just (a ++ [b'] ++ bs, z)
-  _ -> pure Nothing
-
 -- | Adjust the first element of the list which satisfies the
 -- predicate. Returns 'Nothing' if there is no such element.
 findAndAdjust :: (a -> Bool) -> (a -> a) -> [a] -> Maybe [a]
@@ -149,11 +142,6 @@ findAndAdjustA :: Applicative m => (a -> Bool) -> (a -> m a) -> [a] -> m (Maybe 
 findAndAdjustA p f = \case
   [] -> pure Nothing
   x : xs -> if p x then Just . (: xs) <$> f x else (x :) <<$>> findAndAdjustA p f xs
-
-findAndAdjustA' :: Applicative m => (a -> Bool) -> (a -> m (a, z)) -> [a] -> m (Maybe ([a], z))
-findAndAdjustA' p f = \case
-  [] -> pure Nothing
-  x : xs -> if p x then (\(x', z) -> Just . (,z) . (: xs) $ x') <$> f x else first (x :) <<$>> findAndAdjustA' p f xs
 
 -- | Change the type of an error.
 modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -1160,7 +1160,7 @@ data Selection = Selection
   deriving anyclass (NFData)
 
 viewSelection :: App.Selection -> Selection
-viewSelection App.Selection{..} = Selection{def = selectedDef, node = viewNodeSelection <$> selectedNode}
+viewSelection App.Selection{..} = Selection{def = def, node = viewNodeSelection <$> node}
 
 -- | 'App.NodeSelection' without any node metadata.
 data NodeSelection = NodeSelection

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -139,6 +139,7 @@ import Primer.Core (
   CaseBranch' (..),
   Expr,
   Expr' (..),
+  ExprMeta,
   GVarName,
   GlobalName (..),
   HasID (..),
@@ -152,6 +153,7 @@ import Primer.Core (
   TyVarName,
   Type,
   Type' (..),
+  TypeMeta,
   ValConName,
   getID,
   unLocalName,
@@ -1169,5 +1171,5 @@ data NodeSelection = NodeSelection
   deriving (FromJSON, ToJSON) via PrimerJSON NodeSelection
   deriving anyclass (NFData)
 
-viewNodeSelection :: App.NodeSelection -> NodeSelection
+viewNodeSelection :: App.NodeSelection (Either ExprMeta TypeMeta) -> NodeSelection
 viewNodeSelection sel@App.NodeSelection{nodeType} = NodeSelection{nodeType, id = getID sel}

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -63,10 +63,7 @@ module Primer.API (
   viewTreeType,
   viewTreeExpr,
   getApp,
-  Selection (..),
-  viewSelection,
-  NodeSelection (..),
-  viewNodeSelection,
+  Selection,
   undoAvailable,
   redoAvailable,
   Name (..),
@@ -139,7 +136,6 @@ import Primer.Core (
   CaseBranch' (..),
   Expr,
   Expr' (..),
-  ExprMeta,
   GVarName,
   GlobalName (..),
   HasID (..),
@@ -153,7 +149,6 @@ import Primer.Core (
   TyVarName,
   Type,
   Type' (..),
-  TypeMeta,
   ValConName,
   getID,
   unLocalName,
@@ -659,7 +654,7 @@ viewProg :: App.Prog -> Prog
 viewProg p =
   Prog
     { modules = map (viewModule True) (progModules p) <> map (viewModule False) (progImports p)
-    , selection = viewSelection <$> progSelection p
+    , selection = getID <<$>> progSelection p
     , undoAvailable = not $ null $ unlog $ progLog p
     , redoAvailable = not $ null $ unlog $ redoLog p
     }
@@ -1045,10 +1040,10 @@ availableActions = curry3 $ logAPI (noError AvailableActions) $ \(sid, level, se
   case selection.node of
     Nothing ->
       pure $ Available.forDef (snd <$> allDefs) level editable selection.def
-    Just NodeSelection{..} -> do
+    Just App.NodeSelection{..} -> do
       pure $ case nodeType of
-        SigNode -> Available.forSig level editable type_ id
-        BodyNode -> Available.forBody (snd <$> allTypeDefs) level editable expr id
+        SigNode -> Available.forSig level editable type_ meta
+        BodyNode -> Available.forBody (snd <$> allTypeDefs) level editable expr meta
 
 actionOptions ::
   (MonadIO m, MonadThrow m, MonadAPILog l m) =>
@@ -1062,7 +1057,7 @@ actionOptions = curry4 $ logAPI (noError ActionOptions) $ \(sid, level, selectio
   let prog = appProg app
       allDefs = progAllDefs prog
       allTypeDefs = progAllTypeDefs prog
-      nodeSel = selection.node <&> \s -> (s.nodeType, s.id)
+      nodeSel = selection.node <&> \s -> (s.nodeType, s.meta)
   def' <- snd <$> findASTDef allDefs selection.def
   maybe (throwM $ ActionOptionsNoID nodeSel) pure $
     Available.options
@@ -1095,7 +1090,7 @@ applyActionNoInput = curry3 $ logAPI (noError ApplyActionNoInput) $ \(sid, selec
         (snd <$> progAllDefs prog)
         def
         selection.def
-        (selection.node <&> \s -> (s.nodeType, s.id))
+        (selection.node <&> \s -> (s.nodeType, s.meta))
         action
   applyActions sid actions
 
@@ -1113,7 +1108,7 @@ applyActionInput = curry3 $ logAPI (noError ApplyActionInput) $ \(sid, body, act
       toProgActionInput
         def
         body.selection.def
-        (body.selection.node <&> \s -> (s.nodeType, s.id))
+        (body.selection.node <&> \s -> (s.nodeType, s.meta))
         body.option
         action
   applyActions sid actions
@@ -1151,25 +1146,4 @@ redo =
       >>= either (throwM . RedoError) (pure . viewProg)
 
 -- | 'App.Selection' without any node metadata.
-data Selection = Selection
-  { def :: GVarName
-  , node :: Maybe NodeSelection
-  }
-  deriving stock (Eq, Show, Read, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSON Selection
-  deriving anyclass (NFData)
-
-viewSelection :: App.Selection -> Selection
-viewSelection App.Selection{..} = Selection{def = def, node = viewNodeSelection <$> node}
-
--- | 'App.NodeSelection' without any node metadata.
-data NodeSelection = NodeSelection
-  { nodeType :: NodeType
-  , id :: ID
-  }
-  deriving stock (Eq, Show, Read, Generic)
-  deriving (FromJSON, ToJSON) via PrimerJSON NodeSelection
-  deriving anyclass (NFData)
-
-viewNodeSelection :: App.NodeSelection (Either ExprMeta TypeMeta) -> NodeSelection
-viewNodeSelection sel@App.NodeSelection{nodeType} = NodeSelection{nodeType, id = getID sel}
+type Selection = App.Selection' ID

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -681,7 +681,7 @@ viewProg p =
                               flip evalState (0 :: Int) . traverseOf _typeMeta \() -> do
                                 n <- get
                                 put $ n + 1
-                                pure $ "primtype_" <> show d' <> "_" <> show n
+                                pure $ "primtype_" <> Name.unName (Core.baseName name) <> "_" <> show n
                   }
             )
               <$> Map.assocs (moduleDefsQualified m)

--- a/primer/src/Primer/Action/Available.hs
+++ b/primer/src/Primer/Action/Available.hs
@@ -81,6 +81,7 @@ import Primer.Primitives (tChar, tInt)
 import Primer.Questions (
   generateNameExpr,
   generateNameTy,
+  generateNameTyAvoiding,
   variablesInScopeExpr,
   variablesInScopeTy,
  )
@@ -490,8 +491,8 @@ options typeDefs defs cxt level def0 sel0 = \case
             Left zE -> generateNameExpr typeOrKind zE
             Right zT -> generateNameTy typeOrKind zT
         SelectionTypeDef sel -> do
-          (_, zT) <- conField sel
-          pure $ generateNameTy typeOrKind zT
+          (def, zT) <- conField sel
+          pure $ generateNameTyAvoiding (unLocalName . fst <$> astTypeDefParameters def) typeOrKind zT
     varsInScope = case sel0 of
       SelectionDef sel -> do
         nodeSel <- sel.node

--- a/primer/src/Primer/Action/Errors.hs
+++ b/primer/src/Primer/Action/Errors.hs
@@ -69,6 +69,7 @@ data ActionError
   | NeedTypeDefSelection
   | NeedTypeDefNodeSelection
   | NeedTypeDefConsSelection
+  | NeedTypeDefConsFieldSelection
   | NeedTypeDefParamSelection
   | NoNodeSelection
   | ValConNotFound TyConName ValConName

--- a/primer/src/Primer/Action/Errors.hs
+++ b/primer/src/Primer/Action/Errors.hs
@@ -13,7 +13,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..))
 import Primer.Action.Actions (Action)
 import Primer.Action.Available qualified as Available
 import Primer.Action.Movement (Movement)
-import Primer.Core (Expr, GVarName, ID, LVarName, ModuleName, Type)
+import Primer.Core (Expr, GVarName, ID, LVarName, ModuleName, TyConName, Type, ValConName)
 import Primer.JSON (CustomJSON (..), PrimerJSON)
 import Primer.Typecheck.TypeError (TypeError)
 import Primer.Zipper (SomeNode)
@@ -63,6 +63,14 @@ data ActionError
   | NeedLocal Available.Option
   | NeedInt Available.Option
   | NeedChar Available.Option
+  | NeedTermDef
+  | NeedTypeDef
+  | NeedTermDefSelection
+  | NeedTypeDefSelection
+  | NeedTypeDefNodeSelection
+  | NeedTypeDefConsSelection
+  | NeedTypeDefParamSelection
   | NoNodeSelection
+  | ValConNotFound TyConName ValConName
   deriving stock (Eq, Show, Read, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON ActionError

--- a/primer/src/Primer/Action/Priorities.hs
+++ b/primer/src/Primer/Action/Priorities.hs
@@ -55,6 +55,10 @@ module Primer.Action.Priorities (
   constructTypeApp,
   constructForall,
 
+  -- * Type def actions.
+  addCon,
+  addConField,
+
   -- * Generic actions.
   rename,
   duplicate,
@@ -146,3 +150,9 @@ raise _ = 300
 
 delete :: Level -> Int
 delete _ = maxBound
+
+addCon :: Level -> Int
+addCon _ = 10
+
+addConField :: Level -> Int
+addConField _ = 10

--- a/primer/src/Primer/Action/ProgAction.hs
+++ b/primer/src/Primer/Action/ProgAction.hs
@@ -39,8 +39,6 @@ data ProgAction
     RenameTypeParam TyConName TyVarName Text
   | -- | Add a value constructor at the given position, in the given type
     AddCon TyConName Int Text
-  | -- | Change the type of the field at the given index of the given constructor
-    SetConFieldType TyConName ValConName Int (Type' ())
   | -- | Add a new field, at the given index, to the given constructor
     AddConField TyConName ValConName Int (Type' ())
   | -- | Execute a sequence of actions on the body of the definition

--- a/primer/src/Primer/Action/ProgAction.hs
+++ b/primer/src/Primer/Action/ProgAction.hs
@@ -47,6 +47,8 @@ data ProgAction
     BodyAction [Action]
   | -- | Execute a sequence of actions on the type annotation of the definition
     SigAction [Action]
+  | -- | Execute a sequence of actions on the type of a field of a constructor in a typedef
+    ConFieldAction TyConName ValConName Int [Action]
   | SetSmartHoles SmartHoles
   | -- | CopyPaste (d,i) as
     --   remembers the tree in def d, node i

--- a/primer/src/Primer/Action/ProgError.hs
+++ b/primer/src/Primer/Action/ProgError.hs
@@ -11,6 +11,7 @@ import Primer.Name (Name)
 
 data ProgError
   = NoDefSelected
+  | NoTypeDefSelected
   | DefNotFound GVarName
   | DefAlreadyExists GVarName
   | DefInUse GVarName

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -104,7 +104,8 @@ import Primer.App.Base (
   Level (..),
   NodeSelection (..),
   NodeType (..),
-  Selection (..),
+  Selection,
+  Selection' (..),
  )
 import Primer.Core (
   Bind' (Bind),

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- This module defines the high level application functions.
@@ -323,8 +324,8 @@ newEmptyProgImporting imported =
           , progSelection =
               Just
                 Selection
-                  { selectedDef = qualifyName moduleName defName
-                  , selectedNode = Nothing
+                  { def = qualifyName moduleName defName
+                  , node = Nothing
                   }
           }
       , nextID
@@ -881,7 +882,7 @@ applyProgAction prog = \case
                     ActionError $
                       InternalFailure "RenameModule: imported modules were edited by renaming"
   where
-    mdefName = selectedDef <$> progSelection prog
+    mdefName = (.def) <$> progSelection prog
 
 -- Helper for RenameModule action
 data RenameMods a = RM {imported :: [a], editable :: [a]}
@@ -1378,8 +1379,8 @@ tcWholeProg p = do
   newSel <- case oldSel of
     Nothing -> pure Nothing
     Just s -> do
-      let defName_ = s ^. #selectedDef
-      updatedNode <- case s ^. #selectedNode of
+      let defName_ = s.def
+      updatedNode <- case s.node of
         Nothing -> pure Nothing
         Just sel@NodeSelection{nodeType} -> do
           n <- runExceptT $ focusNode p' defName_ $ getID sel
@@ -1390,8 +1391,8 @@ tcWholeProg p = do
       pure $
         Just $
           Selection
-            { selectedDef = defName_
-            , selectedNode = updatedNode
+            { def = defName_
+            , node = updatedNode
             }
   pure $ p'{progSelection = newSel}
 

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -48,8 +48,6 @@ module Primer.App (
   handleEvalFullRequest,
   importModules,
   MutationRequest (..),
-  Selection (..),
-  NodeSelection (..),
   EvalReq (..),
   EvalResp (..),
   EvalFullReq (..),
@@ -63,7 +61,6 @@ import Foreword hiding (mod)
 import Control.Monad.Fresh (MonadFresh (..))
 import Control.Monad.Log (MonadLog, WithSeverity)
 import Control.Monad.NestedError (MonadNestedError, throwError')
-import Data.Data (Data)
 import Data.Generics.Uniplate.Operations (transform, transformM)
 import Data.Generics.Uniplate.Zipper (
   fromZipper,
@@ -78,10 +75,8 @@ import Optics (
   Field3 (_3),
   ReversibleOptic (re),
   ifoldMap,
-  lens,
   mapped,
   over,
-  set,
   traverseOf,
   traversed,
   view,
@@ -107,7 +102,9 @@ import Primer.Action.ProgError (ProgError (..))
 import Primer.App.Base (
   Editable (..),
   Level (..),
+  NodeSelection (..),
   NodeType (..),
+  Selection (..),
  )
 import Primer.Core (
   Bind' (Bind),
@@ -115,10 +112,8 @@ import Primer.Core (
   CaseBranch' (CaseBranch),
   Expr,
   Expr' (Case, Con, EmptyHole, Hole, Var),
-  ExprMeta,
   GVarName,
   GlobalName (baseName, qualifiedModule),
-  HasID (_id),
   ID (..),
   LocalName (LocalName, unLocalName),
   Meta (..),
@@ -414,33 +409,6 @@ newtype Log = Log {unlog :: [[ProgAction]]}
 -- | The default (empty) 'Log'.
 defaultLog :: Log
 defaultLog = Log mempty
-
--- | Describes what interface element the student has selected.
--- A definition in the left hand nav bar, and possibly a node in that definition.
-data Selection = Selection
-  { selectedDef :: GVarName
-  -- ^ the ID of some ASTDef
-  , selectedNode :: Maybe NodeSelection
-  }
-  deriving stock (Eq, Show, Read, Generic, Data)
-  deriving (FromJSON, ToJSON) via PrimerJSON Selection
-  deriving anyclass (NFData)
-
--- | A selected node, in the body or type signature of some definition.
--- We have the following invariant: @nodeType = SigNode ==> isRight meta@
-data NodeSelection = NodeSelection
-  { nodeType :: NodeType
-  , meta :: Either ExprMeta TypeMeta
-  }
-  deriving stock (Eq, Show, Read, Generic, Data)
-  deriving (FromJSON, ToJSON) via PrimerJSON NodeSelection
-  deriving anyclass (NFData)
-
-instance HasID NodeSelection where
-  _id =
-    lens
-      (either getID getID . meta)
-      (flip $ \id -> over #meta $ bimap (set _id id) (set _id id))
 
 -- | The type of requests which can mutate the application state.
 data MutationRequest

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -34,6 +34,7 @@ module Primer.App (
   progAllModules,
   progAllDefs,
   progAllTypeDefs,
+  progAllTypeDefsMeta,
   allValConNames,
   allTyConNames,
   progCxt,
@@ -100,6 +101,7 @@ import Primer.Action (
   ProgAction (..),
   applyAction',
   applyActionsToBody,
+  applyActionsToField,
   applyActionsToTypeSig,
  )
 import Primer.Action.ProgError (ProgError (..))
@@ -115,6 +117,7 @@ import Primer.App.Base (
   TypeDefConsSelection (..),
   TypeDefNodeSelection (..),
   TypeDefSelection (..),
+  getTypeDefConFieldType,
  )
 import Primer.Core (
   Bind' (Bind),
@@ -896,6 +899,31 @@ applyProgAction prog = \case
                         , meta = Right meta
                         }
               )
+  ConFieldAction tyName con index actions -> editModuleOfCrossType (Just tyName) prog $ \ms defName def -> do
+    let smartHoles = progSmartHoles prog
+    applyActionsToField smartHoles (progImports prog) ms (defName, con, index, def) actions >>= \case
+      Left err -> throwError $ ActionError err
+      Right (mod', zt) ->
+        pure
+          ( mod'
+          , Just $
+              SelectionTypeDef
+                TypeDefSelection
+                  { def = tyName
+                  , node =
+                      Just $
+                        TypeDefConsNodeSelection
+                          TypeDefConsSelection
+                            { con
+                            , field =
+                                Just
+                                  TypeDefConsFieldSelection
+                                    { index
+                                    , meta = Right $ zt ^. _target % _typeMetaLens
+                                    }
+                            }
+                  }
+          )
   SetSmartHoles smartHoles ->
     pure $ prog & #progSmartHoles .~ smartHoles
   CopyPasteSig fromIds setup -> case mdefName of
@@ -1028,6 +1056,19 @@ editModuleOfCross mdefName prog f = case mdefName of
     case Map.lookup (baseName defname) (moduleDefs m) of
       Just (DefAST def) -> f ms (baseName defname) def
       _ -> throwError $ DefNotFound defname
+
+editModuleOfCrossType ::
+  MonadError ProgError m =>
+  Maybe TyConName ->
+  Prog ->
+  ((Module, [Module]) -> Name -> ASTTypeDef TypeMeta -> m ([Module], Maybe Selection)) ->
+  m Prog
+editModuleOfCrossType mdefName prog f = case mdefName of
+  Nothing -> throwError NoTypeDefSelected
+  Just defname -> editModuleCross (qualifiedModule defname) prog $ \ms@(m, _) ->
+    case Map.lookup (baseName defname) (moduleTypes m) of
+      Just (TypeDefAST def) -> f ms (baseName defname) def
+      _ -> throwError $ TypeDefNotFound defname
 
 -- | Undo the last block of actions.
 --
@@ -1454,8 +1495,7 @@ tcWholeProg p = do
                 -- This is similar to what we do when selection is in a term, above.
                 td <- Map.lookup s.def $ allTypesMeta p
                 tda <- typeDefAST td
-                vc <- find ((== conSel.con) . valConName) $ astTypeDefConstructors tda
-                atMay (valConArgs vc) fieldSel.index
+                getTypeDefConFieldType tda conSel.con fieldSel.index
   pure $ p'{progSelection = newSel}
 
 -- | Do a full check of a 'Prog', both the imports and the local modules

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -613,28 +613,34 @@ applyProgAction prog = \case
     ty <- newType
     let def = ASTDef expr ty
     pure (insertDef mod name $ DefAST def, Just $ SelectionDef $ DefSelection (qualifyName modName name) Nothing)
-  AddTypeDef tc td -> editModuleSameSelection (qualifiedModule tc) prog $ \m -> do
+  AddTypeDef tc td -> editModule (qualifiedModule tc) prog $ \m -> do
     td' <- generateTypeDefIDs $ TypeDefAST td
     let tydefs' = moduleTypes m <> Map.singleton (baseName tc) td'
-    m{moduleTypes = tydefs'}
-      <$ liftError
-        -- The frontend should never let this error case happen,
-        -- so we just dump out a raw string for debugging/logging purposes
-        -- (This is not currently true! We should synchronise the frontend with
-        -- the typechecker rules. For instance, the form allows to create
-        --   data T (T : *) = T
-        -- but the TC rejects it.
-        -- see https://github.com/hackworthltd/primer/issues/3)
-        (TypeDefError . show @TypeError)
-        ( runReaderT
-            (checkTypeDefs $ Map.singleton tc (TypeDefAST td))
-            (buildTypingContextFromModules (progAllModules prog) NoSmartHoles)
-        )
-  RenameType old (unsafeMkName -> nameRaw) -> editModuleSameSelectionCross (qualifiedModule old) prog $ \(m, ms) -> do
+    liftError
+      -- The frontend should never let this error case happen,
+      -- so we just dump out a raw string for debugging/logging purposes
+      -- (This is not currently true! We should synchronise the frontend with
+      -- the typechecker rules. For instance, the form allows to create
+      --   data T (T : *) = T
+      -- but the TC rejects it.
+      -- see https://github.com/hackworthltd/primer/issues/3)
+      (TypeDefError . show @TypeError)
+      ( runReaderT
+          (checkTypeDefs $ Map.singleton tc (TypeDefAST td))
+          (buildTypingContextFromModules (progAllModules prog) NoSmartHoles)
+      )
+    pure
+      ( m{moduleTypes = tydefs'}
+      , Just $ SelectionTypeDef $ TypeDefSelection tc Nothing
+      )
+  RenameType old (unsafeMkName -> nameRaw) -> editModuleCross (qualifiedModule old) prog $ \(m, ms) -> do
     when (new `elem` allTyConNames prog) $ throwError $ TypeDefAlreadyExists new
     m' <- traverseOf #moduleTypes updateType m
     let renamedInTypes = over (traversed % #moduleTypes) updateRefsInTypes $ m' : ms
-    pure $ over (traversed % #moduleDefs % traversed % #_DefAST) (updateDefBody . updateDefType) renamedInTypes
+    pure
+      ( over (traversed % #moduleDefs % traversed % #_DefAST) (updateDefBody . updateDefType) renamedInTypes
+      , Just $ SelectionTypeDef $ TypeDefSelection new Nothing
+      )
     where
       new = qualifyName (qualifiedModule old) nameRaw
       updateType m = do
@@ -664,10 +670,13 @@ applyProgAction prog = \case
           $ over (#_TCon % _2) updateName
       updateName n = if n == old then new else n
   RenameCon type_ old (unsafeMkGlobalName . (fmap unName (unModuleName (qualifiedModule type_)),) -> new) ->
-    editModuleSameSelectionCross (qualifiedModule type_) prog $ \(m, ms) -> do
+    editModuleCross (qualifiedModule type_) prog $ \(m, ms) -> do
       when (new `elem` allValConNames prog) $ throwError $ ConAlreadyExists new
       m' <- updateType m
-      pure $ over (mapped % #moduleDefs) updateDefs (m' : ms)
+      pure
+        ( over (mapped % #moduleDefs) updateDefs (m' : ms)
+        , Just $ SelectionTypeDef $ TypeDefSelection type_ $ Just $ TypeDefConsNodeSelection $ TypeDefConsSelection new Nothing
+        )
     where
       updateType =
         alterTypeDef
@@ -685,7 +694,12 @@ applyProgAction prog = \case
               . over (#_Case % _3 % traversed % #_CaseBranch % _1) updateName
       updateName n = if n == old then new else n
   RenameTypeParam type_ old (unsafeMkLocalName -> new) ->
-    editModuleSameSelection (qualifiedModule type_) prog updateType
+    editModule (qualifiedModule type_) prog $ \m -> do
+      m' <- updateType m
+      pure
+        ( m'
+        , Just $ SelectionTypeDef $ TypeDefSelection type_ $ Just $ TypeDefParamNodeSelection new
+        )
     where
       updateType =
         alterTypeDef
@@ -713,13 +727,18 @@ applyProgAction prog = \case
           $ \(_, v) -> tvar $ updateName v
       updateName n = if n == old then new else n
   AddCon type_ index (unsafeMkGlobalName . (fmap unName (unModuleName (qualifiedModule type_)),) -> con) ->
-    editModuleSameSelectionCross (qualifiedModule type_) prog $ \(m, ms) -> do
+    editModuleCross (qualifiedModule type_) prog $ \(m, ms) -> do
       when (con `elem` allValConNames prog) $ throwError $ ConAlreadyExists con
       m' <- updateType m
-      traverseOf
-        (traversed % #moduleDefs % traversed % #_DefAST % #astDefExpr)
-        updateDefs
-        $ m' : ms
+      ms' <-
+        traverseOf
+          (traversed % #moduleDefs % traversed % #_DefAST % #astDefExpr)
+          updateDefs
+          $ m' : ms
+      pure
+        ( ms'
+        , Just $ SelectionTypeDef $ TypeDefSelection type_ $ Just $ TypeDefConsNodeSelection $ TypeDefConsSelection con Nothing
+        )
     where
       updateDefs = transformCaseBranches prog type_ $ \bs -> do
         m' <- DSL.meta
@@ -794,9 +813,19 @@ applyProgAction prog = \case
                   e
             else pure cb
   AddConField type_ con index new ->
-    editModuleSameSelectionCross (qualifiedModule type_) prog $ \(m, ms) -> do
+    editModuleCross (qualifiedModule type_) prog $ \(m, ms) -> do
       m' <- updateType m
-      traverseOf (traversed % #moduleDefs) updateDefs (m' : ms)
+      ms' <- traverseOf (traversed % #moduleDefs) updateDefs (m' : ms)
+      pure
+        ( ms'
+        , Just
+            . SelectionTypeDef
+            . TypeDefSelection type_
+            . Just
+            . TypeDefConsNodeSelection
+            . TypeDefConsSelection con
+            $ Nothing
+        )
     where
       updateType =
         alterTypeDef

--- a/primer/src/Primer/App/Base.hs
+++ b/primer/src/Primer/App/Base.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 -- | Definitions needed to build the app.
 -- These are not part of the core language, but we may want to use them in dependencies of 'Primer.App'.
@@ -57,9 +59,9 @@ data NodeType = BodyNode | SigNode
 type Selection = Selection' (Either ExprMeta TypeMeta)
 
 data Selection' a = Selection
-  { selectedDef :: GVarName
+  { def :: GVarName
   -- ^ the ID of some ASTDef
-  , selectedNode :: Maybe (NodeSelection a)
+  , node :: Maybe (NodeSelection a)
   }
   deriving stock (Eq, Show, Read, Functor, Generic, Data)
   deriving (FromJSON, ToJSON) via PrimerJSON (Selection' a)
@@ -76,4 +78,4 @@ data NodeSelection a = NodeSelection
   deriving anyclass (NFData)
 
 instance HasID a => HasID (NodeSelection a) where
-  _id = lens (getID . meta) (flip $ over #meta . set _id)
+  _id = lens (getID . (.meta)) (flip $ over #meta . set _id)

--- a/primer/src/Primer/App/Base.hs
+++ b/primer/src/Primer/App/Base.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
 -- | Definitions needed to build the app.
@@ -17,6 +18,7 @@ module Primer.App.Base (
   TypeDefConsFieldSelection (..),
   DefSelection (..),
   NodeSelection (..),
+  getTypeDefConFieldType,
 ) where
 
 import Protolude
@@ -29,6 +31,7 @@ import Primer.Core (
   HasID (..),
   TyConName,
   TyVarName,
+  Type',
   TypeMeta,
   ValConName,
   getID,
@@ -39,6 +42,7 @@ import Primer.JSON (
   PrimerJSON,
   ToJSON,
  )
+import Primer.TypeDef (ASTTypeDef, ValCon (..), astTypeDefConstructors)
 
 -- | The current programming "level". This setting determines which
 -- actions are displayed to the student, the labels on UI elements,
@@ -130,3 +134,8 @@ data NodeSelection a = NodeSelection
 
 instance HasID a => HasID (NodeSelection a) where
   _id = lens (getID . (.meta)) (flip $ over #meta . set _id)
+
+getTypeDefConFieldType :: ASTTypeDef a -> ValConName -> Int -> Maybe (Type' a)
+getTypeDefConFieldType def con index =
+  flip atMay index . valConArgs
+    =<< find ((== con) . valConName) (astTypeDefConstructors def)

--- a/primer/src/Primer/App/Base.hs
+++ b/primer/src/Primer/App/Base.hs
@@ -6,7 +6,8 @@ module Primer.App.Base (
   Level (..),
   Editable (..),
   NodeType (..),
-  Selection (..),
+  Selection,
+  Selection' (..),
   NodeSelection (..),
 ) where
 
@@ -53,27 +54,26 @@ data NodeType = BodyNode | SigNode
 
 -- | Describes what interface element the student has selected.
 -- A definition in the left hand nav bar, and possibly a node in that definition.
-data Selection = Selection
+type Selection = Selection' (Either ExprMeta TypeMeta)
+
+data Selection' a = Selection
   { selectedDef :: GVarName
   -- ^ the ID of some ASTDef
-  , selectedNode :: Maybe NodeSelection
+  , selectedNode :: Maybe (NodeSelection a)
   }
-  deriving stock (Eq, Show, Read, Generic, Data)
-  deriving (FromJSON, ToJSON) via PrimerJSON Selection
+  deriving stock (Eq, Show, Read, Functor, Generic, Data)
+  deriving (FromJSON, ToJSON) via PrimerJSON (Selection' a)
   deriving anyclass (NFData)
 
 -- | A selected node, in the body or type signature of some definition.
 -- We have the following invariant: @nodeType = SigNode ==> isRight meta@
-data NodeSelection = NodeSelection
+data NodeSelection a = NodeSelection
   { nodeType :: NodeType
-  , meta :: Either ExprMeta TypeMeta
+  , meta :: a
   }
-  deriving stock (Eq, Show, Read, Generic, Data)
-  deriving (FromJSON, ToJSON) via PrimerJSON NodeSelection
+  deriving stock (Eq, Show, Read, Functor, Generic, Data)
+  deriving (FromJSON, ToJSON) via PrimerJSON (NodeSelection a)
   deriving anyclass (NFData)
 
-instance HasID NodeSelection where
-  _id =
-    lens
-      (either getID getID . meta)
-      (flip $ \id -> over #meta $ bimap (set _id id) (set _id id))
+instance HasID a => HasID (NodeSelection a) where
+  _id = lens (getID . meta) (flip $ over #meta . set _id)

--- a/primer/src/Primer/App/Base.hs
+++ b/primer/src/Primer/App/Base.hs
@@ -1,14 +1,26 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 -- | Definitions needed to build the app.
 -- These are not part of the core language, but we may want to use them in dependencies of 'Primer.App'.
 module Primer.App.Base (
   Level (..),
   Editable (..),
   NodeType (..),
+  Selection (..),
+  NodeSelection (..),
 ) where
 
 import Protolude
 
 import Data.Data (Data)
+import Optics
+import Primer.Core (
+  ExprMeta,
+  GVarName,
+  HasID (..),
+  TypeMeta,
+  getID,
+ )
 import Primer.JSON (
   CustomJSON (CustomJSON),
   FromJSON,
@@ -38,3 +50,30 @@ data NodeType = BodyNode | SigNode
   deriving stock (Eq, Show, Read, Bounded, Enum, Generic, Data)
   deriving (FromJSON, ToJSON) via PrimerJSON NodeType
   deriving anyclass (NFData)
+
+-- | Describes what interface element the student has selected.
+-- A definition in the left hand nav bar, and possibly a node in that definition.
+data Selection = Selection
+  { selectedDef :: GVarName
+  -- ^ the ID of some ASTDef
+  , selectedNode :: Maybe NodeSelection
+  }
+  deriving stock (Eq, Show, Read, Generic, Data)
+  deriving (FromJSON, ToJSON) via PrimerJSON Selection
+  deriving anyclass (NFData)
+
+-- | A selected node, in the body or type signature of some definition.
+-- We have the following invariant: @nodeType = SigNode ==> isRight meta@
+data NodeSelection = NodeSelection
+  { nodeType :: NodeType
+  , meta :: Either ExprMeta TypeMeta
+  }
+  deriving stock (Eq, Show, Read, Generic, Data)
+  deriving (FromJSON, ToJSON) via PrimerJSON NodeSelection
+  deriving anyclass (NFData)
+
+instance HasID NodeSelection where
+  _id =
+    lens
+      (either getID getID . meta)
+      (flip $ \id -> over #meta $ bimap (set _id id) (set _id id))

--- a/primer/src/Primer/Core/Meta.hs
+++ b/primer/src/Primer/Core/Meta.hs
@@ -159,6 +159,12 @@ instance HasID ID where
 instance HasID (Meta a) where
   _id = position @1
 
+instance (HasID a, HasID b) => HasID (Either a b) where
+  _id =
+    lens
+      (either getID getID)
+      (flip $ \id -> bimap (set _id id) (set _id id))
+
 -- This instance is used in 'Primer.Zipper', but it would be an orphan if we defined it there.
 instance HasID a => HasID (Zipper a a) where
   _id = lens getter setter

--- a/primer/src/Primer/JSON.hs
+++ b/primer/src/Primer/JSON.hs
@@ -13,8 +13,7 @@ import Data.Aeson (
   ToJSON,
   ToJSONKey,
  )
-import Deriving.Aeson (CustomJSON (..))
-import Deriving.Aeson.Stock (Vanilla)
+import Deriving.Aeson (CustomJSON (..), OmitNothingFields)
 
 -- | A type for Primer API JSON encodings.
 --
@@ -43,4 +42,10 @@ import Deriving.Aeson.Stock (Vanilla)
 --
 -- * @SumTwoElemArray@ is unsupported by openapi3 as it is unrepresentable in
 --   a schema.
-type PrimerJSON a = Vanilla a
+type PrimerJSON a =
+  CustomJSON
+    '[ -- This protects some clients (e.g. TypeScript) from spurious equality failures
+       -- due to null-vs-omitted inconsistency.
+       OmitNothingFields
+     ]
+    a

--- a/primer/src/Primer/Module.hs
+++ b/primer/src/Primer/Module.hs
@@ -2,6 +2,7 @@ module Primer.Module (
   Module (..),
   qualifyTyConName,
   moduleTypesQualified,
+  moduleTypesQualifiedMeta,
   qualifyDefName,
   moduleDefsQualified,
   insertDef,
@@ -77,7 +78,10 @@ qualifyTyConName :: Module -> Name -> TyConName
 qualifyTyConName m = qualifyName (moduleName m)
 
 moduleTypesQualified :: Module -> TypeDefMap
-moduleTypesQualified m = mapKeys (qualifyTyConName m) $ forgetTypeDefMetadata <$> moduleTypes m
+moduleTypesQualified = map forgetTypeDefMetadata . moduleTypesQualifiedMeta
+
+moduleTypesQualifiedMeta :: Module -> Map TyConName (TypeDef TypeMeta)
+moduleTypesQualifiedMeta m = mapKeys (qualifyTyConName m) $ moduleTypes m
 
 qualifyDefName :: Module -> Name -> GVarName
 qualifyDefName m = qualifyName (moduleName m)

--- a/primer/src/Primer/Questions.hs
+++ b/primer/src/Primer/Questions.hs
@@ -10,6 +10,7 @@ module Primer.Questions (
   ShadowedVarsTy (..), -- only exported for testing
   generateNameExpr,
   generateNameTy,
+  generateNameTyAvoiding,
   uniquify,
 ) where
 
@@ -100,9 +101,18 @@ generateNameTy ::
   Either (Maybe (Type' ())) (Maybe Kind) ->
   TypeZip ->
   m [Name]
+generateNameTy = generateNameTyAvoiding []
+
+generateNameTyAvoiding ::
+  MonadReader Cxt m =>
+  [Name] ->
+  Either (Maybe (Type' ())) (Maybe Kind) ->
+  TypeZip ->
+  m [Name]
 -- It doesn't really make sense to ask for a term variable (Left) here, but
 -- it doesn't harm to support it
-generateNameTy tk z = uniquifyMany <$> mkAvoidForFreshNameTy z <*> baseNames tk
+generateNameTyAvoiding avoiding tk z =
+  uniquifyMany <$> ((Set.fromList avoiding <>) <$> mkAvoidForFreshNameTy z) <*> baseNames tk
 
 baseNames ::
   MonadReader Cxt m =>

--- a/primer/src/Primer/TypeDef.hs
+++ b/primer/src/Primer/TypeDef.hs
@@ -54,7 +54,7 @@ type TypeDefMap = Map TyConName (TypeDef ())
 
 -- | Definition of a primitive data type
 data PrimTypeDef = PrimTypeDef
-  { primTypeDefParameters :: [Kind]
+  { primTypeDefParameters :: [(TyVarName, Kind)]
   , primTypeDefNameHints :: [Name]
   }
   deriving stock (Eq, Show, Read, Data, Generic)
@@ -94,16 +94,16 @@ typeDefNameHints :: TypeDef b -> [Name]
 typeDefNameHints = \case
   TypeDefPrim t -> primTypeDefNameHints t
   TypeDefAST t -> astTypeDefNameHints t
-typeDefParameters :: TypeDef b -> [Kind]
+typeDefParameters :: TypeDef b -> [(TyVarName, Kind)]
 typeDefParameters = \case
   TypeDefPrim t -> primTypeDefParameters t
-  TypeDefAST t -> snd <$> astTypeDefParameters t
+  TypeDefAST t -> astTypeDefParameters t
 typeDefAST :: TypeDef b -> Maybe (ASTTypeDef b)
 typeDefAST = \case
   TypeDefPrim _ -> Nothing
   TypeDefAST t -> Just t
 typeDefKind :: TypeDef b -> Kind
-typeDefKind = foldr KFun KType . typeDefParameters
+typeDefKind = foldr (KFun . snd) KType . typeDefParameters
 
 -- | A traversal over the contstructor fields in an typedef.
 _typedefFields :: Traversal (TypeDef b) (TypeDef c) (Type' b) (Type' c)

--- a/primer/src/Primer/Typecheck/Cxt.hs
+++ b/primer/src/Primer/Typecheck/Cxt.hs
@@ -28,4 +28,4 @@ data Cxt = Cxt
   , globalCxt :: Map GVarName Type
   -- ^ global variables (i.e. IDs of top-level definitions)
   }
-  deriving stock (Show)
+  deriving stock (Show, Generic)

--- a/primer/src/Primer/Zipper.hs
+++ b/primer/src/Primer/Zipper.hs
@@ -448,7 +448,7 @@ findNodeWithParent id x = do
     InBind (BindCase bz) -> (CaseBindNode $ caseBindZFocus bz, Just . ExprNode . target . unfocusCaseBind $ bz)
 
 -- | Find a sub-type in a larger type by its ID.
-findType :: ID -> Type -> Maybe Type
+findType :: (Data a, HasID a) => ID -> Type' a -> Maybe (Type' a)
 findType id ty = target <$> focusOnTy id ty
 
 -- | An AST node tagged with its "sort" - i.e. if it's a type or expression or binding etc.

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -36,6 +36,7 @@ import Primer.Action (
  )
 import Primer.App (
   App,
+  DefSelection (..),
   Log (..),
   NodeSelection (..),
   NodeType (..),
@@ -161,7 +162,7 @@ unit_move_to_def_main = progActionTest defaultEmptyProg [moveToDef "main"] $
     prog'
       @?= prog
         { progLog = Log [[moveToDef "main"]]
-        , progSelection = Just $ Selection (gvn "main") Nothing
+        , progSelection = Just $ SelectionDef $ DefSelection (gvn "main") Nothing
         }
 
 -- Expression actions are tested in ActionTest - here we just check that we can modify the correct
@@ -503,7 +504,7 @@ unit_construct_arrow_in_sig =
             TFun _ lhs _ ->
               -- Check that the selection is focused on the lhs, as we instructed
               case progSelection prog' of
-                Just (Selection d (Just sel@NodeSelection{nodeType = SigNode})) -> do
+                Just (SelectionDef (DefSelection d (Just sel@NodeSelection{nodeType = SigNode}))) -> do
                   d @?= qualifyName mainModuleName "other"
                   getID sel @?= getID lhs
                 _ -> assertFailure "no selection"
@@ -1327,7 +1328,11 @@ unit_rename_module =
         Left err -> assertFailure $ show err
         Right p -> do
           fmap (unModuleName . moduleName) (progModules p) @?= [["Module2"]]
-          (.def) <$> progSelection p @?= Just (qualifyName (ModuleName ["Module2"]) "main")
+          sel <- case progSelection p of
+            Just (SelectionDef s) -> pure s
+            Just (SelectionTypeDef _) -> assertFailure "typedef selected"
+            Nothing -> assertFailure "no selection"
+          sel.def @?= qualifyName (ModuleName ["Module2"]) "main"
           case fmap (Map.assocs . moduleDefsQualified) (progModules p) of
             [[(n, DefAST d)]] -> do
               let expectedName = qualifyName (ModuleName ["Module2"]) "main"
@@ -1510,7 +1515,7 @@ unit_sh_lost_id =
         Just def ->
           case astDefExpr <$> defAST def of
             Just (Var m (GlobalVarRef f)) | f == foo -> case progSelection prog' of
-              Just Selection{def = selectedDef, node = Just sel} ->
+              Just (SelectionDef DefSelection{def = selectedDef, node = Just sel}) ->
                 unless (selectedDef == foo && getID sel == getID m) $
                   assertFailure "expected selection to point at the recursive reference"
               _ -> assertFailure "expected the selection to point at some node"
@@ -1548,8 +1553,8 @@ defaultEmptyProg = do
    in pure $
         newEmptyProg'
           { progSelection =
-              Just $
-                Selection (gvn "main") $
+              Just . SelectionDef $
+                DefSelection (gvn "main") $
                   Just
                     NodeSelection
                       { nodeType = BodyNode

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Tests.Action.Prog where
 
@@ -1326,7 +1327,7 @@ unit_rename_module =
         Left err -> assertFailure $ show err
         Right p -> do
           fmap (unModuleName . moduleName) (progModules p) @?= [["Module2"]]
-          selectedDef <$> progSelection p @?= Just (qualifyName (ModuleName ["Module2"]) "main")
+          (.def) <$> progSelection p @?= Just (qualifyName (ModuleName ["Module2"]) "main")
           case fmap (Map.assocs . moduleDefsQualified) (progModules p) of
             [[(n, DefAST d)]] -> do
               let expectedName = qualifyName (ModuleName ["Module2"]) "main"
@@ -1509,7 +1510,7 @@ unit_sh_lost_id =
         Just def ->
           case astDefExpr <$> defAST def of
             Just (Var m (GlobalVarRef f)) | f == foo -> case progSelection prog' of
-              Just Selection{selectedDef, selectedNode = Just sel} ->
+              Just Selection{def = selectedDef, node = Just sel} ->
                 unless (selectedDef == foo && getID sel == getID m) $
                   assertFailure "expected selection to point at the recursive reference"
               _ -> assertFailure "expected the selection to point at some node"

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -1290,6 +1290,40 @@ unit_AddConField_case_ann =
                 ]
           )
 
+unit_ConFieldAction :: Assertion
+unit_ConFieldAction =
+  progActionTest
+    ( defaultProgEditableTypeDefs $ do
+        e <- con cA $ replicate 3 $ con0 $ vcn "True"
+        t <- tEmptyHole
+        pure [astDef "def" e t]
+    )
+    [ConFieldAction tT cA 1 [ConstructArrowL]]
+    $ expectSuccess
+    $ \_ prog' -> do
+      td <- findTypeDef tT prog'
+      def <- findDef (gvn "def") prog'
+      astTypeDefConstructors td
+        @?= [ ValCon
+                cA
+                [ TCon () (tcn "Bool")
+                , TFun () (TCon () (tcn "Bool")) (TEmptyHole ())
+                , TCon () (tcn "Bool")
+                ]
+            , ValCon cB [TApp () (TApp () (TCon () tT) (TVar () "b")) (TVar () "a"), TVar () "b"]
+            ]
+      forgetMetadata (astDefExpr def)
+        @?= forgetMetadata
+          ( create' $
+              do
+                con
+                  cA
+                  [ con0 $ vcn "True"
+                  , hole $ con0 $ vcn "True"
+                  , con0 $ vcn "True"
+                  ]
+          )
+
 -- Check that we see name hints from imported modules
 -- (This differs from the tests in Tests.Question by testing the actual action,
 -- rather than the underlying functionality)

--- a/primer/test/Tests/Action/Prog.hs
+++ b/primer/test/Tests/Action/Prog.hs
@@ -42,7 +42,7 @@ import Primer.App (
   ProgAction (..),
   ProgError (..),
   Question (GenerateName, VariablesInScope),
-  Selection (..),
+  Selection' (..),
   appIdCounter,
   appNameCounter,
   appProg,

--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -20,7 +20,8 @@ import Primer.App (
   Prog (..),
   ProgAction (BodyAction, MoveToDef),
   ProgError (NoDefSelected),
-  Selection (..),
+  Selection,
+  Selection' (..),
   defaultLog,
  )
 import Primer.Builtins (tNat)

--- a/primer/test/Tests/Serialization.hs
+++ b/primer/test/Tests/Serialization.hs
@@ -13,6 +13,7 @@ import Data.Map.Strict qualified as Map
 import Data.String (String)
 import Primer.Action (Action (Move, SetCursor), ActionError (IDNotFound), Movement (Child1))
 import Primer.App (
+  DefSelection (..),
   EvalResp (EvalResp, evalRespDetail, evalRespExpr, evalRespRedexes),
   Log (..),
   NodeSelection (..),
@@ -152,12 +153,13 @@ fixtures =
           }
       selection :: Selection
       selection =
-        Selection (qualifyName modName defName) $
-          Just
-            NodeSelection
-              { nodeType = BodyNode
-              , meta = Left exprMeta
-              }
+        SelectionDef $
+          DefSelection (qualifyName modName defName) $
+            Just
+              NodeSelection
+                { nodeType = BodyNode
+                , meta = Left exprMeta
+                }
       reductionDetail :: EvalDetail
       reductionDetail =
         BetaReduction $

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -799,7 +799,7 @@ instance Eq (TypeCacheAlpha [Module]) where
   (==) = tcaFunctorial
 instance Eq (TypeCacheAlpha ExprMeta) where
   (==) = tcaFunctorial
-instance Eq (TypeCacheAlpha App.NodeSelection) where
+instance Eq (TypeCacheAlpha (App.NodeSelection (Either ExprMeta TypeMeta))) where
   TypeCacheAlpha (App.NodeSelection t1 m1) == TypeCacheAlpha (App.NodeSelection t2 m2) =
     t1 == t2 && ((==) `on` first TypeCacheAlpha) m1 m2
 instance Eq (TypeCacheAlpha App.Selection) where

--- a/primer/test/Tests/Typecheck.hs
+++ b/primer/test/Tests/Typecheck.hs
@@ -18,6 +18,9 @@ import Primer.App (
     progSmartHoles,
     redoLog
   ),
+  TypeDefConsFieldSelection (..),
+  TypeDefConsSelection (..),
+  TypeDefSelection (..),
   appIdCounter,
   appInit,
   appNameCounter,
@@ -30,6 +33,7 @@ import Primer.App (
   tcWholeProgWithImports,
  )
 import Primer.App qualified as App
+import Primer.App.Base (TypeDefNodeSelection (..))
 import Primer.Builtins (
   boolDef,
   cCons,
@@ -782,6 +786,10 @@ tcaFunctorial :: (Functor f, Eq (f (TypeCacheAlpha a))) => TypeCacheAlpha (f a) 
 tcaFunctorial = (==) `on` (fmap TypeCacheAlpha . unTypeCacheAlpha)
 instance Eq (TypeCacheAlpha a) => Eq (TypeCacheAlpha (Maybe a)) where
   (==) = tcaFunctorial
+instance (Eq (TypeCacheAlpha a), Eq (TypeCacheAlpha b)) => Eq (TypeCacheAlpha (Either a b)) where
+  TypeCacheAlpha (Left a1) == TypeCacheAlpha (Left a2) = TypeCacheAlpha a1 == TypeCacheAlpha a2
+  TypeCacheAlpha (Right b1) == TypeCacheAlpha (Right b2) = TypeCacheAlpha b1 == TypeCacheAlpha b2
+  _ == _ = False
 instance (Eq (TypeCacheAlpha a), Eq b) => Eq (TypeCacheAlpha (Expr' (Meta a) b)) where
   (==) = (==) `on` (((_exprMeta % _type) %~ TypeCacheAlpha) . unTypeCacheAlpha)
 instance Eq (TypeCacheAlpha Def) where
@@ -799,12 +807,22 @@ instance Eq (TypeCacheAlpha [Module]) where
   (==) = tcaFunctorial
 instance Eq (TypeCacheAlpha ExprMeta) where
   (==) = tcaFunctorial
+instance Eq (TypeCacheAlpha TypeMeta) where
+  (==) = tcaFunctorial
+instance Eq (TypeCacheAlpha Kind) where
+  TypeCacheAlpha k1 == TypeCacheAlpha k2 = k1 == k2
 instance Eq (TypeCacheAlpha (App.NodeSelection (Either ExprMeta TypeMeta))) where
   TypeCacheAlpha (App.NodeSelection t1 m1) == TypeCacheAlpha (App.NodeSelection t2 m2) =
     t1 == t2 && ((==) `on` first TypeCacheAlpha) m1 m2
 instance Eq (TypeCacheAlpha App.Selection) where
-  TypeCacheAlpha (App.Selection d1 n1) == TypeCacheAlpha (App.Selection d2 n2) =
+  TypeCacheAlpha (App.SelectionDef (App.DefSelection d1 n1)) == TypeCacheAlpha (App.SelectionDef (App.DefSelection d2 n2)) =
     d1 == d2 && TypeCacheAlpha n1 == TypeCacheAlpha n2
+  TypeCacheAlpha (App.SelectionTypeDef (TypeDefSelection a1 (Just (TypeDefConsNodeSelection (TypeDefConsSelection n1 (Just (TypeDefConsFieldSelection b1 m1)))))))
+    == TypeCacheAlpha (App.SelectionTypeDef (TypeDefSelection a2 (Just (TypeDefConsNodeSelection (TypeDefConsSelection n2 (Just (TypeDefConsFieldSelection b2 m2))))))) =
+      a1 == a2 && b1 == b2 && n1 == n2 && TypeCacheAlpha m1 == TypeCacheAlpha m2
+  TypeCacheAlpha (App.SelectionTypeDef (TypeDefSelection n1 s1)) == TypeCacheAlpha (App.SelectionTypeDef (TypeDefSelection n2 s2)) =
+    n1 == n2 && s1 == s2
+  _ == _ = False
 instance Eq (TypeCacheAlpha Prog) where
   TypeCacheAlpha (Prog i1 m1 s1 sh1 l1 r1) == TypeCacheAlpha (Prog i2 m2 s2 sh2 l2 r2) =
     TypeCacheAlpha i1 == TypeCacheAlpha i2

--- a/primer/test/outputs/serialization/edit_response_2.json
+++ b/primer/test/outputs/serialization/edit_response_2.json
@@ -147,28 +147,31 @@
             }
         ],
         "progSelection": {
-            "def": {
-                "baseName": "main",
-                "qualifiedModule": [
-                    "M"
-                ]
-            },
-            "node": {
-                "meta": {
-                    "Left": [
-                        0,
-                        {
-                            "contents": {
-                                "contents": [],
-                                "tag": "TEmptyHole"
-                            },
-                            "tag": "TCSynthed"
-                        },
-                        null
+            "contents": {
+                "def": {
+                    "baseName": "main",
+                    "qualifiedModule": [
+                        "M"
                     ]
                 },
-                "nodeType": "BodyNode"
-            }
+                "node": {
+                    "meta": {
+                        "Left": [
+                            0,
+                            {
+                                "contents": {
+                                    "contents": [],
+                                    "tag": "TEmptyHole"
+                                },
+                                "tag": "TCSynthed"
+                            },
+                            null
+                        ]
+                    },
+                    "nodeType": "BodyNode"
+                }
+            },
+            "tag": "SelectionDef"
         },
         "progSmartHoles": "SmartHoles",
         "redoLog": {

--- a/primer/test/outputs/serialization/edit_response_2.json
+++ b/primer/test/outputs/serialization/edit_response_2.json
@@ -147,13 +147,13 @@
             }
         ],
         "progSelection": {
-            "selectedDef": {
+            "def": {
                 "baseName": "main",
                 "qualifiedModule": [
                     "M"
                 ]
             },
-            "selectedNode": {
+            "node": {
                 "meta": {
                     "Left": [
                         0,

--- a/primer/test/outputs/serialization/prog.json
+++ b/primer/test/outputs/serialization/prog.json
@@ -146,28 +146,31 @@
         }
     ],
     "progSelection": {
-        "def": {
-            "baseName": "main",
-            "qualifiedModule": [
-                "M"
-            ]
-        },
-        "node": {
-            "meta": {
-                "Left": [
-                    0,
-                    {
-                        "contents": {
-                            "contents": [],
-                            "tag": "TEmptyHole"
-                        },
-                        "tag": "TCSynthed"
-                    },
-                    null
+        "contents": {
+            "def": {
+                "baseName": "main",
+                "qualifiedModule": [
+                    "M"
                 ]
             },
-            "nodeType": "BodyNode"
-        }
+            "node": {
+                "meta": {
+                    "Left": [
+                        0,
+                        {
+                            "contents": {
+                                "contents": [],
+                                "tag": "TEmptyHole"
+                            },
+                            "tag": "TCSynthed"
+                        },
+                        null
+                    ]
+                },
+                "nodeType": "BodyNode"
+            }
+        },
+        "tag": "SelectionDef"
     },
     "progSmartHoles": "SmartHoles",
     "redoLog": {

--- a/primer/test/outputs/serialization/prog.json
+++ b/primer/test/outputs/serialization/prog.json
@@ -146,13 +146,13 @@
         }
     ],
     "progSelection": {
-        "selectedDef": {
+        "def": {
             "baseName": "main",
             "qualifiedModule": [
                 "M"
             ]
         },
-        "selectedNode": {
+        "node": {
             "meta": {
                 "Left": [
                     0,

--- a/primer/test/outputs/serialization/selection.json
+++ b/primer/test/outputs/serialization/selection.json
@@ -1,11 +1,11 @@
 {
-    "selectedDef": {
+    "def": {
         "baseName": "main",
         "qualifiedModule": [
             "M"
         ]
     },
-    "selectedNode": {
+    "node": {
         "meta": {
             "Left": [
                 0,

--- a/primer/test/outputs/serialization/selection.json
+++ b/primer/test/outputs/serialization/selection.json
@@ -1,24 +1,27 @@
 {
-    "def": {
-        "baseName": "main",
-        "qualifiedModule": [
-            "M"
-        ]
-    },
-    "node": {
-        "meta": {
-            "Left": [
-                0,
-                {
-                    "contents": {
-                        "contents": [],
-                        "tag": "TEmptyHole"
-                    },
-                    "tag": "TCSynthed"
-                },
-                null
+    "contents": {
+        "def": {
+            "baseName": "main",
+            "qualifiedModule": [
+                "M"
             ]
         },
-        "nodeType": "BodyNode"
-    }
+        "node": {
+            "meta": {
+                "Left": [
+                    0,
+                    {
+                        "contents": {
+                            "contents": [],
+                            "tag": "TEmptyHole"
+                        },
+                        "tag": "TCSynthed"
+                    },
+                    null
+                ]
+            },
+            "nodeType": "BodyNode"
+        }
+    },
+    "tag": "SelectionDef"
 }


### PR DESCRIPTION
This allows us to finally take advantage of #367 (with the caveats detailed in #399, #401 and #402).

This will ultimately enable us to render typedefs alongside terms in our frontend, and modify them using the same actions panel with which we manipulate terms.

See #1040 and #1041 for potential follow-ups.