### PR TITLE
fix: offered names

### DIFF
--- a/primer/src/Primer/Action.hs
+++ b/primer/src/Primer/Action.hs
@@ -10,6 +10,8 @@ module Primer.Action (
   applyActionsToTypeSig,
   applyActionsToExpr,
   moveExpr,
+  enterType,
+  moveType,
   uniquifyDefName,
   toProgActionInput,
   toProgActionNoInput,

--- a/primer/src/Primer/Action/Available.hs
+++ b/primer/src/Primer/Action/Available.hs
@@ -376,8 +376,8 @@ options typeDefs defs cxt level def mNodeSel = \case
   MakeForall ->
     freeVar <$> genNames (Right Nothing)
   RenameForall -> do
-    TypeNode t <- findNode
-    freeVar <$> genNames (Right $ t ^. _typeMetaLens % _type)
+    TypeNode (TForall _ _ k _) <- findNode
+    freeVar <$> genNames (Right $ Just k)
   RenameDef ->
     pure $ freeVar []
   where

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -88,6 +88,7 @@ import Primer.Core.DSL (
   lAM,
   lam,
   let_,
+  letrec,
   lvar,
   tEmptyHole,
   tapp,
@@ -564,3 +565,12 @@ unit_rename_let_names =
     "p"
     (letType "x" (tcon tBool `tfun` tcon tBool) $ emptyHole)
 -}
+
+unit_rename_letrec_names :: Assertion
+unit_rename_letrec_names =
+  offeredNamesTest
+    (letrec "x" emptyHole (tcon tBool) emptyHole)
+    []
+    RenameLet
+    "p"
+    (letrec "p" emptyHole (tcon tBool) emptyHole)

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -545,3 +545,22 @@ unit_rename_let_names =
     RenameLet
     "p"
     (let_ "p" (emptyHole `ann` tcon tBool) emptyHole)
+
+{-
+-- TODO: reinstate once the TC handles let type!
+-- See https://github.com/hackworthltd/primer/issues/5
+--unit_rename_lettype_names :: Assertion
+--unit_rename_lettype_names = do
+  offeredNamesTest
+    (letType "x" (tcon tBool) emptyHole)
+    []
+    RenameLet
+    "p"
+    (letType "p" (tcon tBool) emptyHole)
+  offeredNamesTest
+    (letType "x" (tcon tBool `tfun` tcon tBool) $ emptyHole)
+    []
+    RenameLet
+    "p"
+    (letType "x" (tcon tBool `tfun` tcon tBool) $ emptyHole)
+-}

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, RenameLet),
+  InputAction (MakeCon, MakeLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -482,6 +482,15 @@ offeredNamesTest initial moves act name =
     initial
     moves
     (Right (act, Option name Nothing))
+
+unit_make_lam_names :: Assertion
+unit_make_lam_names =
+  offeredNamesTest
+    (emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+    [Child1]
+    MakeLam
+    "i"
+    (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
 
 -- nb: renaming let cares about the type of the bound var, not of the let
 unit_rename_let_names :: Assertion

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLAM, MakeLam, RenameLam, RenameLet),
+  InputAction (MakeCon, MakeLAM, MakeLam, RenameLAM, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -516,6 +516,21 @@ unit_make_LAM_names = do
     (emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
     [Child1]
     MakeLAM
+    "f"
+    (lAM "f" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+
+unit_rename_LAM_names :: Assertion
+unit_rename_LAM_names = do
+  offeredNamesTest
+    (lAM "x" emptyHole `ann` tforall "a" KType (tcon tBool))
+    [Child1]
+    RenameLAM
+    "α"
+    (lAM "α" emptyHole `ann` tforall "a" KType (tcon tBool))
+  offeredNamesTest
+    (lAM "x" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+    [Child1]
+    RenameLAM
     "f"
     (lAM "f" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
 

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -486,6 +486,8 @@ offeredNamesTest initial moves act name =
     moves
     (Right (act, Option name Nothing))
 
+-- Note that lambdas are the only form which we have interesting name info when
+-- we initially create them.
 unit_make_lam_names :: Assertion
 unit_make_lam_names =
   offeredNamesTest

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -38,7 +38,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLAM, MakeLam, RenameLAM, RenameLam, RenameLet),
+  InputAction (MakeCon, MakeLAM, MakeLam, RenameForall, RenameLAM, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -597,3 +597,18 @@ unit_rename_letrec_names =
     (letrec "p" emptyHole (tcon tBool) emptyHole)
 
 -- There is no unit_rename_pattern_names as can only move to a pattern by ID, which is awkward here
+
+unit_rename_forall_names :: Assertion
+unit_rename_forall_names = do
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" KType (tcon tBool))
+    ([] `InType` [])
+    RenameForall
+    "α"
+    (emptyHole `ann` tforall "α" KType (tcon tBool))
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+    ([] `InType` [])
+    RenameForall
+    "f"
+    (emptyHole `ann` tforall "f" (KFun KType KType) (tcon tBool))

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -574,3 +574,5 @@ unit_rename_letrec_names =
     RenameLet
     "p"
     (letrec "p" emptyHole (tcon tBool) emptyHole)
+
+-- There is no unit_rename_pattern_names as can only move to a pattern by ID, which is awkward here

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLam, RenameLet),
+  InputAction (MakeCon, MakeLam, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -489,6 +489,15 @@ unit_make_lam_names =
     (emptyHole `ann` (tcon tNat `tfun` tcon tBool))
     [Child1]
     MakeLam
+    "i"
+    (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+
+unit_rename_lam_names :: Assertion
+unit_rename_lam_names =
+  offeredNamesTest
+    (lam "x" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+    [Child1]
+    RenameLam
     "i"
     (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
 

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -612,3 +612,22 @@ unit_rename_forall_names = do
     RenameForall
     "f"
     (emptyHole `ann` tforall "f" (KFun KType KType) (tcon tBool))
+
+{-
+-- TODO: reinstate once the TC handles let type!
+-- See https://github.com/hackworthltd/primer/issues/5
+--unit_rename_tlet_names :: Assertion
+--unit_rename_tlet_names = do
+  offeredNamesTest
+    (emptyHole `ann` tlet "a" (tcon tNat) tEmptyHole)
+    ([] `InType` [])
+    RenameLet
+    "α"
+    (emptyHole `ann` tlet "α" (tcon tNat) tEmptyHole)
+  offeredNamesTest
+    (emptyHole `ann` tlet "a" (tcon tList) tEmptyHole)
+    ([] `InType` [])
+    RenameLet
+    "f"
+    (emptyHole `ann` tlet "f" (tcon tList) tEmptyHole)
+-}

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLam, RenameLam, RenameLet),
+  InputAction (MakeCon, MakeLAM, MakeLam, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -68,6 +68,7 @@ import Primer.Core (
   GlobalName (baseName, qualifiedModule),
   HasID (_id),
   ID,
+  Kind (KFun, KType),
   ModuleName (ModuleName, unModuleName),
   getID,
   mkSimpleModuleName,
@@ -84,12 +85,14 @@ import Primer.Core.DSL (
   emptyHole,
   gvar,
   hole,
+  lAM,
   lam,
   let_,
   lvar,
   tEmptyHole,
   tapp,
   tcon,
+  tforall,
   tfun,
  )
 import Primer.Core.Utils (
@@ -500,6 +503,21 @@ unit_rename_lam_names =
     RenameLam
     "i"
     (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+
+unit_make_LAM_names :: Assertion
+unit_make_LAM_names = do
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" KType (tcon tBool))
+    [Child1]
+    MakeLAM
+    "α"
+    (lAM "α" emptyHole `ann` tforall "a" KType (tcon tBool))
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+    [Child1]
+    MakeLAM
+    "f"
+    (lAM "f" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
 
 -- nb: renaming let cares about the type of the bound var, not of the let
 unit_rename_let_names :: Assertion

--- a/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
@@ -41,15 +41,11 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "z"
+                                { option = "p"
                                 , context = Nothing
                                 }
                             , Option
-                                { option = "x1"
-                                , context = Nothing
-                                }
-                            , Option
-                                { option = "y1"
+                                { option = "q"
                                 , context = Nothing
                                 }
                             ]

--- a/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
@@ -63,15 +63,11 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "z"
+                                { option = "p"
                                 , context = Nothing
                                 }
                             , Option
-                                { option = "x1"
-                                , context = Nothing
-                                }
-                            , Option
-                                { option = "y1"
+                                { option = "q"
                                 , context = Nothing
                                 }
                             ]

--- a/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
@@ -42,15 +42,11 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "z"
+                                { option = "p"
                                 , context = Nothing
                                 }
                             , Option
-                                { option = "x1"
-                                , context = Nothing
-                                }
-                            , Option
-                                { option = "y1"
+                                { option = "q"
                                 , context = Nothing
                                 }
                             ]


### PR DESCRIPTION
We fix what names are offered for `let`s and `forall`s, and add tests for each available action which offers names (except for type lets and renaming pattern variables, which are hard to test for technical reasons).