### PR TITLE
DNM: messy test to try to find undo bug; only found some other bugs

### DIFF
--- a/primer/gen/Primer/Gen/App.hs
+++ b/primer/gen/Primer/Gen/App.hs
@@ -8,6 +8,7 @@
 module Primer.Gen.App (
   genProg,
   genApp,
+  extendCxtByModules,
 ) where
 
 import Control.Monad.Fresh (MonadFresh (fresh))
@@ -88,10 +89,6 @@ genProg sh initialImports = local (extendCxtByModules initialImports) $ do
           pure $ x : rest
     extendCxtByModule :: Module -> Cxt -> Cxt
     extendCxtByModule = extendCxtByModules . pure
-    extendCxtByModules :: [Module] -> Cxt -> Cxt
-    extendCxtByModules ms =
-      extendTypeDefCxt (foldMap' moduleTypesQualified ms)
-        . extendGlobalCxt (M.toList . fmap (forgetTypeMetadata . defType) $ foldMap' moduleDefsQualified ms)
     genModule :: Name -> Int -> GenT WT Module
     genModule prefix index = do
       let mn = ModuleName $ prefix :| [unsafeMkName $ show index]
@@ -104,6 +101,11 @@ genProg sh initialImports = local (extendCxtByModules initialImports) $ do
           , moduleTypes = M.fromList $ first baseName <$> tds
           , moduleDefs = defs
           }
+
+extendCxtByModules :: [Module] -> Cxt -> Cxt
+extendCxtByModules ms =
+      extendTypeDefCxt (foldMap' moduleTypesQualified ms)
+        . extendGlobalCxt (M.toList . fmap (forgetTypeMetadata . defType) $ foldMap' moduleDefsQualified ms)
 
 -- Generate a mutually-recursive group of term definitions
 genASTDefGroup :: ModuleName -> GenT WT (Map Name Def)

--- a/primer/gen/Primer/Gen/App.hs
+++ b/primer/gen/Primer/Gen/App.hs
@@ -104,8 +104,8 @@ genProg sh initialImports = local (extendCxtByModules initialImports) $ do
 
 extendCxtByModules :: [Module] -> Cxt -> Cxt
 extendCxtByModules ms =
-      extendTypeDefCxt (foldMap' moduleTypesQualified ms)
-        . extendGlobalCxt (M.toList . fmap (forgetTypeMetadata . defType) $ foldMap' moduleDefsQualified ms)
+  extendTypeDefCxt (foldMap' moduleTypesQualified ms)
+    . extendGlobalCxt (M.toList . fmap (forgetTypeMetadata . defType) $ foldMap' moduleDefsQualified ms)
 
 -- Generate a mutually-recursive group of term definitions
 genASTDefGroup :: ModuleName -> GenT WT (Map Name Def)

--- a/primer/src/Primer/Action.hs
+++ b/primer/src/Primer/Action.hs
@@ -294,12 +294,17 @@ applyActionAndCheck ty action z = do
   -- Refocus on where we were previously
   refocus Refocus{pre = z', post = exprTtoExpr typedAST} >>= \case
     Just z'' -> pure z''
-    Nothing -> throwError $ CustomFailure action $
-      "internal error: lost ID after typechecking; initial was \n "
-      <> show (unfocus z)
-      <> "\n   focused on " <> show (getID z)
-      <> "\n   action was " <> show action
-      <> "\n   result was \n" <> show typedAST
+    Nothing ->
+      throwError $
+        CustomFailure action $
+          "internal error: lost ID after typechecking; initial was \n "
+            <> show (unfocus z)
+            <> "\n   focused on "
+            <> show (getID z)
+            <> "\n   action was "
+            <> show action
+            <> "\n   result was \n"
+            <> show typedAST
 
 -- This is currently only used for tests.
 -- We may need it in the future for a REPL, where we want to build standalone expressions.

--- a/primer/src/Primer/Action.hs
+++ b/primer/src/Primer/Action.hs
@@ -242,7 +242,7 @@ refocus Refocus{pre, post} = do
         TC.NoSmartHoles -> [getID pre]
         TC.SmartHoles -> case pre of
           InExpr e -> candidateIDsExpr $ target e
-          InType t -> candidateIDsType $ target t
+          InType t -> candidateIDsType t
           InBind (BindCase ze) -> [getID ze]
   pure . getFirst . mconcat $ fmap (\i -> First $ focusOn i post) candidateIDs
   where
@@ -251,10 +251,17 @@ refocus Refocus{pre, post} = do
         Hole _ e' -> candidateIDsExpr e'
         Ann _ e' _ -> candidateIDsExpr e'
         _ -> []
-    candidateIDsType t =
-      getID t : case t of
-        THole _ t' -> candidateIDsType t'
-        _ -> []
+    candidateIDsTypeDown t = case t of
+      THole _ t' -> candidateIDsTypeDown t'
+      _ -> []
+    candidateIDsType tz =
+      getID tz
+        : candidateIDsTypeDown (target tz)
+          -- if we are focused inside a type annotation which gets elided, we
+          -- refocus on the expression it was annotating
+          <> case (up tz, target $ unfocusType tz) of
+            (Nothing, Ann _ e _) -> candidateIDsExpr e
+            _ -> []
 
 -- | Apply a sequence of actions to the body of a definition, producing a new Expr or an error if
 -- any of the actions failed to apply.
@@ -287,7 +294,12 @@ applyActionAndCheck ty action z = do
   -- Refocus on where we were previously
   refocus Refocus{pre = z', post = exprTtoExpr typedAST} >>= \case
     Just z'' -> pure z''
-    Nothing -> throwError $ CustomFailure action "internal error: lost ID after typechecking"
+    Nothing -> throwError $ CustomFailure action $
+      "internal error: lost ID after typechecking; initial was \n "
+      <> show (unfocus z)
+      <> "\n   focused on " <> show (getID z)
+      <> "\n   action was " <> show action
+      <> "\n   result was \n" <> show typedAST
 
 -- This is currently only used for tests.
 -- We may need it in the future for a REPL, where we want to build standalone expressions.

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -34,7 +34,7 @@ import Primer.Action (
   moveExpr,
   moveType,
   toProgActionInput,
-  toProgActionNoInput, ProgAction (AddTypeDef,CreateDef), applyActionsToBody,
+  toProgActionNoInput, ProgAction (AddTypeDef,CreateDef), applyActionsToBody, applyActionsToExpr,
  )
 import Primer.Action qualified as Action
 import Primer.Action.Available (
@@ -1178,6 +1178,14 @@ unit_tmp_3 =
                , astDefType
                }
   in case evalTestM i $ applyActionsToBody SmartHoles [] d [Action.Move Child1, Action.EnterType, Action.Delete] of
+    Left err -> assertFailure $ show err
+    Right _ -> pure ()
+
+-- As unit_tmp_3, but using applyActionsToExpr
+unit_tmp_4 :: Assertion
+unit_tmp_4 =
+  let (e, i) = create $ hole (emptyHole `ann` tforall "x" KType (tvar "x")) `ann` tforall "x" KType (tvar "x" `tfun` tEmptyHole)
+  in case evalTestM i $ applyActionsToExpr SmartHoles [] e [Action.Move Child1, Action.Move Child1, Action.EnterType, Action.Delete] of
     Left err -> assertFailure $ show err
     Right _ -> pure ()
 --------------------------------------

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -546,7 +546,7 @@ unit_tmp_1 = do
               fa <- tforall "x" KType (pure v)
               pure (getID v, getID fa, fa)
         (_, p2, a) <- ty
-        astDefExpr <- emptyHole `ann` (pure a)
+        astDefExpr <- emptyHole `ann` pure a
         (p1, _, astDefType) <- ty
         pure
           ( p1

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -25,9 +25,8 @@ import Hedgehog (
   (===), Gen, forAll,
  )
 import Hedgehog.Gen qualified as Gen
-import Hedgehog.Internal.Property (forAllWithT)
 import Hedgehog.Range qualified as Range
-import Optics (ix, toListOf, (%), (.~), (^..), _head)
+import Optics (ix, toListOf, (%), (.~), _head)
 import Primer.Action (
   ActionError (CaseBindsClash, NameCapture),
   Movement (Child1, Child2),
@@ -422,19 +421,19 @@ runRandomAvailableAction l a = do
       EditAppM (PureLog (WithSeverity ())) ProgError a ->
       App ->
       PropertyT WT (Either ProgError a, App)
-    runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+    runEditAppMLogs m a' = case runPureLog $ runEditAppM m a' of
       (r, logs) -> testNoSevereLogs logs >> pure r
     actionSucceeds :: HasCallStack => EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT App
-    actionSucceeds m a =
-      runEditAppMLogs m a >>= \case
+    actionSucceeds m a' =
+      runEditAppMLogs m a' >>= \case
         (Left err, _) -> annotateShow err >> failure
-        (Right _, a') -> pure a'
+        (Right _, a'') -> pure a''
     -- If we submit our own name rather than an offered one, then
     -- we should expect that name capture/clashing may happen
     actionSucceedsOrCapture :: HasCallStack => Provenance -> EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT (Maybe App)
-    actionSucceedsOrCapture p m a = do
-      a' <- runEditAppMLogs m a
-      case (p, a') of
+    actionSucceedsOrCapture p m a' = do
+      a'' <- runEditAppMLogs m a'
+      case (p, a'') of
         (StudentProvided, (Left (ActionError NameCapture), _)) -> do
           label "name-capture with entered name"
           annotate "ignoring name capture error as was generated name, not offered one"
@@ -448,7 +447,7 @@ runRandomAvailableAction l a = do
           annotate "ignoring def already exists error as was generated name, not offered one"
           pure Nothing
         (_, (Left err, _)) -> annotateShow err >> failure
-        (_, (Right _, a'')) -> pure $ Just a''
+        (_, (Right _, a''')) -> pure $ Just a'''
 
 -- helper type for tasty_undo_redo
 data Act = AddTm | AddTy

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -22,7 +22,7 @@ import Hedgehog (
   failure,
   label,
   success,
-  (===),
+  (===), Gen, forAll,
  )
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Internal.Property (forAllWithT)
@@ -35,7 +35,7 @@ import Primer.Action (
   moveExpr,
   moveType,
   toProgActionInput,
-  toProgActionNoInput,
+  toProgActionNoInput, ProgAction (AddTypeDef,CreateDef),
  )
 import Primer.Action.Available (
   InputAction (MakeCon, MakeLAM, MakeLam, RenameForall, RenameLAM, RenameLam, RenameLet),
@@ -49,7 +49,9 @@ import Primer.App (
   Editable (..),
   Level (Beginner, Expert, Intermediate),
   NodeType (..),
+  Prog (progLog, redoLog),
   ProgError (ActionError, DefAlreadyExists),
+  MutationRequest(Edit),
   appProg,
   checkAppWellFormed,
   checkProgWellFormed,
@@ -61,7 +63,7 @@ import Primer.App (
   progImports,
   progModules,
   progSmartHoles,
-  runEditAppM,
+  runEditAppM, handleMutationRequest, MutationRequest (Undo, Redo), Log (unlog),
  )
 import Primer.Builtins (builtinModuleName, cCons, tBool, tList, tNat)
 import Primer.Core (
@@ -111,10 +113,11 @@ import Primer.Def (
 import Primer.Examples (comprehensiveWellTyped)
 import Primer.Gen.App (genApp)
 import Primer.Gen.Core.Raw (genName)
-import Primer.Gen.Core.Typed (WT, forAllT, propertyWT)
+import Primer.Gen.Core.Typed (WT, forAllT, propertyWT, freshNameForCxt)
+import Primer.Gen.App (extendCxtByModules)
 import Primer.Log (PureLog, runPureLog)
 import Primer.Module (
-  Module (Module, moduleDefs),
+  Module (Module, moduleDefs, moduleName),
   builtinModule,
   moduleDefsQualified,
   moduleName,
@@ -144,6 +147,7 @@ import Tests.Typecheck (
   runTypecheckTestMIn,
  )
 import Text.Pretty.Simple (pShowNoColor)
+import Primer.TypeDef (ASTTypeDef(ASTTypeDef))
 
 -- | Comprehensive DSL test.
 test_1 :: TestTree
@@ -258,37 +262,13 @@ tasty_available_actions_accepted = withTests 500 $
       -- We only test SmartHoles mode (which is the only supported user-facing
       -- mode - NoSmartHoles is only used for internal sanity testing etc)
       a <- forAllT $ genApp SmartHoles cxt
-      let allDefs = progAllDefs $ appProg a
-      let isMutable = \case
-            Editable -> True
-            NonEditable -> False
-      (defName, (defMut, def)) <- case partition (isMutable . fst . snd) $ Map.toList allDefs of
-        ([], []) -> discard
-        (mut, []) -> label "all mut" >> forAllT (Gen.element mut)
-        ([], immut) -> label "all immut" >> forAllT (Gen.element immut)
-        (mut, immut) -> label "mixed mut/immut" >> forAllT (Gen.frequency [(9, Gen.element mut), (1, Gen.element immut)])
-      collect defMut
-      case def of
-        DefAST{} -> label "AST"
-        DefPrim{} -> label "Prim"
-      (loc, acts) <-
-        fmap snd . forAllWithT fst $
-          Gen.frequency $
-            catMaybes
-              [ Just (1, pure ("actionsForDef", (Nothing, Available.forDef (snd <$> allDefs) l defMut defName)))
-              , defAST def <&> \d' -> (2,) $ do
-                  let ty = astDefType d'
-                      ids = ty ^.. typeIDs
-                  i <- Gen.element ids
-                  let hedgehogMsg = "actionsForDefSig id " <> show i
-                  pure (hedgehogMsg, (Just (SigNode, i), Available.forSig l defMut ty i))
-              , defAST def <&> \d' -> (7,) $ do
-                  let expr = astDefExpr d'
-                      ids = expr ^.. exprIDs
-                  i <- Gen.element ids
-                  let hedgehogMsg = "actionsForDefBody id " <> show i
-                  pure (hedgehogMsg, (Just (BodyNode, i), Available.forBody (snd <$> progAllTypeDefs (appProg a)) l defMut expr i))
-              ]
+      (defName,defMut,defLoc) <- maybe discard forAll (pickPos $ appProg a)
+      -- TODO: use runRandomAction
+      let defMap = fmap snd $ progAllDefs $ appProg a
+      let (def, loc,acts) = case defLoc of
+            Left d -> (d, Nothing,Available.forDef defMap l defMut defName)
+            Right (d,SigNode, i) -> (DefAST d, Just (SigNode, i), Available.forSig l defMut (astDefType d) i)
+            Right (d,BodyNode, i) -> (DefAST d, Just (BodyNode, i), Available.forBody (snd <$> progAllTypeDefs (appProg a)) l defMut (astDefExpr d) i)
       case acts of
         [] -> label "no offered actions" >> success
         acts' -> do
@@ -358,7 +338,186 @@ tasty_available_actions_accepted = withTests 500 $
         (_, (Right _, a'')) -> ensureSHNormal a''
     ensureSHNormal a = case checkAppWellFormed a of
       Left err -> annotateShow err >> failure
-      Right a' -> TypeCacheAlpha a === TypeCacheAlpha a'
+      Right a' -> TypeCacheAlpha a === TypeCacheAlpha a' >> checkUndo a
+    checkUndo a = runEditAppMLogs (handleMutationRequest Undo) a >>= \case
+        (Left err, _) -> annotateShow err >> failure
+        (Right _, a') -> runEditAppMLogs (handleMutationRequest Redo) a' >>= \case
+          (Left err, _) -> annotateShow err >> failure
+          (Right _, a'') -> TypeCacheAlpha a === TypeCacheAlpha a''
+
+--gives def name and perhaps a node inside it (if Nothing, then has selected the definition itself)
+-- If the outer Maybe is Nothing, then there were no definitions at all!
+pickPos :: Prog -> Maybe (Gen (GVarName, Editable, Either Def (ASTDef, NodeType, ID)))
+pickPos p = ((\(defName, (editable, def)) -> (defName, editable,) <$> pickLoc def) =<<) <$> pickDef
+  where
+    isMutable = \case
+            Editable -> True
+            NonEditable -> False
+    pickDef = case partition (isMutable . fst . snd) $ Map.toList $ progAllDefs p of
+        ([], []) -> Nothing
+        (mut, []) -> Just $ Gen.element mut
+        ([], immut) -> Just $ Gen.element immut
+        (mut, immut) -> Just $ Gen.frequency [(9, Gen.element mut), (1, Gen.element immut)]
+    pickLoc d =
+          Gen.frequency $
+            catMaybes
+              [ Just (1, pure $ Left d)
+              , defAST d <&> \d' -> (2,) . Gen.element $ fmap (Right . (d',SigNode,)) $ toListOf typeIDs $ astDefType d'
+              , defAST d <&> \d' -> (7,) . Gen.element $ fmap (Right . (d',BodyNode,)) $ toListOf exprIDs $ astDefExpr d'
+              ]
+
+-- TODO: if I work in PropertyT, should I revive the labels I dropped?
+-- 'Nothing' means that a somewhat-expected problem occured:
+-- - picked a node with no actions available
+-- - picked an action with no options available
+-- - entered a free-choice option and had name-clashing issues
+runRandomAvailableAction :: Level -> App -> PropertyT WT (Maybe App)
+runRandomAvailableAction l a = do
+      (defName,defMut,defLoc) <- maybe discard forAll (pickPos $ appProg a)
+      let defMap = fmap snd $ progAllDefs $ appProg a
+      let (def, loc,acts) = case defLoc of
+            Left d -> (d, Nothing,Available.forDef defMap l defMut defName)
+            Right (d,SigNode, i) -> (DefAST d, Just (SigNode, i), Available.forSig l defMut (astDefType d) i)
+            Right (d,BodyNode, i) -> (DefAST d, Just (BodyNode, i), Available.forBody (snd <$> progAllTypeDefs (appProg a)) l defMut (astDefExpr d) i)
+      case acts of
+        [] -> label "no offered actions" >> pure Nothing
+        acts' -> do
+          action <- forAllT $ Gen.element acts'
+          collect action
+          case action of
+            Available.NoInput act' -> do
+              def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              progActs <-
+                either (\e -> annotateShow e >> failure) pure $
+                  toProgActionNoInput (map snd $ progAllDefs $ appProg a) def' defName loc act'
+              Just <$> actionSucceeds (handleEditRequest progActs) a
+            Available.Input act' -> do
+              def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              Available.Options{Available.opts, Available.free} <-
+                maybe (annotate "id not found" >> failure) pure $
+                  Available.options
+                    (map snd $ progAllTypeDefs $ appProg a)
+                    (map snd $ progAllDefs $ appProg a)
+                    (progCxt $ appProg a)
+                    l
+                    def'
+                    loc
+                    act'
+              let opts' = [Gen.element $ (Offered,) <$> opts | not (null opts)]
+              let opts'' =
+                    opts' <> case free of
+                      Available.FreeNone -> []
+                      Available.FreeVarName -> [(StudentProvided,) . flip Available.Option Nothing <$> (unName <$> genName)]
+                      Available.FreeInt -> [(StudentProvided,) . flip Available.Option Nothing <$> (show <$> Gen.integral (Range.linear @Integer 0 1_000_000_000))]
+                      Available.FreeChar -> [(StudentProvided,) . flip Available.Option Nothing . T.singleton <$> Gen.unicode]
+              case opts'' of
+                [] -> annotate "no options" >> pure Nothing
+                options -> do
+                  opt <- forAllT $ Gen.choice options
+                  progActs <- either (\e -> annotateShow e >> failure) pure $ toProgActionInput def' defName loc (snd opt) act'
+                  actionSucceedsOrCapture (fst opt) (handleEditRequest progActs) a
+  where
+    runEditAppMLogs ::
+      HasCallStack =>
+      EditAppM (PureLog (WithSeverity ())) ProgError a ->
+      App ->
+      PropertyT WT (Either ProgError a, App)
+    runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+      (r, logs) -> testNoSevereLogs logs >> pure r
+    actionSucceeds :: HasCallStack => EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT App
+    actionSucceeds m a =
+      runEditAppMLogs m a >>= \case
+        (Left err, _) -> annotateShow err >> failure
+        (Right _, a') -> pure a'
+    -- If we submit our own name rather than an offered one, then
+    -- we should expect that name capture/clashing may happen
+    actionSucceedsOrCapture :: HasCallStack => Provenance -> EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT (Maybe App)
+    actionSucceedsOrCapture p m a = do
+      a' <- runEditAppMLogs m a
+      case (p, a') of
+        (StudentProvided, (Left (ActionError NameCapture), _)) -> do
+          label "name-capture with entered name"
+          annotate "ignoring name capture error as was generated name, not offered one"
+          pure Nothing
+        (StudentProvided, (Left (ActionError (CaseBindsClash{})), _)) -> do
+          label "name-clash with entered name"
+          annotate "ignoring name clash error as was generated name, not offered one"
+          pure Nothing
+        (StudentProvided, (Left DefAlreadyExists{}, _)) -> do
+          label "rename def name clash with entered name"
+          annotate "ignoring def already exists error as was generated name, not offered one"
+          pure Nothing
+        (_, (Left err, _)) -> annotateShow err >> failure
+        (_, (Right _, a'')) -> pure $ Just a''
+
+-- helper type for tasty_undo_redo
+data Act = AddTm | AddTy
+  | Un | Re | Avail
+  deriving stock Show
+
+tasty_undo_redo :: Property
+tasty_undo_redo = withTests 500 $
+  withDiscards 2000 $
+    propertyWT [] $ do
+      l <- forAllT $ Gen.element enumerate
+      cxt <- forAllT $ Gen.choice $ map sequence [[], [builtinModule], [builtinModule, pure primitiveModule]]
+      -- We only test SmartHoles mode (which is the only supported user-facing
+      -- mode - NoSmartHoles is only used for internal sanity testing etc)
+      let annotateShow' :: HasCallStack => App -> PropertyT WT ()
+          annotateShow' = withFrozenCallStack $ annotateShow . (\p -> (progModules p, progLog p, redoLog p)) . appProg
+      a <- forAllT $ genApp SmartHoles cxt
+      annotateShow' a
+      n <- forAll $ Gen.int $ Range.linear 1 20
+      a' <- iterateNM n a $ \a' -> runRandomAction l a'
+      annotateShow' a'
+      if null $ unlog $ progLog $ appProg a' -- TODO: expose a "log-is-null" helper from App?
+        -- It is possible for the random actions to undo everything!
+        then success
+        else do
+          a'' <- runEditAppMLogs (handleMutationRequest Undo) a'
+          annotateShow' a''
+          a''' <- runEditAppMLogs (handleMutationRequest Redo) a''
+          annotateShow' a'''
+          TypeCacheAlpha a' === TypeCacheAlpha a'''
+  where
+    -- TODO: dry
+    runEditAppMLogs ::
+      HasCallStack =>
+      EditAppM (PureLog (WithSeverity ())) ProgError a ->
+      App ->
+      PropertyT WT App
+    runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+      (r, logs) -> testNoSevereLogs logs >> case r of
+        (Left err, _) -> annotateShow err >> failure
+        (Right _, a') -> pure a'
+    runRandomAction l a = do
+      act <- forAll $ Gen.frequency $ second pure <$> [
+        (2,AddTm)
+        ,(1,AddTy)
+        ,(if null $ unlog $ progLog $ appProg a then 0 else 1,Un) -- TODO: expose a "log-is-null" helper from App?
+        ,(if null $ unlog $ redoLog $ appProg a then 0 else 1,Re) -- TODO: expose a "log-is-null" helper from App?
+        ,(5,Avail)
+                                    ]
+      case act of
+        AddTm -> do
+          let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+          n <- forAllT $ Gen.choice [Just . unName <$> n', pure Nothing]
+          m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+          runEditAppMLogs (handleMutationRequest $ Edit [CreateDef m n]) a
+        AddTy -> do
+          m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+          let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+          n <- qualifyName m <$> forAllT n'
+          runEditAppMLogs (handleMutationRequest $ Edit [AddTypeDef n $ ASTTypeDef [] [] []]) a
+        Un -> runEditAppMLogs (handleMutationRequest Undo) a
+        Re -> runEditAppMLogs (handleMutationRequest Redo) a
+        Avail -> fromMaybe a <$> runRandomAvailableAction l a
+
+
+iterateNM :: Monad m => Int -> a -> (a -> m a) -> m a
+iterateNM n a f
+  | n <= 0 = pure a
+  | otherwise = f a >>= \fa -> iterateNM (n - 1) fa f
 
 -- 'Raise' works when moving checkable terms into synthesisable position
 unit_raise_sh :: Assertion

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -1188,6 +1188,25 @@ unit_tmp_4 =
   in case evalTestM i $ applyActionsToExpr SmartHoles [] e [Action.Move Child1, Action.Move Child1, Action.EnterType, Action.Delete] of
     Left err -> assertFailure $ show err
     Right _ -> pure ()
+
+-- We can simplify the expression that fails
+unit_tmp_5 :: Assertion
+unit_tmp_5 =
+  let ((builtins, d), i) = create $ do
+        m <- builtinModule
+        astDefExpr <- hole $ emptyHole `ann` tcon tBool
+        astDefType <- tcon tNat
+        pure
+          ( m
+          , ASTDef
+              { astDefExpr
+              , astDefType
+              }
+          )
+   in case evalTestM i $ applyActionsToBody SmartHoles [builtins] d [Action.Move Child1, Action.EnterType, Action.Delete] of
+        Left err -> assertFailure $ show err
+        Right _ -> pure ()
+
 --------------------------------------
 
 iterateNM :: Monad m => Int -> a -> (a -> m a) -> m a

--- a/primer/undo-bugs.org
+++ b/primer/undo-bugs.org
@@ -997,6 +997,7 @@ test/Test.hs
 1 out of 1 tests failed (1.28s)
 #+end_src
 
+** Unit test is hard (so not done), as second action acts on a node created by the first
 * cabal run -O primer-test -- -p "undo redo" --hedgehog-replay "Size 57 Seed 5594787156260972540 7447132206390486147"
 ** Actions: MakeFun ; MakeCase ; MakeFun ; DeleteType
 ** Output
@@ -2256,6 +2257,7 @@ test/Test.hs
 1 out of 1 tests failed (1.65s)
 #+end_src
 
+** Unit test is hard (so not done), as second action acts on a node created by the first
 * cabal run -O primer-test -- -p "undo redo" --hedgehog-replay "Size 98 Seed 10665341429893025564 10182452733544053075"
 ** Actions: Raise ; DeleteType
 ** Output
@@ -3652,6 +3654,7 @@ test/Test.hs
 1 out of 1 tests failed (2.38s)
 #+end_src
 
+** Unit test is hard (so not done), as second action acts on a node created by the first
 * cabal run -O primer-test -- -p "undo redo" --hedgehog-replay "Size 33 Seed 4268413180681694343 17092859468972210393"
 ** Actions: MakeFun ; DeleteType
 ** Output
@@ -4206,3 +4209,5 @@ test/Test.hs
 
 1 out of 1 tests failed (0.49s)
 #+end_src
+
+** Unit test: unit_tmp_1

--- a/primer/undo-bugs.org
+++ b/primer/undo-bugs.org
@@ -1,0 +1,4208 @@
+* cabal run -O primer-test -- -p "undo redo" --hedgehog-replay "Size 35 Seed 16534253545938615628 6870018911351305901"
+** Actions: Raise ; Raise
+** Output
+#+begin_src
+test/Test.hs
+  Tests
+    Action
+      Available
+        undo redo: FAIL (0.51s)
+            ✗ undo redo failed at test/Tests/Action/Available.hs:430:46
+              after 1 test and 6 shrinks.
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              374 ┃ runRandomAvailableAction :: Level -> App -> PropertyT WT (Maybe App)
+              375 ┃ runRandomAvailableAction l a = do
+              376 ┃       (defName,defMut,defLoc) <- maybe discard forAll (pickPos $ appProg a)
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a4"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             LAM
+                  ┃       │               (Meta
+                  ┃       │                  0
+                  ┃       │                  (Just
+                  ┃       │                     (TCChkedAt
+                  ┃       │                        (TForall
+                  ┃       │                           ()
+                  ┃       │                           LocalName { unLocalName = "y" }
+                  ┃       │                           KType
+                  ┃       │                           (TCon
+                  ┃       │                              ()
+                  ┃       │                              GlobalName
+                  ┃       │                                { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                , baseName = "a3"
+                  ┃       │                                }))))
+                  ┃       │                  Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               (Case
+                  ┃       │                  (Meta
+                  ┃       │                     3
+                  ┃       │                     (Just
+                  ┃       │                        (TCChkedAt
+                  ┃       │                           (TCon
+                  ┃       │                              ()
+                  ┃       │                              GlobalName
+                  ┃       │                                { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                , baseName = "a3"
+                  ┃       │                                })))
+                  ┃       │                     Nothing)
+                  ┃       │                  (Ann
+                  ┃       │                     (Meta
+                  ┃       │                        4
+                  ┃       │                        (Just
+                  ┃       │                           (TCSynthed
+                  ┃       │                              (TApp
+                  ┃       │                                 ()
+                  ┃       │                                 (TApp
+                  ┃       │                                    ()
+                  ┃       │                                    (TCon
+                  ┃       │                                       ()
+                  ┃       │                                       GlobalName
+                  ┃       │                                         { qualifiedModule =
+                  ┃       │                                             ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                         , baseName = "a"
+                  ┃       │                                         })
+                  ┃       │                                    (TEmptyHole ()))
+                  ┃       │                                 (TEmptyHole ()))))
+                  ┃       │                        Nothing)
+                  ┃       │                     (Case
+                  ┃       │                        (Meta
+                  ┃       │                           5
+                  ┃       │                           (Just
+                  ┃       │                              (TCChkedAt
+                  ┃       │                                 (TApp
+                  ┃       │                                    ()
+                  ┃       │                                    (TApp
+                  ┃       │                                       ()
+                  ┃       │                                       (TCon
+                  ┃       │                                          ()
+                  ┃       │                                          GlobalName
+                  ┃       │                                            { qualifiedModule =
+                  ┃       │                                                ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                            , baseName = "a"
+                  ┃       │                                            })
+                  ┃       │                                       (TEmptyHole ()))
+                  ┃       │                                    (TEmptyHole ()))))
+                  ┃       │                           Nothing)
+                  ┃       │                        (Hole
+                  ┃       │                           (Meta 6 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                           (EmptyHole (Meta 7 (Just (TCSynthed (TEmptyHole ()))) Nothing)))
+                  ┃       │                        [])
+                  ┃       │                     (TApp
+                  ┃       │                        (Meta 8 (Just KType) Nothing)
+                  ┃       │                        (TApp
+                  ┃       │                           (Meta 9 (Just (KFun KType KType)) Nothing)
+                  ┃       │                           (TCon
+                  ┃       │                              (Meta
+                  ┃       │                                 10
+                  ┃       │                                 (Just
+                  ┃       │                                    (KFun
+                  ┃       │                                       (KFun
+                  ┃       │                                          (KFun KType KType)
+                  ┃       │                                          (KFun
+                  ┃       │                                             (KFun
+                  ┃       │                                                KType
+                  ┃       │                                                (KFun
+                  ┃       │                                                   (KFun
+                  ┃       │                                                      (KFun KType KType)
+                  ┃       │                                                      (KFun KType (KFun KType KType)))
+                  ┃       │                                                   (KFun KType (KFun (KFun KType KType) KType))))
+                  ┃       │                                             KType))
+                  ┃       │                                       (KFun KType KType)))
+                  ┃       │                                 Nothing)
+                  ┃       │                              GlobalName
+                  ┃       │                                { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                , baseName = "a"
+                  ┃       │                                })
+                  ┃       │                           (TEmptyHole (Meta 11 (Just KHole) Nothing)))
+                  ┃       │                        (TEmptyHole (Meta 12 (Just KHole) Nothing))))
+                  ┃       │                  [])
+                  ┃       │         , astDefType =
+                  ┃       │             TForall
+                  ┃       │               (Meta 14 (Just KType) Nothing)
+                  ┃       │               LocalName { unLocalName = "y" }
+                  ┃       │               KType
+                  ┃       │               (TCon
+                  ┃       │                  (Meta 15 (Just KType) Nothing)
+                  ┃       │                  GlobalName
+                  ┃       │                    { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                    , baseName = "a3"
+                  ┃       │                    })
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 4
+                  ┃       │     )
+                  ┃       │ )
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a4"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             LAM
+                  ┃       │               (Meta
+                  ┃       │                  0
+                  ┃       │                  (Just
+                  ┃       │                     (TCChkedAt
+                  ┃       │                        (TForall
+                  ┃       │                           ()
+                  ┃       │                           LocalName { unLocalName = "y" }
+                  ┃       │                           KType
+                  ┃       │                           (TCon
+                  ┃       │                              ()
+                  ┃       │                              GlobalName
+                  ┃       │                                { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                , baseName = "a3"
+                  ┃       │                                }))))
+                  ┃       │                  Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               (Hole
+                  ┃       │                  (Meta
+                  ┃       │                     26
+                  ┃       │                     (Just
+                  ┃       │                        (TCEmb
+                  ┃       │                           TCBoth
+                  ┃       │                             { tcChkedAt =
+                  ┃       │                                 TCon
+                  ┃       │                                   ()
+                  ┃       │                                   GlobalName
+                  ┃       │                                     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                     , baseName = "a3"
+                  ┃       │                                     }
+                  ┃       │                             , tcSynthed = TEmptyHole ()
+                  ┃       │                             }))
+                  ┃       │                     Nothing)
+                  ┃       │                  (Ann
+                  ┃       │                     (Meta
+                  ┃       │                        17
+                  ┃       │                        (Just
+                  ┃       │                           (TCSynthed
+                  ┃       │                              (TApp
+                  ┃       │                                 ()
+                  ┃       │                                 (TApp
+                  ┃       │                                    ()
+                  ┃       │                                    (TCon
+                  ┃       │                                       ()
+                  ┃       │                                       GlobalName
+                  ┃       │                                         { qualifiedModule =
+                  ┃       │                                             ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                         , baseName = "a"
+                  ┃       │                                         })
+                  ┃       │                                    (TEmptyHole ()))
+                  ┃       │                                 (TEmptyHole ()))))
+                  ┃       │                        Nothing)
+                  ┃       │                     (Case
+                  ┃       │                        (Meta
+                  ┃       │                           18
+                  ┃       │                           (Just
+                  ┃       │                              (TCChkedAt
+                  ┃       │                                 (TApp
+                  ┃       │                                    ()
+                  ┃       │                                    (TApp
+                  ┃       │                                       ()
+                  ┃       │                                       (TCon
+                  ┃       │                                          ()
+                  ┃       │                                          GlobalName
+                  ┃       │                                            { qualifiedModule =
+                  ┃       │                                                ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                            , baseName = "a"
+                  ┃       │                                            })
+                  ┃       │                                       (TEmptyHole ()))
+                  ┃       │                                    (TEmptyHole ()))))
+                  ┃       │                           Nothing)
+                  ┃       │                        (Hole
+                  ┃       │                           (Meta 19 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                           (EmptyHole (Meta 20 (Just (TCSynthed (TEmptyHole ()))) Nothing)))
+                  ┃       │                        [])
+                  ┃       │                     (TApp
+                  ┃       │                        (Meta 21 (Just KType) Nothing)
+                  ┃       │                        (TApp
+                  ┃       │                           (Meta 22 (Just (KFun KType KType)) Nothing)
+                  ┃       │                           (TCon
+                  ┃       │                              (Meta
+                  ┃       │                                 23
+                  ┃       │                                 (Just
+                  ┃       │                                    (KFun
+                  ┃       │                                       (KFun
+                  ┃       │                                          (KFun KType KType)
+                  ┃       │                                          (KFun
+                  ┃       │                                             (KFun
+                  ┃       │                                                KType
+                  ┃       │                                                (KFun
+                  ┃       │                                                   (KFun
+                  ┃       │                                                      (KFun KType KType)
+                  ┃       │                                                      (KFun KType (KFun KType KType)))
+                  ┃       │                                                   (KFun KType (KFun (KFun KType KType) KType))))
+                  ┃       │                                             KType))
+                  ┃       │                                       (KFun KType KType)))
+                  ┃       │                                 Nothing)
+                  ┃       │                              GlobalName
+                  ┃       │                                { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                , baseName = "a"
+                  ┃       │                                })
+                  ┃       │                           (TEmptyHole (Meta 24 (Just KHole) Nothing)))
+                  ┃       │                        (TEmptyHole (Meta 25 (Just KHole) Nothing)))))
+                  ┃       │         , astDefType =
+                  ┃       │             TForall
+                  ┃       │               (Meta 14 (Just KType) Nothing)
+                  ┃       │               LocalName { unLocalName = "y" }
+                  ┃       │               KType
+                  ┃       │               (TCon
+                  ┃       │                  (Meta 15 (Just KType) Nothing)
+                  ┃       │                  GlobalName
+                  ┃       │                    { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                    , baseName = "a3"
+                  ┃       │                    })
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 25
+                  ┃       │     )
+                  ┃       │ )
+              377 ┃       let defMap = fmap snd $ progAllDefs $ appProg a
+              378 ┃       let (def, loc,acts) = case defLoc of
+              379 ┃             Left d -> (d, Nothing,Available.forDef defMap l defMut defName)
+              380 ┃             Right (d,SigNode, i) -> (DefAST d, Just (SigNode, i), Available.forSig l defMut (astDefType d) i)
+              381 ┃             Right (d,BodyNode, i) -> (DefAST d, Just (BodyNode, i), Available.forBody (snd <$> progAllTypeDefs (appProg a)) l defMut (astDefExpr d) i)
+              382 ┃       case acts of
+              383 ┃         [] -> label "no offered actions" >> pure Nothing
+              384 ┃         acts' -> do
+              385 ┃           action <- forAllT $ Gen.element acts'
+                  ┃           │ NoInput Raise
+                  ┃           │ NoInput Raise
+              386 ┃           collect action
+              387 ┃           case action of
+              388 ┃             Available.NoInput act' -> do
+              389 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              390 ┃               progActs <-
+              391 ┃                 either (\e -> annotateShow e >> failure) pure $
+              392 ┃                   toProgActionNoInput (map snd $ progAllDefs $ appProg a) def' defName loc act'
+              393 ┃               Just <$> actionSucceeds (handleEditRequest progActs) a
+              394 ┃             Available.Input act' -> do
+              395 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              396 ┃               Available.Options{Available.opts, Available.free} <-
+              397 ┃                 maybe (annotate "id not found" >> failure) pure $
+              398 ┃                   Available.options
+              399 ┃                     (map snd $ progAllTypeDefs $ appProg a)
+              400 ┃                     (map snd $ progAllDefs $ appProg a)
+              401 ┃                     (progCxt $ appProg a)
+              402 ┃                     l
+              403 ┃                     def'
+              404 ┃                     loc
+              405 ┃                     act'
+              406 ┃               let opts' = [Gen.element $ (Offered,) <$> opts | not (null opts)]
+              407 ┃               let opts'' =
+              408 ┃                     opts' <> case free of
+              409 ┃                       Available.FreeNone -> []
+              410 ┃                       Available.FreeVarName -> [(StudentProvided,) . flip Available.Option Nothing <$> (unName <$> genName)]
+              411 ┃                       Available.FreeInt -> [(StudentProvided,) . flip Available.Option Nothing <$> (show <$> Gen.integral (Range.linear @Integer 0 1_000_000_000))]
+              412 ┃                       Available.FreeChar -> [(StudentProvided,) . flip Available.Option Nothing . T.singleton <$> Gen.unicode]
+              413 ┃               case opts'' of
+              414 ┃                 [] -> annotate "no options" >> pure Nothing
+              415 ┃                 options -> do
+              416 ┃                   opt <- forAllT $ Gen.choice options
+              417 ┃                   progActs <- either (\e -> annotateShow e >> failure) pure $ toProgActionInput def' defName loc (snd opt) act'
+              418 ┃                   actionSucceedsOrCapture (fst opt) (handleEditRequest progActs) a
+              419 ┃   where
+              420 ┃     runEditAppMLogs ::
+              421 ┃       HasCallStack =>
+              422 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              423 ┃       App ->
+              424 ┃       PropertyT WT (Either ProgError a, App)
+              425 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              426 ┃       (r, logs) -> testNoSevereLogs logs >> pure r
+              427 ┃     actionSucceeds :: HasCallStack => EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT App
+              428 ┃     actionSucceeds m a =
+              429 ┃       runEditAppMLogs m a >>= \case
+              430 ┃         (Left err, _) -> annotateShow err >> failure
+                  ┃         │ ActionError
+                  ┃         │   (CustomFailure Delete "internal error: lost ID after typechecking")
+                  ┃         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              431 ┃         (Right _, a') -> pure a'
+              432 ┃     -- If we submit our own name rather than an offered one, then
+              433 ┃     -- we should expect that name capture/clashing may happen
+              434 ┃     actionSucceedsOrCapture :: HasCallStack => Provenance -> EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT (Maybe App)
+              435 ┃     actionSucceedsOrCapture p m a = do
+              436 ┃       a' <- runEditAppMLogs m a
+              437 ┃       case (p, a') of
+              438 ┃         (StudentProvided, (Left (ActionError NameCapture), _)) -> do
+              439 ┃           label "name-capture with entered name"
+              440 ┃           annotate "ignoring name capture error as was generated name, not offered one"
+              441 ┃           pure Nothing
+              442 ┃         (StudentProvided, (Left (ActionError (CaseBindsClash{})), _)) -> do
+              443 ┃           label "name-clash with entered name"
+              444 ┃           annotate "ignoring name clash error as was generated name, not offered one"
+              445 ┃           pure Nothing
+              446 ┃         (StudentProvided, (Left DefAlreadyExists{}, _)) -> do
+              447 ┃           label "rename def name clash with entered name"
+              448 ┃           annotate "ignoring def already exists error as was generated name, not offered one"
+              449 ┃           pure Nothing
+              450 ┃         (_, (Left err, _)) -> annotateShow err >> failure
+              451 ┃         (_, (Right _, a'')) -> pure $ Just a''
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              458 ┃ tasty_undo_redo :: Property
+              459 ┃ tasty_undo_redo = withTests 500 $
+              460 ┃   withDiscards 2000 $
+              461 ┃     propertyWT [] $ do
+              462 ┃       l <- forAllT $ Gen.element enumerate
+                  ┃       │ Beginner
+              463 ┃       cxt <- forAllT $ Gen.choice $ map sequence [[], [builtinModule], [builtinModule, pure primitiveModule]]
+                  ┃       │ []
+              464 ┃       -- We only test SmartHoles mode (which is the only supported user-facing
+              465 ┃       -- mode - NoSmartHoles is only used for internal sanity testing etc)
+              466 ┃       let annotateShow' :: HasCallStack => App -> PropertyT WT ()
+              467 ┃           annotateShow' = withFrozenCallStack $ annotateShow . (\p -> (progModules p, progLog p, redoLog p)) . appProg
+              468 ┃       a <- forAllT $ genApp SmartHoles cxt
+                  ┃       │ App
+                  ┃       │   { currentState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 16
+                  ┃       │         , nameCounter = NC 416
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports = []
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a1" }
+                  ┃       │                                           , KFun
+                  ┃       │                                               (KFun KType KType)
+                  ┃       │                                               (KFun
+                  ┃       │                                                  (KFun
+                  ┃       │                                                     KType
+                  ┃       │                                                     (KFun
+                  ┃       │                                                        (KFun
+                  ┃       │                                                           (KFun KType KType)
+                  ┃       │                                                           (KFun KType (KFun KType KType)))
+                  ┃       │                                                        (KFun
+                  ┃       │                                                           KType (KFun (KFun KType KType) KType))))
+                  ┃       │                                                  KType)
+                  ┃       │                                           )
+                  ┃       │                                         , ( LocalName { unLocalName = "a2" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors = []
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "a3"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors = []
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a4"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         LAM
+                  ┃       │                                           (Meta
+                  ┃       │                                              0
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCChkedAt
+                  ┃       │                                                    (TForall
+                  ┃       │                                                       ()
+                  ┃       │                                                       LocalName { unLocalName = "y" }
+                  ┃       │                                                       KType
+                  ┃       │                                                       (TCon
+                  ┃       │                                                          ()
+                  ┃       │                                                          GlobalName
+                  ┃       │                                                            { qualifiedModule =
+                  ┃       │                                                                ModuleName
+                  ┃       │                                                                  { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                            , baseName = "a3"
+                  ┃       │                                                            }))))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           (Case
+                  ┃       │                                              (Meta
+                  ┃       │                                                 3
+                  ┃       │                                                 (Just
+                  ┃       │                                                    (TCChkedAt
+                  ┃       │                                                       (TCon
+                  ┃       │                                                          ()
+                  ┃       │                                                          GlobalName
+                  ┃       │                                                            { qualifiedModule =
+                  ┃       │                                                                ModuleName
+                  ┃       │                                                                  { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                            , baseName = "a3"
+                  ┃       │                                                            })))
+                  ┃       │                                                 Nothing)
+                  ┃       │                                              (Ann
+                  ┃       │                                                 (Meta
+                  ┃       │                                                    4
+                  ┃       │                                                    (Just
+                  ┃       │                                                       (TCSynthed
+                  ┃       │                                                          (TApp
+                  ┃       │                                                             ()
+                  ┃       │                                                             (TApp
+                  ┃       │                                                                ()
+                  ┃       │                                                                (TCon
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   GlobalName
+                  ┃       │                                                                     { qualifiedModule =
+                  ┃       │                                                                         ModuleName
+                  ┃       │                                                                           { unModuleName =
+                  ┃       │                                                                               "M" :| [ "0" ]
+                  ┃       │                                                                           }
+                  ┃       │                                                                     , baseName = "a"
+                  ┃       │                                                                     })
+                  ┃       │                                                                (TEmptyHole ()))
+                  ┃       │                                                             (TEmptyHole ()))))
+                  ┃       │                                                    Nothing)
+                  ┃       │                                                 (Case
+                  ┃       │                                                    (Meta
+                  ┃       │                                                       5
+                  ┃       │                                                       (Just
+                  ┃       │                                                          (TCChkedAt
+                  ┃       │                                                             (TApp
+                  ┃       │                                                                ()
+                  ┃       │                                                                (TApp
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   (TCon
+                  ┃       │                                                                      ()
+                  ┃       │                                                                      GlobalName
+                  ┃       │                                                                        { qualifiedModule =
+                  ┃       │                                                                            ModuleName
+                  ┃       │                                                                              { unModuleName =
+                  ┃       │                                                                                  "M" :| [ "0" ]
+                  ┃       │                                                                              }
+                  ┃       │                                                                        , baseName = "a"
+                  ┃       │                                                                        })
+                  ┃       │                                                                   (TEmptyHole ()))
+                  ┃       │                                                                (TEmptyHole ()))))
+                  ┃       │                                                       Nothing)
+                  ┃       │                                                    (Hole
+                  ┃       │                                                       (Meta
+                  ┃       │                                                          6
+                  ┃       │                                                          (Just (TCSynthed (TEmptyHole ())))
+                  ┃       │                                                          Nothing)
+                  ┃       │                                                       (EmptyHole
+                  ┃       │                                                          (Meta
+                  ┃       │                                                             7
+                  ┃       │                                                             (Just (TCSynthed (TEmptyHole ())))
+                  ┃       │                                                             Nothing)))
+                  ┃       │                                                    [])
+                  ┃       │                                                 (TApp
+                  ┃       │                                                    (Meta 8 (Just KType) Nothing)
+                  ┃       │                                                    (TApp
+                  ┃       │                                                       (Meta 9 (Just (KFun KType KType)) Nothing)
+                  ┃       │                                                       (TCon
+                  ┃       │                                                          (Meta
+                  ┃       │                                                             10
+                  ┃       │                                                             (Just
+                  ┃       │                                                                (KFun
+                  ┃       │                                                                   (KFun
+                  ┃       │                                                                      (KFun KType KType)
+                  ┃       │                                                                      (KFun
+                  ┃       │                                                                         (KFun
+                  ┃       │                                                                            KType
+                  ┃       │                                                                            (KFun
+                  ┃       │                                                                               (KFun
+                  ┃       │                                                                                  (KFun KType KType)
+                  ┃       │                                                                                  (KFun
+                  ┃       │                                                                                     KType
+                  ┃       │                                                                                     (KFun
+                  ┃       │                                                                                        KType
+                  ┃       │                                                                                        KType)))
+                  ┃       │                                                                               (KFun
+                  ┃       │                                                                                  KType
+                  ┃       │                                                                                  (KFun
+                  ┃       │                                                                                     (KFun
+                  ┃       │                                                                                        KType KType)
+                  ┃       │                                                                                     KType))))
+                  ┃       │                                                                         KType))
+                  ┃       │                                                                   (KFun KType KType)))
+                  ┃       │                                                             Nothing)
+                  ┃       │                                                          GlobalName
+                  ┃       │                                                            { qualifiedModule =
+                  ┃       │                                                                ModuleName
+                  ┃       │                                                                  { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                            , baseName = "a"
+                  ┃       │                                                            })
+                  ┃       │                                                       (TEmptyHole (Meta 11 (Just KHole) Nothing)))
+                  ┃       │                                                    (TEmptyHole (Meta 12 (Just KHole) Nothing))))
+                  ┃       │                                              [])
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TForall
+                  ┃       │                                           (Meta 14 (Just KType) Nothing)
+                  ┃       │                                           LocalName { unLocalName = "y" }
+                  ┃       │                                           KType
+                  ┃       │                                           (TCon
+                  ┃       │                                              (Meta 15 (Just KType) Nothing)
+                  ┃       │                                              GlobalName
+                  ┃       │                                                { qualifiedModule =
+                  ┃       │                                                    ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                , baseName = "a3"
+                  ┃       │                                                })
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   , initialState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 16
+                  ┃       │         , nameCounter = NC 416
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports = []
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a1" }
+                  ┃       │                                           , KFun
+                  ┃       │                                               (KFun KType KType)
+                  ┃       │                                               (KFun
+                  ┃       │                                                  (KFun
+                  ┃       │                                                     KType
+                  ┃       │                                                     (KFun
+                  ┃       │                                                        (KFun
+                  ┃       │                                                           (KFun KType KType)
+                  ┃       │                                                           (KFun KType (KFun KType KType)))
+                  ┃       │                                                        (KFun
+                  ┃       │                                                           KType (KFun (KFun KType KType) KType))))
+                  ┃       │                                                  KType)
+                  ┃       │                                           )
+                  ┃       │                                         , ( LocalName { unLocalName = "a2" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors = []
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "a3"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors = []
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a4"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         LAM
+                  ┃       │                                           (Meta
+                  ┃       │                                              0
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCChkedAt
+                  ┃       │                                                    (TForall
+                  ┃       │                                                       ()
+                  ┃       │                                                       LocalName { unLocalName = "y" }
+                  ┃       │                                                       KType
+                  ┃       │                                                       (TCon
+                  ┃       │                                                          ()
+                  ┃       │                                                          GlobalName
+                  ┃       │                                                            { qualifiedModule =
+                  ┃       │                                                                ModuleName
+                  ┃       │                                                                  { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                            , baseName = "a3"
+                  ┃       │                                                            }))))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           (Case
+                  ┃       │                                              (Meta
+                  ┃       │                                                 3
+                  ┃       │                                                 (Just
+                  ┃       │                                                    (TCChkedAt
+                  ┃       │                                                       (TCon
+                  ┃       │                                                          ()
+                  ┃       │                                                          GlobalName
+                  ┃       │                                                            { qualifiedModule =
+                  ┃       │                                                                ModuleName
+                  ┃       │                                                                  { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                            , baseName = "a3"
+                  ┃       │                                                            })))
+                  ┃       │                                                 Nothing)
+                  ┃       │                                              (Ann
+                  ┃       │                                                 (Meta
+                  ┃       │                                                    4
+                  ┃       │                                                    (Just
+                  ┃       │                                                       (TCSynthed
+                  ┃       │                                                          (TApp
+                  ┃       │                                                             ()
+                  ┃       │                                                             (TApp
+                  ┃       │                                                                ()
+                  ┃       │                                                                (TCon
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   GlobalName
+                  ┃       │                                                                     { qualifiedModule =
+                  ┃       │                                                                         ModuleName
+                  ┃       │                                                                           { unModuleName =
+                  ┃       │                                                                               "M" :| [ "0" ]
+                  ┃       │                                                                           }
+                  ┃       │                                                                     , baseName = "a"
+                  ┃       │                                                                     })
+                  ┃       │                                                                (TEmptyHole ()))
+                  ┃       │                                                             (TEmptyHole ()))))
+                  ┃       │                                                    Nothing)
+                  ┃       │                                                 (Case
+                  ┃       │                                                    (Meta
+                  ┃       │                                                       5
+                  ┃       │                                                       (Just
+                  ┃       │                                                          (TCChkedAt
+                  ┃       │                                                             (TApp
+                  ┃       │                                                                ()
+                  ┃       │                                                                (TApp
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   (TCon
+                  ┃       │                                                                      ()
+                  ┃       │                                                                      GlobalName
+                  ┃       │                                                                        { qualifiedModule =
+                  ┃       │                                                                            ModuleName
+                  ┃       │                                                                              { unModuleName =
+                  ┃       │                                                                                  "M" :| [ "0" ]
+                  ┃       │                                                                              }
+                  ┃       │                                                                        , baseName = "a"
+                  ┃       │                                                                        })
+                  ┃       │                                                                   (TEmptyHole ()))
+                  ┃       │                                                                (TEmptyHole ()))))
+                  ┃       │                                                       Nothing)
+                  ┃       │                                                    (Hole
+                  ┃       │                                                       (Meta
+                  ┃       │                                                          6
+                  ┃       │                                                          (Just (TCSynthed (TEmptyHole ())))
+                  ┃       │                                                          Nothing)
+                  ┃       │                                                       (EmptyHole
+                  ┃       │                                                          (Meta
+                  ┃       │                                                             7
+                  ┃       │                                                             (Just (TCSynthed (TEmptyHole ())))
+                  ┃       │                                                             Nothing)))
+                  ┃       │                                                    [])
+                  ┃       │                                                 (TApp
+                  ┃       │                                                    (Meta 8 (Just KType) Nothing)
+                  ┃       │                                                    (TApp
+                  ┃       │                                                       (Meta 9 (Just (KFun KType KType)) Nothing)
+                  ┃       │                                                       (TCon
+                  ┃       │                                                          (Meta
+                  ┃       │                                                             10
+                  ┃       │                                                             (Just
+                  ┃       │                                                                (KFun
+                  ┃       │                                                                   (KFun
+                  ┃       │                                                                      (KFun KType KType)
+                  ┃       │                                                                      (KFun
+                  ┃       │                                                                         (KFun
+                  ┃       │                                                                            KType
+                  ┃       │                                                                            (KFun
+                  ┃       │                                                                               (KFun
+                  ┃       │                                                                                  (KFun KType KType)
+                  ┃       │                                                                                  (KFun
+                  ┃       │                                                                                     KType
+                  ┃       │                                                                                     (KFun
+                  ┃       │                                                                                        KType
+                  ┃       │                                                                                        KType)))
+                  ┃       │                                                                               (KFun
+                  ┃       │                                                                                  KType
+                  ┃       │                                                                                  (KFun
+                  ┃       │                                                                                     (KFun
+                  ┃       │                                                                                        KType KType)
+                  ┃       │                                                                                     KType))))
+                  ┃       │                                                                         KType))
+                  ┃       │                                                                   (KFun KType KType)))
+                  ┃       │                                                             Nothing)
+                  ┃       │                                                          GlobalName
+                  ┃       │                                                            { qualifiedModule =
+                  ┃       │                                                                ModuleName
+                  ┃       │                                                                  { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                            , baseName = "a"
+                  ┃       │                                                            })
+                  ┃       │                                                       (TEmptyHole (Meta 11 (Just KHole) Nothing)))
+                  ┃       │                                                    (TEmptyHole (Meta 12 (Just KHole) Nothing))))
+                  ┃       │                                              [])
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TForall
+                  ┃       │                                           (Meta 14 (Just KType) Nothing)
+                  ┃       │                                           LocalName { unLocalName = "y" }
+                  ┃       │                                           KType
+                  ┃       │                                           (TCon
+                  ┃       │                                              (Meta 15 (Just KType) Nothing)
+                  ┃       │                                              GlobalName
+                  ┃       │                                                { qualifiedModule =
+                  ┃       │                                                    ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                , baseName = "a3"
+                  ┃       │                                                })
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   }
+              469 ┃       annotateShow' a
+                  ┃       │ ( [ Module
+                  ┃       │       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │       , moduleTypes =
+                  ┃       │           fromList
+                  ┃       │             [ ( "a"
+                  ┃       │               , TypeDefAST
+                  ┃       │                   ASTTypeDef
+                  ┃       │                     { astTypeDefParameters =
+                  ┃       │                         [ ( LocalName { unLocalName = "a1" }
+                  ┃       │                           , KFun
+                  ┃       │                               (KFun KType KType)
+                  ┃       │                               (KFun
+                  ┃       │                                  (KFun
+                  ┃       │                                     KType
+                  ┃       │                                     (KFun
+                  ┃       │                                        (KFun (KFun KType KType) (KFun KType (KFun KType KType)))
+                  ┃       │                                        (KFun KType (KFun (KFun KType KType) KType))))
+                  ┃       │                                  KType)
+                  ┃       │                           )
+                  ┃       │                         , ( LocalName { unLocalName = "a2" } , KType )
+                  ┃       │                         ]
+                  ┃       │                     , astTypeDefConstructors = []
+                  ┃       │                     , astTypeDefNameHints = []
+                  ┃       │                     }
+                  ┃       │               )
+                  ┃       │             , ( "a3"
+                  ┃       │               , TypeDefAST
+                  ┃       │                   ASTTypeDef
+                  ┃       │                     { astTypeDefParameters = []
+                  ┃       │                     , astTypeDefConstructors = []
+                  ┃       │                     , astTypeDefNameHints = []
+                  ┃       │                     }
+                  ┃       │               )
+                  ┃       │             ]
+                  ┃       │       , moduleDefs =
+                  ┃       │           fromList
+                  ┃       │             [ ( "a4"
+                  ┃       │               , DefAST
+                  ┃       │                   ASTDef
+                  ┃       │                     { astDefExpr =
+                  ┃       │                         LAM
+                  ┃       │                           (Meta
+                  ┃       │                              0
+                  ┃       │                              (Just
+                  ┃       │                                 (TCChkedAt
+                  ┃       │                                    (TForall
+                  ┃       │                                       ()
+                  ┃       │                                       LocalName { unLocalName = "y" }
+                  ┃       │                                       KType
+                  ┃       │                                       (TCon
+                  ┃       │                                          ()
+                  ┃       │                                          GlobalName
+                  ┃       │                                            { qualifiedModule =
+                  ┃       │                                                ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                            , baseName = "a3"
+                  ┃       │                                            }))))
+                  ┃       │                              Nothing)
+                  ┃       │                           LocalName { unLocalName = "x" }
+                  ┃       │                           (Case
+                  ┃       │                              (Meta
+                  ┃       │                                 3
+                  ┃       │                                 (Just
+                  ┃       │                                    (TCChkedAt
+                  ┃       │                                       (TCon
+                  ┃       │                                          ()
+                  ┃       │                                          GlobalName
+                  ┃       │                                            { qualifiedModule =
+                  ┃       │                                                ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                            , baseName = "a3"
+                  ┃       │                                            })))
+                  ┃       │                                 Nothing)
+                  ┃       │                              (Ann
+                  ┃       │                                 (Meta
+                  ┃       │                                    4
+                  ┃       │                                    (Just
+                  ┃       │                                       (TCSynthed
+                  ┃       │                                          (TApp
+                  ┃       │                                             ()
+                  ┃       │                                             (TApp
+                  ┃       │                                                ()
+                  ┃       │                                                (TCon
+                  ┃       │                                                   ()
+                  ┃       │                                                   GlobalName
+                  ┃       │                                                     { qualifiedModule =
+                  ┃       │                                                         ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                     , baseName = "a"
+                  ┃       │                                                     })
+                  ┃       │                                                (TEmptyHole ()))
+                  ┃       │                                             (TEmptyHole ()))))
+                  ┃       │                                    Nothing)
+                  ┃       │                                 (Case
+                  ┃       │                                    (Meta
+                  ┃       │                                       5
+                  ┃       │                                       (Just
+                  ┃       │                                          (TCChkedAt
+                  ┃       │                                             (TApp
+                  ┃       │                                                ()
+                  ┃       │                                                (TApp
+                  ┃       │                                                   ()
+                  ┃       │                                                   (TCon
+                  ┃       │                                                      ()
+                  ┃       │                                                      GlobalName
+                  ┃       │                                                        { qualifiedModule =
+                  ┃       │                                                            ModuleName
+                  ┃       │                                                              { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                                        , baseName = "a"
+                  ┃       │                                                        })
+                  ┃       │                                                   (TEmptyHole ()))
+                  ┃       │                                                (TEmptyHole ()))))
+                  ┃       │                                       Nothing)
+                  ┃       │                                    (Hole
+                  ┃       │                                       (Meta 6 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                                       (EmptyHole
+                  ┃       │                                          (Meta 7 (Just (TCSynthed (TEmptyHole ()))) Nothing)))
+                  ┃       │                                    [])
+                  ┃       │                                 (TApp
+                  ┃       │                                    (Meta 8 (Just KType) Nothing)
+                  ┃       │                                    (TApp
+                  ┃       │                                       (Meta 9 (Just (KFun KType KType)) Nothing)
+                  ┃       │                                       (TCon
+                  ┃       │                                          (Meta
+                  ┃       │                                             10
+                  ┃       │                                             (Just
+                  ┃       │                                                (KFun
+                  ┃       │                                                   (KFun
+                  ┃       │                                                      (KFun KType KType)
+                  ┃       │                                                      (KFun
+                  ┃       │                                                         (KFun
+                  ┃       │                                                            KType
+                  ┃       │                                                            (KFun
+                  ┃       │                                                               (KFun
+                  ┃       │                                                                  (KFun KType KType)
+                  ┃       │                                                                  (KFun KType (KFun KType KType)))
+                  ┃       │                                                               (KFun
+                  ┃       │                                                                  KType
+                  ┃       │                                                                  (KFun (KFun KType KType) KType))))
+                  ┃       │                                                         KType))
+                  ┃       │                                                   (KFun KType KType)))
+                  ┃       │                                             Nothing)
+                  ┃       │                                          GlobalName
+                  ┃       │                                            { qualifiedModule =
+                  ┃       │                                                ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                            , baseName = "a"
+                  ┃       │                                            })
+                  ┃       │                                       (TEmptyHole (Meta 11 (Just KHole) Nothing)))
+                  ┃       │                                    (TEmptyHole (Meta 12 (Just KHole) Nothing))))
+                  ┃       │                              [])
+                  ┃       │                     , astDefType =
+                  ┃       │                         TForall
+                  ┃       │                           (Meta 14 (Just KType) Nothing)
+                  ┃       │                           LocalName { unLocalName = "y" }
+                  ┃       │                           KType
+                  ┃       │                           (TCon
+                  ┃       │                              (Meta 15 (Just KType) Nothing)
+                  ┃       │                              GlobalName
+                  ┃       │                                { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                                , baseName = "a3"
+                  ┃       │                                })
+                  ┃       │                     }
+                  ┃       │               )
+                  ┃       │             ]
+                  ┃       │       }
+                  ┃       │   ]
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ )
+              470 ┃       n <- forAll $ Gen.int $ Range.linear 1 20
+                  ┃       │ 5
+              471 ┃       a' <- iterateNM n a $ \a' -> runRandomAction l a'
+              472 ┃       annotateShow' a'
+              473 ┃       if null $ unlog $ progLog $ appProg a' -- TODO: expose a "log-is-null" helper from App?
+              474 ┃         -- It is possible for the random actions to undo everything!
+              475 ┃         then success
+              476 ┃         else do
+              477 ┃           a'' <- runEditAppMLogs (handleMutationRequest Undo) a'
+              478 ┃           annotateShow' a''
+              479 ┃           a''' <- runEditAppMLogs (handleMutationRequest Redo) a''
+              480 ┃           annotateShow' a'''
+              481 ┃           TypeCacheAlpha a' === TypeCacheAlpha a'''
+              482 ┃   where
+              483 ┃     -- TODO: dry
+              484 ┃     runEditAppMLogs ::
+              485 ┃       HasCallStack =>
+              486 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              487 ┃       App ->
+              488 ┃       PropertyT WT App
+              489 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              490 ┃       (r, logs) -> testNoSevereLogs logs >> case r of
+              491 ┃         (Left err, _) -> annotateShow err >> failure
+              492 ┃         (Right _, a') -> pure a'
+              493 ┃     runRandomAction l a = do
+              494 ┃       act <- forAll $ Gen.frequency $ second pure <$> [
+                  ┃       │ Avail
+                  ┃       │ AddTm
+                  ┃       │ Un
+                  ┃       │ AddTm
+                  ┃       │ Avail
+              495 ┃         (2,AddTm)
+              496 ┃         ,(1,AddTy)
+              497 ┃         ,(if null $ unlog $ progLog $ appProg a then 0 else 1,Un) -- TODO: expose a "log-is-null" helper from App?
+              498 ┃         ,(if null $ unlog $ redoLog $ appProg a then 0 else 1,Re) -- TODO: expose a "log-is-null" helper from App?
+              499 ┃         ,(5,Avail)
+              500 ┃                                     ]
+              501 ┃       case act of
+              502 ┃         AddTm -> do
+              503 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              504 ┃           n <- forAllT $ Gen.choice [Just . unName <$> n', pure Nothing]
+                  ┃           │ Just "a1"
+                  ┃           │ Just "a1"
+              505 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+              506 ┃           runEditAppMLogs (handleMutationRequest $ Edit [CreateDef m n]) a
+              507 ┃         AddTy -> do
+              508 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+              509 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              510 ┃           n <- qualifyName m <$> forAllT n'
+              511 ┃           runEditAppMLogs (handleMutationRequest $ Edit [AddTypeDef n $ ASTTypeDef [] [] []]) a
+              512 ┃         Un -> runEditAppMLogs (handleMutationRequest Undo) a
+              513 ┃         Re -> runEditAppMLogs (handleMutationRequest Redo) a
+              514 ┃         Avail -> fromMaybe a <$> runRandomAvailableAction l a
+
+              This failure can be reproduced by running:
+              > recheck (Size 35) (Seed 16534253545938615628 6870018911351305901) undo redo
+
+          Use '--pattern "$NF ~ /undo redo/" --hedgehog-replay "Size 35 Seed 16534253545938615628 6870018911351305901"' to reproduce from the command-line.
+
+1 out of 1 tests failed (1.28s)
+#+end_src
+
+* cabal run -O primer-test -- -p "undo redo" --hedgehog-replay "Size 57 Seed 5594787156260972540 7447132206390486147"
+** Actions: MakeFun ; MakeCase ; MakeFun ; DeleteType
+** Output
+#+begin_src
+test/Test.hs
+  Tests
+    Action
+      Available
+        undo redo: FAIL (1.04s)
+            ✗ undo redo failed at test/Tests/Action/Available.hs:430:46
+              after 1 test and 14 shrinks.
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              374 ┃ runRandomAvailableAction :: Level -> App -> PropertyT WT (Maybe App)
+              375 ┃ runRandomAvailableAction l a = do
+              376 ┃       (defName,defMut,defLoc) <- maybe discard forAll (pickPos $ appProg a)
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             Hole
+                  ┃       │               (Meta
+                  ┃       │                  19
+                  ┃       │                  (Just
+                  ┃       │                     (TCEmb
+                  ┃       │                        TCBoth
+                  ┃       │                          { tcChkedAt = TApp () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                          , tcSynthed = TEmptyHole ()
+                  ┃       │                          }))
+                  ┃       │                  Nothing)
+                  ┃       │               (Ann
+                  ┃       │                  (Meta 18 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                  (Con
+                  ┃       │                     (Meta
+                  ┃       │                        2
+                  ┃       │                        (Just
+                  ┃       │                           (TCChkedAt
+                  ┃       │                              (TCon
+                  ┃       │                                 ()
+                  ┃       │                                 GlobalName
+                  ┃       │                                   { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                   , baseName = "Bool"
+                  ┃       │                                   })))
+                  ┃       │                        Nothing)
+                  ┃       │                     GlobalName
+                  ┃       │                       { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                       , baseName = "False"
+                  ┃       │                       }
+                  ┃       │                     [])
+                  ┃       │                  (TEmptyHole (Meta 17 (Just KHole) Nothing)))
+                  ┃       │         , astDefType =
+                  ┃       │             TApp
+                  ┃       │               (Meta 4 (Just KHole) Nothing)
+                  ┃       │               (TEmptyHole (Meta 5 (Just KHole) Nothing))
+                  ┃       │               (TEmptyHole (Meta 6 (Just KHole) Nothing))
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 17
+                  ┃       │     )
+                  ┃       │ )
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             Hole
+                  ┃       │               (Meta
+                  ┃       │                  19
+                  ┃       │                  (Just
+                  ┃       │                     (TCEmb
+                  ┃       │                        TCBoth
+                  ┃       │                          { tcChkedAt = TApp () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                          , tcSynthed = TEmptyHole ()
+                  ┃       │                          }))
+                  ┃       │                  Nothing)
+                  ┃       │               (Ann
+                  ┃       │                  (Meta
+                  ┃       │                     18
+                  ┃       │                     (Just (TCSynthed (TFun () (TEmptyHole ()) (TEmptyHole ()))))
+                  ┃       │                     Nothing)
+                  ┃       │                  (Hole
+                  ┃       │                     (Meta
+                  ┃       │                        27
+                  ┃       │                        (Just
+                  ┃       │                           (TCEmb
+                  ┃       │                              TCBoth
+                  ┃       │                                { tcChkedAt = TFun () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                                , tcSynthed = TEmptyHole ()
+                  ┃       │                                }))
+                  ┃       │                        Nothing)
+                  ┃       │                     (Ann
+                  ┃       │                        (Meta 26 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                        (Con
+                  ┃       │                           (Meta
+                  ┃       │                              2
+                  ┃       │                              (Just
+                  ┃       │                                 (TCChkedAt
+                  ┃       │                                    (TCon
+                  ┃       │                                       ()
+                  ┃       │                                       GlobalName
+                  ┃       │                                         { qualifiedModule =
+                  ┃       │                                             ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                         , baseName = "Bool"
+                  ┃       │                                         })))
+                  ┃       │                              Nothing)
+                  ┃       │                           GlobalName
+                  ┃       │                             { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                             , baseName = "False"
+                  ┃       │                             }
+                  ┃       │                           [])
+                  ┃       │                        (TEmptyHole (Meta 25 (Just KHole) Nothing))))
+                  ┃       │                  (TFun
+                  ┃       │                     (Meta 23 (Just KType) Nothing)
+                  ┃       │                     (TEmptyHole (Meta 17 (Just KHole) Nothing))
+                  ┃       │                     (TEmptyHole (Meta 24 (Just KHole) Nothing))))
+                  ┃       │         , astDefType =
+                  ┃       │             TApp
+                  ┃       │               (Meta 4 (Just KHole) Nothing)
+                  ┃       │               (TEmptyHole (Meta 5 (Just KHole) Nothing))
+                  ┃       │               (TEmptyHole (Meta 6 (Just KHole) Nothing))
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 26
+                  ┃       │     )
+                  ┃       │ )
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             Hole
+                  ┃       │               (Meta
+                  ┃       │                  19
+                  ┃       │                  (Just
+                  ┃       │                     (TCEmb
+                  ┃       │                        TCBoth
+                  ┃       │                          { tcChkedAt = TApp () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                          , tcSynthed = TEmptyHole ()
+                  ┃       │                          }))
+                  ┃       │                  Nothing)
+                  ┃       │               (Ann
+                  ┃       │                  (Meta
+                  ┃       │                     18
+                  ┃       │                     (Just (TCSynthed (TFun () (TEmptyHole ()) (TEmptyHole ()))))
+                  ┃       │                     Nothing)
+                  ┃       │                  (Case
+                  ┃       │                     (Meta
+                  ┃       │                        37
+                  ┃       │                        (Just (TCChkedAt (TFun () (TEmptyHole ()) (TEmptyHole ()))))
+                  ┃       │                        Nothing)
+                  ┃       │                     (Ann
+                  ┃       │                        (Meta 26 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                        (Con
+                  ┃       │                           (Meta
+                  ┃       │                              2
+                  ┃       │                              (Just
+                  ┃       │                                 (TCChkedAt
+                  ┃       │                                    (TCon
+                  ┃       │                                       ()
+                  ┃       │                                       GlobalName
+                  ┃       │                                         { qualifiedModule =
+                  ┃       │                                             ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                         , baseName = "Bool"
+                  ┃       │                                         })))
+                  ┃       │                              Nothing)
+                  ┃       │                           GlobalName
+                  ┃       │                             { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                             , baseName = "False"
+                  ┃       │                             }
+                  ┃       │                           [])
+                  ┃       │                        (TEmptyHole (Meta 25 (Just KHole) Nothing)))
+                  ┃       │                     [])
+                  ┃       │                  (TFun
+                  ┃       │                     (Meta 23 (Just KType) Nothing)
+                  ┃       │                     (TEmptyHole (Meta 17 (Just KHole) Nothing))
+                  ┃       │                     (TEmptyHole (Meta 24 (Just KHole) Nothing))))
+                  ┃       │         , astDefType =
+                  ┃       │             TApp
+                  ┃       │               (Meta 4 (Just KHole) Nothing)
+                  ┃       │               (TEmptyHole (Meta 5 (Just KHole) Nothing))
+                  ┃       │               (TEmptyHole (Meta 6 (Just KHole) Nothing))
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 25
+                  ┃       │     )
+                  ┃       │ )
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             Hole
+                  ┃       │               (Meta
+                  ┃       │                  19
+                  ┃       │                  (Just
+                  ┃       │                     (TCEmb
+                  ┃       │                        TCBoth
+                  ┃       │                          { tcChkedAt = TApp () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                          , tcSynthed = TEmptyHole ()
+                  ┃       │                          }))
+                  ┃       │                  Nothing)
+                  ┃       │               (Ann
+                  ┃       │                  (Meta
+                  ┃       │                     18
+                  ┃       │                     (Just (TCSynthed (TFun () (TEmptyHole ()) (TEmptyHole ()))))
+                  ┃       │                     Nothing)
+                  ┃       │                  (Case
+                  ┃       │                     (Meta
+                  ┃       │                        37
+                  ┃       │                        (Just (TCChkedAt (TFun () (TEmptyHole ()) (TEmptyHole ()))))
+                  ┃       │                        Nothing)
+                  ┃       │                     (Hole
+                  ┃       │                        (Meta 47 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                        (Ann
+                  ┃       │                           (Meta
+                  ┃       │                              26
+                  ┃       │                              (Just (TCSynthed (TFun () (TEmptyHole ()) (TEmptyHole ()))))
+                  ┃       │                              Nothing)
+                  ┃       │                           (Hole
+                  ┃       │                              (Meta
+                  ┃       │                                 46
+                  ┃       │                                 (Just
+                  ┃       │                                    (TCEmb
+                  ┃       │                                       TCBoth
+                  ┃       │                                         { tcChkedAt = TFun () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                                         , tcSynthed = TEmptyHole ()
+                  ┃       │                                         }))
+                  ┃       │                                 Nothing)
+                  ┃       │                              (Ann
+                  ┃       │                                 (Meta 45 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                                 (Con
+                  ┃       │                                    (Meta
+                  ┃       │                                       2
+                  ┃       │                                       (Just
+                  ┃       │                                          (TCChkedAt
+                  ┃       │                                             (TCon
+                  ┃       │                                                ()
+                  ┃       │                                                GlobalName
+                  ┃       │                                                  { qualifiedModule =
+                  ┃       │                                                      ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                  , baseName = "Bool"
+                  ┃       │                                                  })))
+                  ┃       │                                       Nothing)
+                  ┃       │                                    GlobalName
+                  ┃       │                                      { qualifiedModule =
+                  ┃       │                                          ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                      , baseName = "False"
+                  ┃       │                                      }
+                  ┃       │                                    [])
+                  ┃       │                                 (TEmptyHole (Meta 44 (Just KHole) Nothing))))
+                  ┃       │                           (TFun
+                  ┃       │                              (Meta 42 (Just KType) Nothing)
+                  ┃       │                              (TEmptyHole (Meta 25 (Just KHole) Nothing))
+                  ┃       │                              (TEmptyHole (Meta 43 (Just KHole) Nothing)))))
+                  ┃       │                     [])
+                  ┃       │                  (TFun
+                  ┃       │                     (Meta 23 (Just KType) Nothing)
+                  ┃       │                     (TEmptyHole (Meta 17 (Just KHole) Nothing))
+                  ┃       │                     (TEmptyHole (Meta 24 (Just KHole) Nothing))))
+                  ┃       │         , astDefType =
+                  ┃       │             TApp
+                  ┃       │               (Meta 4 (Just KHole) Nothing)
+                  ┃       │               (TEmptyHole (Meta 5 (Just KHole) Nothing))
+                  ┃       │               (TEmptyHole (Meta 6 (Just KHole) Nothing))
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 23
+                  ┃       │     )
+                  ┃       │ )
+              377 ┃       let defMap = fmap snd $ progAllDefs $ appProg a
+              378 ┃       let (def, loc,acts) = case defLoc of
+              379 ┃             Left d -> (d, Nothing,Available.forDef defMap l defMut defName)
+              380 ┃             Right (d,SigNode, i) -> (DefAST d, Just (SigNode, i), Available.forSig l defMut (astDefType d) i)
+              381 ┃             Right (d,BodyNode, i) -> (DefAST d, Just (BodyNode, i), Available.forBody (snd <$> progAllTypeDefs (appProg a)) l defMut (astDefExpr d) i)
+              382 ┃       case acts of
+              383 ┃         [] -> label "no offered actions" >> pure Nothing
+              384 ┃         acts' -> do
+              385 ┃           action <- forAllT $ Gen.element acts'
+                  ┃           │ NoInput MakeFun
+                  ┃           │ NoInput MakeCase
+                  ┃           │ NoInput MakeFun
+                  ┃           │ NoInput DeleteType
+              386 ┃           collect action
+              387 ┃           case action of
+              388 ┃             Available.NoInput act' -> do
+              389 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              390 ┃               progActs <-
+              391 ┃                 either (\e -> annotateShow e >> failure) pure $
+              392 ┃                   toProgActionNoInput (map snd $ progAllDefs $ appProg a) def' defName loc act'
+              393 ┃               Just <$> actionSucceeds (handleEditRequest progActs) a
+              394 ┃             Available.Input act' -> do
+              395 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              396 ┃               Available.Options{Available.opts, Available.free} <-
+              397 ┃                 maybe (annotate "id not found" >> failure) pure $
+              398 ┃                   Available.options
+              399 ┃                     (map snd $ progAllTypeDefs $ appProg a)
+              400 ┃                     (map snd $ progAllDefs $ appProg a)
+              401 ┃                     (progCxt $ appProg a)
+              402 ┃                     l
+              403 ┃                     def'
+              404 ┃                     loc
+              405 ┃                     act'
+              406 ┃               let opts' = [Gen.element $ (Offered,) <$> opts | not (null opts)]
+              407 ┃               let opts'' =
+              408 ┃                     opts' <> case free of
+              409 ┃                       Available.FreeNone -> []
+              410 ┃                       Available.FreeVarName -> [(StudentProvided,) . flip Available.Option Nothing <$> (unName <$> genName)]
+              411 ┃                       Available.FreeInt -> [(StudentProvided,) . flip Available.Option Nothing <$> (show <$> Gen.integral (Range.linear @Integer 0 1_000_000_000))]
+              412 ┃                       Available.FreeChar -> [(StudentProvided,) . flip Available.Option Nothing . T.singleton <$> Gen.unicode]
+              413 ┃               case opts'' of
+              414 ┃                 [] -> annotate "no options" >> pure Nothing
+              415 ┃                 options -> do
+              416 ┃                   opt <- forAllT $ Gen.choice options
+              417 ┃                   progActs <- either (\e -> annotateShow e >> failure) pure $ toProgActionInput def' defName loc (snd opt) act'
+              418 ┃                   actionSucceedsOrCapture (fst opt) (handleEditRequest progActs) a
+              419 ┃   where
+              420 ┃     runEditAppMLogs ::
+              421 ┃       HasCallStack =>
+              422 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              423 ┃       App ->
+              424 ┃       PropertyT WT (Either ProgError a, App)
+              425 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              426 ┃       (r, logs) -> testNoSevereLogs logs >> pure r
+              427 ┃     actionSucceeds :: HasCallStack => EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT App
+              428 ┃     actionSucceeds m a =
+              429 ┃       runEditAppMLogs m a >>= \case
+              430 ┃         (Left err, _) -> annotateShow err >> failure
+                  ┃         │ ActionError
+                  ┃         │   (CustomFailure Delete "internal error: lost ID after typechecking")
+                  ┃         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              431 ┃         (Right _, a') -> pure a'
+              432 ┃     -- If we submit our own name rather than an offered one, then
+              433 ┃     -- we should expect that name capture/clashing may happen
+              434 ┃     actionSucceedsOrCapture :: HasCallStack => Provenance -> EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT (Maybe App)
+              435 ┃     actionSucceedsOrCapture p m a = do
+              436 ┃       a' <- runEditAppMLogs m a
+              437 ┃       case (p, a') of
+              438 ┃         (StudentProvided, (Left (ActionError NameCapture), _)) -> do
+              439 ┃           label "name-capture with entered name"
+              440 ┃           annotate "ignoring name capture error as was generated name, not offered one"
+              441 ┃           pure Nothing
+              442 ┃         (StudentProvided, (Left (ActionError (CaseBindsClash{})), _)) -> do
+              443 ┃           label "name-clash with entered name"
+              444 ┃           annotate "ignoring name clash error as was generated name, not offered one"
+              445 ┃           pure Nothing
+              446 ┃         (StudentProvided, (Left DefAlreadyExists{}, _)) -> do
+              447 ┃           label "rename def name clash with entered name"
+              448 ┃           annotate "ignoring def already exists error as was generated name, not offered one"
+              449 ┃           pure Nothing
+              450 ┃         (_, (Left err, _)) -> annotateShow err >> failure
+              451 ┃         (_, (Right _, a'')) -> pure $ Just a''
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              458 ┃ tasty_undo_redo :: Property
+              459 ┃ tasty_undo_redo = withTests 500 $
+              460 ┃   withDiscards 2000 $
+              461 ┃     propertyWT [] $ do
+              462 ┃       l <- forAllT $ Gen.element enumerate
+                  ┃       │ Beginner
+              463 ┃       cxt <- forAllT $ Gen.choice $ map sequence [[], [builtinModule], [builtinModule, pure primitiveModule]]
+                  ┃       │ [ Module
+                  ┃       │     { moduleName = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │     , moduleTypes =
+                  ┃       │         fromList
+                  ┃       │           [ ( "Bool"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters = []
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "True"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "False"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "p" , "q" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Either"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                       , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Left"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 8 Nothing Nothing) LocalName { unLocalName = "a" } ]
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Right"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 9 Nothing Nothing) LocalName { unLocalName = "b" } ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = []
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "List"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Nil"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Cons"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 1 Nothing Nothing) LocalName { unLocalName = "a" }
+                  ┃       │                               , TApp
+                  ┃       │                                   (Meta 2 Nothing Nothing)
+                  ┃       │                                   (TCon
+                  ┃       │                                      (Meta 3 Nothing Nothing)
+                  ┃       │                                      GlobalName
+                  ┃       │                                        { qualifiedModule =
+                  ┃       │                                            ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                        , baseName = "List"
+                  ┃       │                                        })
+                  ┃       │                                   (TVar (Meta 4 Nothing Nothing) LocalName { unLocalName = "a" })
+                  ┃       │                               ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "xs" , "ys" , "zs" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Maybe"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Nothing"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Just"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 5 Nothing Nothing) LocalName { unLocalName = "a" } ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "mx" , "my" , "mz" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Nat"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters = []
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Zero"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Succ"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TCon
+                  ┃       │                                   (Meta 0 Nothing Nothing)
+                  ┃       │                                   GlobalName
+                  ┃       │                                     { qualifiedModule =
+                  ┃       │                                         ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                     , baseName = "Nat"
+                  ┃       │                                     }
+                  ┃       │                               ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "i" , "j" , "n" , "m" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Pair"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                       , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "MakePair"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 6 Nothing Nothing) LocalName { unLocalName = "a" }
+                  ┃       │                               , TVar (Meta 7 Nothing Nothing) LocalName { unLocalName = "b" }
+                  ┃       │                               ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = []
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           ]
+                  ┃       │     , moduleDefs = fromList []
+                  ┃       │     }
+                  ┃       │ ]
+              464 ┃       -- We only test SmartHoles mode (which is the only supported user-facing
+              465 ┃       -- mode - NoSmartHoles is only used for internal sanity testing etc)
+              466 ┃       let annotateShow' :: HasCallStack => App -> PropertyT WT ()
+              467 ┃           annotateShow' = withFrozenCallStack $ annotateShow . (\p -> (progModules p, progLog p, redoLog p)) . appProg
+              468 ┃       a <- forAllT $ genApp SmartHoles cxt
+                  ┃       │ App
+                  ┃       │   { currentState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 20
+                  ┃       │         , nameCounter = NC 520
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "Bool"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "True"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "False"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "p" , "q" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Either"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Left"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 8 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Right"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 9 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "List"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nil"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Cons"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 1 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TApp
+                  ┃       │                                                     (Meta 2 Nothing Nothing)
+                  ┃       │                                                     (TCon
+                  ┃       │                                                        (Meta 3 Nothing Nothing)
+                  ┃       │                                                        GlobalName
+                  ┃       │                                                          { qualifiedModule =
+                  ┃       │                                                              ModuleName
+                  ┃       │                                                                { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                          , baseName = "List"
+                  ┃       │                                                          })
+                  ┃       │                                                     (TVar
+                  ┃       │                                                        (Meta 4 Nothing Nothing)
+                  ┃       │                                                        LocalName { unLocalName = "a" })
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "xs" , "ys" , "zs" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Maybe"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nothing"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Just"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 5 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "mx" , "my" , "mz" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Nat"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Zero"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Succ"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TCon
+                  ┃       │                                                     (Meta 0 Nothing Nothing)
+                  ┃       │                                                     GlobalName
+                  ┃       │                                                       { qualifiedModule =
+                  ┃       │                                                           ModuleName
+                  ┃       │                                                             { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                       , baseName = "Nat"
+                  ┃       │                                                       }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "i" , "j" , "n" , "m" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Pair"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "MakePair"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 6 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TVar
+                  ┃       │                                                     (Meta 7 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs = fromList []
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes = fromList []
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         Hole
+                  ┃       │                                           (Meta
+                  ┃       │                                              19
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCEmb
+                  ┃       │                                                    TCBoth
+                  ┃       │                                                      { tcChkedAt =
+                  ┃       │                                                          TApp () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                                                      , tcSynthed = TEmptyHole ()
+                  ┃       │                                                      }))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           (Ann
+                  ┃       │                                              (Meta 18 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                                              (Con
+                  ┃       │                                                 (Meta
+                  ┃       │                                                    2
+                  ┃       │                                                    (Just
+                  ┃       │                                                       (TCChkedAt
+                  ┃       │                                                          (TCon
+                  ┃       │                                                             ()
+                  ┃       │                                                             GlobalName
+                  ┃       │                                                               { qualifiedModule =
+                  ┃       │                                                                   ModuleName
+                  ┃       │                                                                     { unModuleName =
+                  ┃       │                                                                         "Builtins" :| []
+                  ┃       │                                                                     }
+                  ┃       │                                                               , baseName = "Bool"
+                  ┃       │                                                               })))
+                  ┃       │                                                    Nothing)
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "False"
+                  ┃       │                                                   }
+                  ┃       │                                                 [])
+                  ┃       │                                              (TEmptyHole (Meta 17 (Just KHole) Nothing)))
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TApp
+                  ┃       │                                           (Meta 4 (Just KHole) Nothing)
+                  ┃       │                                           (TEmptyHole (Meta 5 (Just KHole) Nothing))
+                  ┃       │                                           (TEmptyHole (Meta 6 (Just KHole) Nothing))
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   , initialState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 20
+                  ┃       │         , nameCounter = NC 520
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "Bool"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "True"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "False"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "p" , "q" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Either"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Left"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 8 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Right"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 9 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "List"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nil"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Cons"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 1 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TApp
+                  ┃       │                                                     (Meta 2 Nothing Nothing)
+                  ┃       │                                                     (TCon
+                  ┃       │                                                        (Meta 3 Nothing Nothing)
+                  ┃       │                                                        GlobalName
+                  ┃       │                                                          { qualifiedModule =
+                  ┃       │                                                              ModuleName
+                  ┃       │                                                                { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                          , baseName = "List"
+                  ┃       │                                                          })
+                  ┃       │                                                     (TVar
+                  ┃       │                                                        (Meta 4 Nothing Nothing)
+                  ┃       │                                                        LocalName { unLocalName = "a" })
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "xs" , "ys" , "zs" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Maybe"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nothing"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Just"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 5 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "mx" , "my" , "mz" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Nat"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Zero"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Succ"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TCon
+                  ┃       │                                                     (Meta 0 Nothing Nothing)
+                  ┃       │                                                     GlobalName
+                  ┃       │                                                       { qualifiedModule =
+                  ┃       │                                                           ModuleName
+                  ┃       │                                                             { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                       , baseName = "Nat"
+                  ┃       │                                                       }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "i" , "j" , "n" , "m" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Pair"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "MakePair"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 6 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TVar
+                  ┃       │                                                     (Meta 7 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs = fromList []
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes = fromList []
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         Hole
+                  ┃       │                                           (Meta
+                  ┃       │                                              19
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCEmb
+                  ┃       │                                                    TCBoth
+                  ┃       │                                                      { tcChkedAt =
+                  ┃       │                                                          TApp () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                                                      , tcSynthed = TEmptyHole ()
+                  ┃       │                                                      }))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           (Ann
+                  ┃       │                                              (Meta 18 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                                              (Con
+                  ┃       │                                                 (Meta
+                  ┃       │                                                    2
+                  ┃       │                                                    (Just
+                  ┃       │                                                       (TCChkedAt
+                  ┃       │                                                          (TCon
+                  ┃       │                                                             ()
+                  ┃       │                                                             GlobalName
+                  ┃       │                                                               { qualifiedModule =
+                  ┃       │                                                                   ModuleName
+                  ┃       │                                                                     { unModuleName =
+                  ┃       │                                                                         "Builtins" :| []
+                  ┃       │                                                                     }
+                  ┃       │                                                               , baseName = "Bool"
+                  ┃       │                                                               })))
+                  ┃       │                                                    Nothing)
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "False"
+                  ┃       │                                                   }
+                  ┃       │                                                 [])
+                  ┃       │                                              (TEmptyHole (Meta 17 (Just KHole) Nothing)))
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TApp
+                  ┃       │                                           (Meta 4 (Just KHole) Nothing)
+                  ┃       │                                           (TEmptyHole (Meta 5 (Just KHole) Nothing))
+                  ┃       │                                           (TEmptyHole (Meta 6 (Just KHole) Nothing))
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   }
+              469 ┃       annotateShow' a
+                  ┃       │ ( [ Module
+                  ┃       │       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │       , moduleTypes = fromList []
+                  ┃       │       , moduleDefs =
+                  ┃       │           fromList
+                  ┃       │             [ ( "a"
+                  ┃       │               , DefAST
+                  ┃       │                   ASTDef
+                  ┃       │                     { astDefExpr =
+                  ┃       │                         Hole
+                  ┃       │                           (Meta
+                  ┃       │                              19
+                  ┃       │                              (Just
+                  ┃       │                                 (TCEmb
+                  ┃       │                                    TCBoth
+                  ┃       │                                      { tcChkedAt = TApp () (TEmptyHole ()) (TEmptyHole ())
+                  ┃       │                                      , tcSynthed = TEmptyHole ()
+                  ┃       │                                      }))
+                  ┃       │                              Nothing)
+                  ┃       │                           (Ann
+                  ┃       │                              (Meta 18 (Just (TCSynthed (TEmptyHole ()))) Nothing)
+                  ┃       │                              (Con
+                  ┃       │                                 (Meta
+                  ┃       │                                    2
+                  ┃       │                                    (Just
+                  ┃       │                                       (TCChkedAt
+                  ┃       │                                          (TCon
+                  ┃       │                                             ()
+                  ┃       │                                             GlobalName
+                  ┃       │                                               { qualifiedModule =
+                  ┃       │                                                   ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                               , baseName = "Bool"
+                  ┃       │                                               })))
+                  ┃       │                                    Nothing)
+                  ┃       │                                 GlobalName
+                  ┃       │                                   { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                   , baseName = "False"
+                  ┃       │                                   }
+                  ┃       │                                 [])
+                  ┃       │                              (TEmptyHole (Meta 17 (Just KHole) Nothing)))
+                  ┃       │                     , astDefType =
+                  ┃       │                         TApp
+                  ┃       │                           (Meta 4 (Just KHole) Nothing)
+                  ┃       │                           (TEmptyHole (Meta 5 (Just KHole) Nothing))
+                  ┃       │                           (TEmptyHole (Meta 6 (Just KHole) Nothing))
+                  ┃       │                     }
+                  ┃       │               )
+                  ┃       │             ]
+                  ┃       │       }
+                  ┃       │   ]
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ )
+              470 ┃       n <- forAll $ Gen.int $ Range.linear 1 20
+                  ┃       │ 10
+              471 ┃       a' <- iterateNM n a $ \a' -> runRandomAction l a'
+              472 ┃       annotateShow' a'
+              473 ┃       if null $ unlog $ progLog $ appProg a' -- TODO: expose a "log-is-null" helper from App?
+              474 ┃         -- It is possible for the random actions to undo everything!
+              475 ┃         then success
+              476 ┃         else do
+              477 ┃           a'' <- runEditAppMLogs (handleMutationRequest Undo) a'
+              478 ┃           annotateShow' a''
+              479 ┃           a''' <- runEditAppMLogs (handleMutationRequest Redo) a''
+              480 ┃           annotateShow' a'''
+              481 ┃           TypeCacheAlpha a' === TypeCacheAlpha a'''
+              482 ┃   where
+              483 ┃     -- TODO: dry
+              484 ┃     runEditAppMLogs ::
+              485 ┃       HasCallStack =>
+              486 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              487 ┃       App ->
+              488 ┃       PropertyT WT App
+              489 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              490 ┃       (r, logs) -> testNoSevereLogs logs >> case r of
+              491 ┃         (Left err, _) -> annotateShow err >> failure
+              492 ┃         (Right _, a') -> pure a'
+              493 ┃     runRandomAction l a = do
+              494 ┃       act <- forAll $ Gen.frequency $ second pure <$> [
+                  ┃       │ Avail
+                  ┃       │ AddTy
+                  ┃       │ Avail
+                  ┃       │ AddTm
+                  ┃       │ AddTm
+                  ┃       │ AddTy
+                  ┃       │ AddTm
+                  ┃       │ Un
+                  ┃       │ Avail
+                  ┃       │ Avail
+              495 ┃         (2,AddTm)
+              496 ┃         ,(1,AddTy)
+              497 ┃         ,(if null $ unlog $ progLog $ appProg a then 0 else 1,Un) -- TODO: expose a "log-is-null" helper from App?
+              498 ┃         ,(if null $ unlog $ redoLog $ appProg a then 0 else 1,Re) -- TODO: expose a "log-is-null" helper from App?
+              499 ┃         ,(5,Avail)
+              500 ┃                                     ]
+              501 ┃       case act of
+              502 ┃         AddTm -> do
+              503 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              504 ┃           n <- forAllT $ Gen.choice [Just . unName <$> n', pure Nothing]
+                  ┃           │ Just "a2"
+                  ┃           │ Just "a3"
+                  ┃           │ Just "a5"
+              505 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+              506 ┃           runEditAppMLogs (handleMutationRequest $ Edit [CreateDef m n]) a
+              507 ┃         AddTy -> do
+              508 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+              509 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              510 ┃           n <- qualifyName m <$> forAllT n'
+                  ┃           │ "a1"
+                  ┃           │ "a4"
+              511 ┃           runEditAppMLogs (handleMutationRequest $ Edit [AddTypeDef n $ ASTTypeDef [] [] []]) a
+              512 ┃         Un -> runEditAppMLogs (handleMutationRequest Undo) a
+              513 ┃         Re -> runEditAppMLogs (handleMutationRequest Redo) a
+              514 ┃         Avail -> fromMaybe a <$> runRandomAvailableAction l a
+
+              This failure can be reproduced by running:
+              > recheck (Size 57) (Seed 5594787156260972540 7447132206390486147) undo redo
+
+          Use '--pattern "$NF ~ /undo redo/" --hedgehog-replay "Size 57 Seed 5594787156260972540 7447132206390486147"' to reproduce from the command-line.
+
+1 out of 1 tests failed (1.65s)
+#+end_src
+
+* cabal run -O primer-test -- -p "undo redo" --hedgehog-replay "Size 98 Seed 10665341429893025564 10182452733544053075"
+** Actions: Raise ; DeleteType
+** Output
+#+begin_src
+test/Test.hs
+  Tests
+    Action
+      Available
+        undo redo: FAIL (1.10s)
+            ✗ undo redo failed at test/Tests/Action/Available.hs:430:46
+              after 1 test and 24 shrinks.
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              374 ┃ runRandomAvailableAction :: Level -> App -> PropertyT WT (Maybe App)
+              375 ┃ runRandomAvailableAction l a = do
+              376 ┃       (defName,defMut,defLoc) <- maybe discard forAll (pickPos $ appProg a)
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             LAM
+                  ┃       │               (Meta
+                  ┃       │                  0
+                  ┃       │                  (Just
+                  ┃       │                     (TCChkedAt
+                  ┃       │                        (TForall
+                  ┃       │                           ()
+                  ┃       │                           LocalName { unLocalName = "x" }
+                  ┃       │                           KType
+                  ┃       │                           (TFun
+                  ┃       │                              ()
+                  ┃       │                              (TForall () LocalName { unLocalName = "x" } KType (TEmptyHole ()))
+                  ┃       │                              (TVar () LocalName { unLocalName = "x" })))))
+                  ┃       │                  Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               (Ann
+                  ┃       │                  (Meta
+                  ┃       │                     1
+                  ┃       │                     (Just
+                  ┃       │                        (TCEmb
+                  ┃       │                           TCBoth
+                  ┃       │                             { tcChkedAt =
+                  ┃       │                                 TFun
+                  ┃       │                                   ()
+                  ┃       │                                   (TForall
+                  ┃       │                                      () LocalName { unLocalName = "a25" } KType (TEmptyHole ()))
+                  ┃       │                                   (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                             , tcSynthed =
+                  ┃       │                                 TFun
+                  ┃       │                                   ()
+                  ┃       │                                   (TForall () LocalName { unLocalName = "a" } KType (TEmptyHole ()))
+                  ┃       │                                   (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                             }))
+                  ┃       │                     Nothing)
+                  ┃       │                  (Let
+                  ┃       │                     (Meta
+                  ┃       │                        2
+                  ┃       │                        (Just
+                  ┃       │                           (TCChkedAt
+                  ┃       │                              (TFun
+                  ┃       │                                 ()
+                  ┃       │                                 (TForall () LocalName { unLocalName = "a" } KType (TEmptyHole ()))
+                  ┃       │                                 (TVar () LocalName { unLocalName = "x" }))))
+                  ┃       │                        Nothing)
+                  ┃       │                     LocalName { unLocalName = "x_1" }
+                  ┃       │                     (EmptyHole (Meta 3 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                     (Case
+                  ┃       │                        (Meta
+                  ┃       │                           4
+                  ┃       │                           (Just
+                  ┃       │                              (TCChkedAt
+                  ┃       │                                 (TFun
+                  ┃       │                                    ()
+                  ┃       │                                    (TForall
+                  ┃       │                                       () LocalName { unLocalName = "a" } KType (TEmptyHole ()))
+                  ┃       │                                    (TVar () LocalName { unLocalName = "x" }))))
+                  ┃       │                           Nothing)
+                  ┃       │                        (EmptyHole (Meta 5 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                        []))
+                  ┃       │                  (TFun
+                  ┃       │                     (Meta 6 (Just KType) Nothing)
+                  ┃       │                     (TForall
+                  ┃       │                        (Meta 7 (Just KType) Nothing)
+                  ┃       │                        LocalName { unLocalName = "a" }
+                  ┃       │                        KType
+                  ┃       │                        (TEmptyHole (Meta 8 (Just KHole) Nothing)))
+                  ┃       │                     (TVar
+                  ┃       │                        (Meta 9 (Just KType) Nothing) LocalName { unLocalName = "x" })))
+                  ┃       │         , astDefType =
+                  ┃       │             TForall
+                  ┃       │               (Meta 10 (Just KType) Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               KType
+                  ┃       │               (TFun
+                  ┃       │                  (Meta 11 (Just KType) Nothing)
+                  ┃       │                  (TForall
+                  ┃       │                     (Meta 12 (Just KType) Nothing)
+                  ┃       │                     LocalName { unLocalName = "x" }
+                  ┃       │                     KType
+                  ┃       │                     (TEmptyHole (Meta 13 (Just KHole) Nothing)))
+                  ┃       │                  (TVar
+                  ┃       │                     (Meta 14 (Just KType) Nothing) LocalName { unLocalName = "x" }))
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 7
+                  ┃       │     )
+                  ┃       │ )
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             LAM
+                  ┃       │               (Meta
+                  ┃       │                  0
+                  ┃       │                  (Just
+                  ┃       │                     (TCChkedAt
+                  ┃       │                        (TForall
+                  ┃       │                           ()
+                  ┃       │                           LocalName { unLocalName = "x" }
+                  ┃       │                           KType
+                  ┃       │                           (TFun
+                  ┃       │                              ()
+                  ┃       │                              (TForall () LocalName { unLocalName = "x" } KType (TEmptyHole ()))
+                  ┃       │                              (TVar () LocalName { unLocalName = "x" })))))
+                  ┃       │                  Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               (Hole
+                  ┃       │                  (Meta
+                  ┃       │                     29
+                  ┃       │                     (Just
+                  ┃       │                        (TCEmb
+                  ┃       │                           TCBoth
+                  ┃       │                             { tcChkedAt =
+                  ┃       │                                 TFun
+                  ┃       │                                   ()
+                  ┃       │                                   (TForall
+                  ┃       │                                      () LocalName { unLocalName = "e26" } KType (TEmptyHole ()))
+                  ┃       │                                   (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                             , tcSynthed = TEmptyHole ()
+                  ┃       │                             }))
+                  ┃       │                     Nothing)
+                  ┃       │                  (Ann
+                  ┃       │                     (Meta
+                  ┃       │                        1
+                  ┃       │                        (Just
+                  ┃       │                           (TCSynthed
+                  ┃       │                              (TForall
+                  ┃       │                                 () LocalName { unLocalName = "a" } KType (TEmptyHole ()))))
+                  ┃       │                        Nothing)
+                  ┃       │                     (Let
+                  ┃       │                        (Meta
+                  ┃       │                           2
+                  ┃       │                           (Just
+                  ┃       │                              (TCChkedAt
+                  ┃       │                                 (TForall
+                  ┃       │                                    () LocalName { unLocalName = "a" } KType (TEmptyHole ()))))
+                  ┃       │                           Nothing)
+                  ┃       │                        LocalName { unLocalName = "x_1" }
+                  ┃       │                        (EmptyHole (Meta 3 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                        (Case
+                  ┃       │                           (Meta
+                  ┃       │                              4
+                  ┃       │                              (Just
+                  ┃       │                                 (TCChkedAt
+                  ┃       │                                    (TForall
+                  ┃       │                                       () LocalName { unLocalName = "a" } KType (TEmptyHole ()))))
+                  ┃       │                              Nothing)
+                  ┃       │                           (EmptyHole (Meta 5 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                           []))
+                  ┃       │                     (TForall
+                  ┃       │                        (Meta 27 (Just KType) Nothing)
+                  ┃       │                        LocalName { unLocalName = "a" }
+                  ┃       │                        KType
+                  ┃       │                        (TEmptyHole (Meta 28 (Just KHole) Nothing)))))
+                  ┃       │         , astDefType =
+                  ┃       │             TForall
+                  ┃       │               (Meta 10 (Just KType) Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               KType
+                  ┃       │               (TFun
+                  ┃       │                  (Meta 11 (Just KType) Nothing)
+                  ┃       │                  (TForall
+                  ┃       │                     (Meta 12 (Just KType) Nothing)
+                  ┃       │                     LocalName { unLocalName = "x" }
+                  ┃       │                     KType
+                  ┃       │                     (TEmptyHole (Meta 13 (Just KHole) Nothing)))
+                  ┃       │                  (TVar
+                  ┃       │                     (Meta 14 (Just KType) Nothing) LocalName { unLocalName = "x" }))
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 27
+                  ┃       │     )
+                  ┃       │ )
+              377 ┃       let defMap = fmap snd $ progAllDefs $ appProg a
+              378 ┃       let (def, loc,acts) = case defLoc of
+              379 ┃             Left d -> (d, Nothing,Available.forDef defMap l defMut defName)
+              380 ┃             Right (d,SigNode, i) -> (DefAST d, Just (SigNode, i), Available.forSig l defMut (astDefType d) i)
+              381 ┃             Right (d,BodyNode, i) -> (DefAST d, Just (BodyNode, i), Available.forBody (snd <$> progAllTypeDefs (appProg a)) l defMut (astDefExpr d) i)
+              382 ┃       case acts of
+              383 ┃         [] -> label "no offered actions" >> pure Nothing
+              384 ┃         acts' -> do
+              385 ┃           action <- forAllT $ Gen.element acts'
+                  ┃           │ NoInput Raise
+                  ┃           │ NoInput DeleteType
+              386 ┃           collect action
+              387 ┃           case action of
+              388 ┃             Available.NoInput act' -> do
+              389 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              390 ┃               progActs <-
+              391 ┃                 either (\e -> annotateShow e >> failure) pure $
+              392 ┃                   toProgActionNoInput (map snd $ progAllDefs $ appProg a) def' defName loc act'
+              393 ┃               Just <$> actionSucceeds (handleEditRequest progActs) a
+              394 ┃             Available.Input act' -> do
+              395 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              396 ┃               Available.Options{Available.opts, Available.free} <-
+              397 ┃                 maybe (annotate "id not found" >> failure) pure $
+              398 ┃                   Available.options
+              399 ┃                     (map snd $ progAllTypeDefs $ appProg a)
+              400 ┃                     (map snd $ progAllDefs $ appProg a)
+              401 ┃                     (progCxt $ appProg a)
+              402 ┃                     l
+              403 ┃                     def'
+              404 ┃                     loc
+              405 ┃                     act'
+              406 ┃               let opts' = [Gen.element $ (Offered,) <$> opts | not (null opts)]
+              407 ┃               let opts'' =
+              408 ┃                     opts' <> case free of
+              409 ┃                       Available.FreeNone -> []
+              410 ┃                       Available.FreeVarName -> [(StudentProvided,) . flip Available.Option Nothing <$> (unName <$> genName)]
+              411 ┃                       Available.FreeInt -> [(StudentProvided,) . flip Available.Option Nothing <$> (show <$> Gen.integral (Range.linear @Integer 0 1_000_000_000))]
+              412 ┃                       Available.FreeChar -> [(StudentProvided,) . flip Available.Option Nothing . T.singleton <$> Gen.unicode]
+              413 ┃               case opts'' of
+              414 ┃                 [] -> annotate "no options" >> pure Nothing
+              415 ┃                 options -> do
+              416 ┃                   opt <- forAllT $ Gen.choice options
+              417 ┃                   progActs <- either (\e -> annotateShow e >> failure) pure $ toProgActionInput def' defName loc (snd opt) act'
+              418 ┃                   actionSucceedsOrCapture (fst opt) (handleEditRequest progActs) a
+              419 ┃   where
+              420 ┃     runEditAppMLogs ::
+              421 ┃       HasCallStack =>
+              422 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              423 ┃       App ->
+              424 ┃       PropertyT WT (Either ProgError a, App)
+              425 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              426 ┃       (r, logs) -> testNoSevereLogs logs >> pure r
+              427 ┃     actionSucceeds :: HasCallStack => EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT App
+              428 ┃     actionSucceeds m a =
+              429 ┃       runEditAppMLogs m a >>= \case
+              430 ┃         (Left err, _) -> annotateShow err >> failure
+                  ┃         │ ActionError
+                  ┃         │   (CustomFailure Delete "internal error: lost ID after typechecking")
+                  ┃         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              431 ┃         (Right _, a') -> pure a'
+              432 ┃     -- If we submit our own name rather than an offered one, then
+              433 ┃     -- we should expect that name capture/clashing may happen
+              434 ┃     actionSucceedsOrCapture :: HasCallStack => Provenance -> EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT (Maybe App)
+              435 ┃     actionSucceedsOrCapture p m a = do
+              436 ┃       a' <- runEditAppMLogs m a
+              437 ┃       case (p, a') of
+              438 ┃         (StudentProvided, (Left (ActionError NameCapture), _)) -> do
+              439 ┃           label "name-capture with entered name"
+              440 ┃           annotate "ignoring name capture error as was generated name, not offered one"
+              441 ┃           pure Nothing
+              442 ┃         (StudentProvided, (Left (ActionError (CaseBindsClash{})), _)) -> do
+              443 ┃           label "name-clash with entered name"
+              444 ┃           annotate "ignoring name clash error as was generated name, not offered one"
+              445 ┃           pure Nothing
+              446 ┃         (StudentProvided, (Left DefAlreadyExists{}, _)) -> do
+              447 ┃           label "rename def name clash with entered name"
+              448 ┃           annotate "ignoring def already exists error as was generated name, not offered one"
+              449 ┃           pure Nothing
+              450 ┃         (_, (Left err, _)) -> annotateShow err >> failure
+              451 ┃         (_, (Right _, a'')) -> pure $ Just a''
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              458 ┃ tasty_undo_redo :: Property
+              459 ┃ tasty_undo_redo = withTests 500 $
+              460 ┃   withDiscards 2000 $
+              461 ┃     propertyWT [] $ do
+              462 ┃       l <- forAllT $ Gen.element enumerate
+                  ┃       │ Beginner
+              463 ┃       cxt <- forAllT $ Gen.choice $ map sequence [[], [builtinModule], [builtinModule, pure primitiveModule]]
+                  ┃       │ [ Module
+                  ┃       │     { moduleName = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │     , moduleTypes =
+                  ┃       │         fromList
+                  ┃       │           [ ( "Bool"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters = []
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "True"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "False"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "p" , "q" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Either"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                       , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Left"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 8 Nothing Nothing) LocalName { unLocalName = "a" } ]
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Right"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 9 Nothing Nothing) LocalName { unLocalName = "b" } ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = []
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "List"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Nil"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Cons"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 1 Nothing Nothing) LocalName { unLocalName = "a" }
+                  ┃       │                               , TApp
+                  ┃       │                                   (Meta 2 Nothing Nothing)
+                  ┃       │                                   (TCon
+                  ┃       │                                      (Meta 3 Nothing Nothing)
+                  ┃       │                                      GlobalName
+                  ┃       │                                        { qualifiedModule =
+                  ┃       │                                            ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                        , baseName = "List"
+                  ┃       │                                        })
+                  ┃       │                                   (TVar (Meta 4 Nothing Nothing) LocalName { unLocalName = "a" })
+                  ┃       │                               ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "xs" , "ys" , "zs" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Maybe"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Nothing"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Just"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 5 Nothing Nothing) LocalName { unLocalName = "a" } ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "mx" , "my" , "mz" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Nat"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters = []
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Zero"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs = []
+                  ┃       │                           }
+                  ┃       │                       , ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "Succ"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TCon
+                  ┃       │                                   (Meta 0 Nothing Nothing)
+                  ┃       │                                   GlobalName
+                  ┃       │                                     { qualifiedModule =
+                  ┃       │                                         ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                     , baseName = "Nat"
+                  ┃       │                                     }
+                  ┃       │                               ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = [ "i" , "j" , "n" , "m" ]
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           , ( "Pair"
+                  ┃       │             , TypeDefAST
+                  ┃       │                 ASTTypeDef
+                  ┃       │                   { astTypeDefParameters =
+                  ┃       │                       [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                       , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefConstructors =
+                  ┃       │                       [ ValCon
+                  ┃       │                           { valConName =
+                  ┃       │                               GlobalName
+                  ┃       │                                 { qualifiedModule = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                 , baseName = "MakePair"
+                  ┃       │                                 }
+                  ┃       │                           , valConArgs =
+                  ┃       │                               [ TVar (Meta 6 Nothing Nothing) LocalName { unLocalName = "a" }
+                  ┃       │                               , TVar (Meta 7 Nothing Nothing) LocalName { unLocalName = "b" }
+                  ┃       │                               ]
+                  ┃       │                           }
+                  ┃       │                       ]
+                  ┃       │                   , astTypeDefNameHints = []
+                  ┃       │                   }
+                  ┃       │             )
+                  ┃       │           ]
+                  ┃       │     , moduleDefs = fromList []
+                  ┃       │     }
+                  ┃       │ ]
+              464 ┃       -- We only test SmartHoles mode (which is the only supported user-facing
+              465 ┃       -- mode - NoSmartHoles is only used for internal sanity testing etc)
+              466 ┃       let annotateShow' :: HasCallStack => App -> PropertyT WT ()
+              467 ┃           annotateShow' = withFrozenCallStack $ annotateShow . (\p -> (progModules p, progLog p, redoLog p)) . appProg
+              468 ┃       a <- forAllT $ genApp SmartHoles cxt
+                  ┃       │ App
+                  ┃       │   { currentState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 26
+                  ┃       │         , nameCounter = NC 676
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "Bool"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "True"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "False"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "p" , "q" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Either"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Left"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 8 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Right"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 9 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "List"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nil"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Cons"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 1 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TApp
+                  ┃       │                                                     (Meta 2 Nothing Nothing)
+                  ┃       │                                                     (TCon
+                  ┃       │                                                        (Meta 3 Nothing Nothing)
+                  ┃       │                                                        GlobalName
+                  ┃       │                                                          { qualifiedModule =
+                  ┃       │                                                              ModuleName
+                  ┃       │                                                                { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                          , baseName = "List"
+                  ┃       │                                                          })
+                  ┃       │                                                     (TVar
+                  ┃       │                                                        (Meta 4 Nothing Nothing)
+                  ┃       │                                                        LocalName { unLocalName = "a" })
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "xs" , "ys" , "zs" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Maybe"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nothing"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Just"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 5 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "mx" , "my" , "mz" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Nat"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Zero"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Succ"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TCon
+                  ┃       │                                                     (Meta 0 Nothing Nothing)
+                  ┃       │                                                     GlobalName
+                  ┃       │                                                       { qualifiedModule =
+                  ┃       │                                                           ModuleName
+                  ┃       │                                                             { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                       , baseName = "Nat"
+                  ┃       │                                                       }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "i" , "j" , "n" , "m" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Pair"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "MakePair"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 6 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TVar
+                  ┃       │                                                     (Meta 7 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs = fromList []
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes = fromList []
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         LAM
+                  ┃       │                                           (Meta
+                  ┃       │                                              0
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCChkedAt
+                  ┃       │                                                    (TForall
+                  ┃       │                                                       ()
+                  ┃       │                                                       LocalName { unLocalName = "x" }
+                  ┃       │                                                       KType
+                  ┃       │                                                       (TFun
+                  ┃       │                                                          ()
+                  ┃       │                                                          (TForall
+                  ┃       │                                                             ()
+                  ┃       │                                                             LocalName { unLocalName = "x" }
+                  ┃       │                                                             KType
+                  ┃       │                                                             (TEmptyHole ()))
+                  ┃       │                                                          (TVar
+                  ┃       │                                                             () LocalName { unLocalName = "x" })))))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           (Ann
+                  ┃       │                                              (Meta
+                  ┃       │                                                 1
+                  ┃       │                                                 (Just
+                  ┃       │                                                    (TCEmb
+                  ┃       │                                                       TCBoth
+                  ┃       │                                                         { tcChkedAt =
+                  ┃       │                                                             TFun
+                  ┃       │                                                               ()
+                  ┃       │                                                               (TForall
+                  ┃       │                                                                  ()
+                  ┃       │                                                                  LocalName { unLocalName = "a25" }
+                  ┃       │                                                                  KType
+                  ┃       │                                                                  (TEmptyHole ()))
+                  ┃       │                                                               (TVar
+                  ┃       │                                                                  () LocalName { unLocalName = "x" })
+                  ┃       │                                                         , tcSynthed =
+                  ┃       │                                                             TFun
+                  ┃       │                                                               ()
+                  ┃       │                                                               (TForall
+                  ┃       │                                                                  ()
+                  ┃       │                                                                  LocalName { unLocalName = "a" }
+                  ┃       │                                                                  KType
+                  ┃       │                                                                  (TEmptyHole ()))
+                  ┃       │                                                               (TVar
+                  ┃       │                                                                  () LocalName { unLocalName = "x" })
+                  ┃       │                                                         }))
+                  ┃       │                                                 Nothing)
+                  ┃       │                                              (Let
+                  ┃       │                                                 (Meta
+                  ┃       │                                                    2
+                  ┃       │                                                    (Just
+                  ┃       │                                                       (TCChkedAt
+                  ┃       │                                                          (TFun
+                  ┃       │                                                             ()
+                  ┃       │                                                             (TForall
+                  ┃       │                                                                ()
+                  ┃       │                                                                LocalName { unLocalName = "a" }
+                  ┃       │                                                                KType
+                  ┃       │                                                                (TEmptyHole ()))
+                  ┃       │                                                             (TVar
+                  ┃       │                                                                ()
+                  ┃       │                                                                LocalName { unLocalName = "x" }))))
+                  ┃       │                                                    Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x_1" }
+                  ┃       │                                                 (EmptyHole
+                  ┃       │                                                    (Meta
+                  ┃       │                                                       3 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                                                 (Case
+                  ┃       │                                                    (Meta
+                  ┃       │                                                       4
+                  ┃       │                                                       (Just
+                  ┃       │                                                          (TCChkedAt
+                  ┃       │                                                             (TFun
+                  ┃       │                                                                ()
+                  ┃       │                                                                (TForall
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   LocalName { unLocalName = "a" }
+                  ┃       │                                                                   KType
+                  ┃       │                                                                   (TEmptyHole ()))
+                  ┃       │                                                                (TVar
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   LocalName
+                  ┃       │                                                                     { unLocalName = "x" }))))
+                  ┃       │                                                       Nothing)
+                  ┃       │                                                    (EmptyHole
+                  ┃       │                                                       (Meta
+                  ┃       │                                                          5
+                  ┃       │                                                          (Just (TCSynthed (TEmptyHole ())))
+                  ┃       │                                                          Nothing))
+                  ┃       │                                                    []))
+                  ┃       │                                              (TFun
+                  ┃       │                                                 (Meta 6 (Just KType) Nothing)
+                  ┃       │                                                 (TForall
+                  ┃       │                                                    (Meta 7 (Just KType) Nothing)
+                  ┃       │                                                    LocalName { unLocalName = "a" }
+                  ┃       │                                                    KType
+                  ┃       │                                                    (TEmptyHole (Meta 8 (Just KHole) Nothing)))
+                  ┃       │                                                 (TVar
+                  ┃       │                                                    (Meta 9 (Just KType) Nothing)
+                  ┃       │                                                    LocalName { unLocalName = "x" })))
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TForall
+                  ┃       │                                           (Meta 10 (Just KType) Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           KType
+                  ┃       │                                           (TFun
+                  ┃       │                                              (Meta 11 (Just KType) Nothing)
+                  ┃       │                                              (TForall
+                  ┃       │                                                 (Meta 12 (Just KType) Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x" }
+                  ┃       │                                                 KType
+                  ┃       │                                                 (TEmptyHole (Meta 13 (Just KHole) Nothing)))
+                  ┃       │                                              (TVar
+                  ┃       │                                                 (Meta 14 (Just KType) Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x" }))
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   , initialState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 26
+                  ┃       │         , nameCounter = NC 676
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "Bool"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "True"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "False"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "p" , "q" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Either"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Left"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 8 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Right"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 9 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "List"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nil"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Cons"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 1 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TApp
+                  ┃       │                                                     (Meta 2 Nothing Nothing)
+                  ┃       │                                                     (TCon
+                  ┃       │                                                        (Meta 3 Nothing Nothing)
+                  ┃       │                                                        GlobalName
+                  ┃       │                                                          { qualifiedModule =
+                  ┃       │                                                              ModuleName
+                  ┃       │                                                                { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                          , baseName = "List"
+                  ┃       │                                                          })
+                  ┃       │                                                     (TVar
+                  ┃       │                                                        (Meta 4 Nothing Nothing)
+                  ┃       │                                                        LocalName { unLocalName = "a" })
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "xs" , "ys" , "zs" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Maybe"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType ) ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Nothing"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Just"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 5 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "mx" , "my" , "mz" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Nat"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Zero"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs = []
+                  ┃       │                                             }
+                  ┃       │                                         , ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "Succ"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TCon
+                  ┃       │                                                     (Meta 0 Nothing Nothing)
+                  ┃       │                                                     GlobalName
+                  ┃       │                                                       { qualifiedModule =
+                  ┃       │                                                           ModuleName
+                  ┃       │                                                             { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                       , baseName = "Nat"
+                  ┃       │                                                       }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = [ "i" , "j" , "n" , "m" ]
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             , ( "Pair"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters =
+                  ┃       │                                         [ ( LocalName { unLocalName = "a" } , KType )
+                  ┃       │                                         , ( LocalName { unLocalName = "b" } , KType )
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefConstructors =
+                  ┃       │                                         [ ValCon
+                  ┃       │                                             { valConName =
+                  ┃       │                                                 GlobalName
+                  ┃       │                                                   { qualifiedModule =
+                  ┃       │                                                       ModuleName { unModuleName = "Builtins" :| [] }
+                  ┃       │                                                   , baseName = "MakePair"
+                  ┃       │                                                   }
+                  ┃       │                                             , valConArgs =
+                  ┃       │                                                 [ TVar
+                  ┃       │                                                     (Meta 6 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "a" }
+                  ┃       │                                                 , TVar
+                  ┃       │                                                     (Meta 7 Nothing Nothing)
+                  ┃       │                                                     LocalName { unLocalName = "b" }
+                  ┃       │                                                 ]
+                  ┃       │                                             }
+                  ┃       │                                         ]
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs = fromList []
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes = fromList []
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         LAM
+                  ┃       │                                           (Meta
+                  ┃       │                                              0
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCChkedAt
+                  ┃       │                                                    (TForall
+                  ┃       │                                                       ()
+                  ┃       │                                                       LocalName { unLocalName = "x" }
+                  ┃       │                                                       KType
+                  ┃       │                                                       (TFun
+                  ┃       │                                                          ()
+                  ┃       │                                                          (TForall
+                  ┃       │                                                             ()
+                  ┃       │                                                             LocalName { unLocalName = "x" }
+                  ┃       │                                                             KType
+                  ┃       │                                                             (TEmptyHole ()))
+                  ┃       │                                                          (TVar
+                  ┃       │                                                             () LocalName { unLocalName = "x" })))))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           (Ann
+                  ┃       │                                              (Meta
+                  ┃       │                                                 1
+                  ┃       │                                                 (Just
+                  ┃       │                                                    (TCEmb
+                  ┃       │                                                       TCBoth
+                  ┃       │                                                         { tcChkedAt =
+                  ┃       │                                                             TFun
+                  ┃       │                                                               ()
+                  ┃       │                                                               (TForall
+                  ┃       │                                                                  ()
+                  ┃       │                                                                  LocalName { unLocalName = "a25" }
+                  ┃       │                                                                  KType
+                  ┃       │                                                                  (TEmptyHole ()))
+                  ┃       │                                                               (TVar
+                  ┃       │                                                                  () LocalName { unLocalName = "x" })
+                  ┃       │                                                         , tcSynthed =
+                  ┃       │                                                             TFun
+                  ┃       │                                                               ()
+                  ┃       │                                                               (TForall
+                  ┃       │                                                                  ()
+                  ┃       │                                                                  LocalName { unLocalName = "a" }
+                  ┃       │                                                                  KType
+                  ┃       │                                                                  (TEmptyHole ()))
+                  ┃       │                                                               (TVar
+                  ┃       │                                                                  () LocalName { unLocalName = "x" })
+                  ┃       │                                                         }))
+                  ┃       │                                                 Nothing)
+                  ┃       │                                              (Let
+                  ┃       │                                                 (Meta
+                  ┃       │                                                    2
+                  ┃       │                                                    (Just
+                  ┃       │                                                       (TCChkedAt
+                  ┃       │                                                          (TFun
+                  ┃       │                                                             ()
+                  ┃       │                                                             (TForall
+                  ┃       │                                                                ()
+                  ┃       │                                                                LocalName { unLocalName = "a" }
+                  ┃       │                                                                KType
+                  ┃       │                                                                (TEmptyHole ()))
+                  ┃       │                                                             (TVar
+                  ┃       │                                                                ()
+                  ┃       │                                                                LocalName { unLocalName = "x" }))))
+                  ┃       │                                                    Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x_1" }
+                  ┃       │                                                 (EmptyHole
+                  ┃       │                                                    (Meta
+                  ┃       │                                                       3 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                                                 (Case
+                  ┃       │                                                    (Meta
+                  ┃       │                                                       4
+                  ┃       │                                                       (Just
+                  ┃       │                                                          (TCChkedAt
+                  ┃       │                                                             (TFun
+                  ┃       │                                                                ()
+                  ┃       │                                                                (TForall
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   LocalName { unLocalName = "a" }
+                  ┃       │                                                                   KType
+                  ┃       │                                                                   (TEmptyHole ()))
+                  ┃       │                                                                (TVar
+                  ┃       │                                                                   ()
+                  ┃       │                                                                   LocalName
+                  ┃       │                                                                     { unLocalName = "x" }))))
+                  ┃       │                                                       Nothing)
+                  ┃       │                                                    (EmptyHole
+                  ┃       │                                                       (Meta
+                  ┃       │                                                          5
+                  ┃       │                                                          (Just (TCSynthed (TEmptyHole ())))
+                  ┃       │                                                          Nothing))
+                  ┃       │                                                    []))
+                  ┃       │                                              (TFun
+                  ┃       │                                                 (Meta 6 (Just KType) Nothing)
+                  ┃       │                                                 (TForall
+                  ┃       │                                                    (Meta 7 (Just KType) Nothing)
+                  ┃       │                                                    LocalName { unLocalName = "a" }
+                  ┃       │                                                    KType
+                  ┃       │                                                    (TEmptyHole (Meta 8 (Just KHole) Nothing)))
+                  ┃       │                                                 (TVar
+                  ┃       │                                                    (Meta 9 (Just KType) Nothing)
+                  ┃       │                                                    LocalName { unLocalName = "x" })))
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TForall
+                  ┃       │                                           (Meta 10 (Just KType) Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           KType
+                  ┃       │                                           (TFun
+                  ┃       │                                              (Meta 11 (Just KType) Nothing)
+                  ┃       │                                              (TForall
+                  ┃       │                                                 (Meta 12 (Just KType) Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x" }
+                  ┃       │                                                 KType
+                  ┃       │                                                 (TEmptyHole (Meta 13 (Just KHole) Nothing)))
+                  ┃       │                                              (TVar
+                  ┃       │                                                 (Meta 14 (Just KType) Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x" }))
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   }
+              469 ┃       annotateShow' a
+                  ┃       │ ( [ Module
+                  ┃       │       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │       , moduleTypes = fromList []
+                  ┃       │       , moduleDefs =
+                  ┃       │           fromList
+                  ┃       │             [ ( "a"
+                  ┃       │               , DefAST
+                  ┃       │                   ASTDef
+                  ┃       │                     { astDefExpr =
+                  ┃       │                         LAM
+                  ┃       │                           (Meta
+                  ┃       │                              0
+                  ┃       │                              (Just
+                  ┃       │                                 (TCChkedAt
+                  ┃       │                                    (TForall
+                  ┃       │                                       ()
+                  ┃       │                                       LocalName { unLocalName = "x" }
+                  ┃       │                                       KType
+                  ┃       │                                       (TFun
+                  ┃       │                                          ()
+                  ┃       │                                          (TForall
+                  ┃       │                                             ()
+                  ┃       │                                             LocalName { unLocalName = "x" }
+                  ┃       │                                             KType
+                  ┃       │                                             (TEmptyHole ()))
+                  ┃       │                                          (TVar () LocalName { unLocalName = "x" })))))
+                  ┃       │                              Nothing)
+                  ┃       │                           LocalName { unLocalName = "x" }
+                  ┃       │                           (Ann
+                  ┃       │                              (Meta
+                  ┃       │                                 1
+                  ┃       │                                 (Just
+                  ┃       │                                    (TCEmb
+                  ┃       │                                       TCBoth
+                  ┃       │                                         { tcChkedAt =
+                  ┃       │                                             TFun
+                  ┃       │                                               ()
+                  ┃       │                                               (TForall
+                  ┃       │                                                  ()
+                  ┃       │                                                  LocalName { unLocalName = "a25" }
+                  ┃       │                                                  KType
+                  ┃       │                                                  (TEmptyHole ()))
+                  ┃       │                                               (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                         , tcSynthed =
+                  ┃       │                                             TFun
+                  ┃       │                                               ()
+                  ┃       │                                               (TForall
+                  ┃       │                                                  ()
+                  ┃       │                                                  LocalName { unLocalName = "a" }
+                  ┃       │                                                  KType
+                  ┃       │                                                  (TEmptyHole ()))
+                  ┃       │                                               (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                         }))
+                  ┃       │                                 Nothing)
+                  ┃       │                              (Let
+                  ┃       │                                 (Meta
+                  ┃       │                                    2
+                  ┃       │                                    (Just
+                  ┃       │                                       (TCChkedAt
+                  ┃       │                                          (TFun
+                  ┃       │                                             ()
+                  ┃       │                                             (TForall
+                  ┃       │                                                ()
+                  ┃       │                                                LocalName { unLocalName = "a" }
+                  ┃       │                                                KType
+                  ┃       │                                                (TEmptyHole ()))
+                  ┃       │                                             (TVar () LocalName { unLocalName = "x" }))))
+                  ┃       │                                    Nothing)
+                  ┃       │                                 LocalName { unLocalName = "x_1" }
+                  ┃       │                                 (EmptyHole (Meta 3 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                                 (Case
+                  ┃       │                                    (Meta
+                  ┃       │                                       4
+                  ┃       │                                       (Just
+                  ┃       │                                          (TCChkedAt
+                  ┃       │                                             (TFun
+                  ┃       │                                                ()
+                  ┃       │                                                (TForall
+                  ┃       │                                                   ()
+                  ┃       │                                                   LocalName { unLocalName = "a" }
+                  ┃       │                                                   KType
+                  ┃       │                                                   (TEmptyHole ()))
+                  ┃       │                                                (TVar () LocalName { unLocalName = "x" }))))
+                  ┃       │                                       Nothing)
+                  ┃       │                                    (EmptyHole (Meta 5 (Just (TCSynthed (TEmptyHole ()))) Nothing))
+                  ┃       │                                    []))
+                  ┃       │                              (TFun
+                  ┃       │                                 (Meta 6 (Just KType) Nothing)
+                  ┃       │                                 (TForall
+                  ┃       │                                    (Meta 7 (Just KType) Nothing)
+                  ┃       │                                    LocalName { unLocalName = "a" }
+                  ┃       │                                    KType
+                  ┃       │                                    (TEmptyHole (Meta 8 (Just KHole) Nothing)))
+                  ┃       │                                 (TVar
+                  ┃       │                                    (Meta 9 (Just KType) Nothing) LocalName { unLocalName = "x" })))
+                  ┃       │                     , astDefType =
+                  ┃       │                         TForall
+                  ┃       │                           (Meta 10 (Just KType) Nothing)
+                  ┃       │                           LocalName { unLocalName = "x" }
+                  ┃       │                           KType
+                  ┃       │                           (TFun
+                  ┃       │                              (Meta 11 (Just KType) Nothing)
+                  ┃       │                              (TForall
+                  ┃       │                                 (Meta 12 (Just KType) Nothing)
+                  ┃       │                                 LocalName { unLocalName = "x" }
+                  ┃       │                                 KType
+                  ┃       │                                 (TEmptyHole (Meta 13 (Just KHole) Nothing)))
+                  ┃       │                              (TVar
+                  ┃       │                                 (Meta 14 (Just KType) Nothing) LocalName { unLocalName = "x" }))
+                  ┃       │                     }
+                  ┃       │               )
+                  ┃       │             ]
+                  ┃       │       }
+                  ┃       │   ]
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ )
+              470 ┃       n <- forAll $ Gen.int $ Range.linear 1 20
+                  ┃       │ 10
+              471 ┃       a' <- iterateNM n a $ \a' -> runRandomAction l a'
+              472 ┃       annotateShow' a'
+              473 ┃       if null $ unlog $ progLog $ appProg a' -- TODO: expose a "log-is-null" helper from App?
+              474 ┃         -- It is possible for the random actions to undo everything!
+              475 ┃         then success
+              476 ┃         else do
+              477 ┃           a'' <- runEditAppMLogs (handleMutationRequest Undo) a'
+              478 ┃           annotateShow' a''
+              479 ┃           a''' <- runEditAppMLogs (handleMutationRequest Redo) a''
+              480 ┃           annotateShow' a'''
+              481 ┃           TypeCacheAlpha a' === TypeCacheAlpha a'''
+              482 ┃   where
+              483 ┃     -- TODO: dry
+              484 ┃     runEditAppMLogs ::
+              485 ┃       HasCallStack =>
+              486 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              487 ┃       App ->
+              488 ┃       PropertyT WT App
+              489 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              490 ┃       (r, logs) -> testNoSevereLogs logs >> case r of
+              491 ┃         (Left err, _) -> annotateShow err >> failure
+              492 ┃         (Right _, a') -> pure a'
+              493 ┃     runRandomAction l a = do
+              494 ┃       act <- forAll $ Gen.frequency $ second pure <$> [
+                  ┃       │ Avail
+                  ┃       │ AddTm
+                  ┃       │ AddTm
+                  ┃       │ AddTm
+                  ┃       │ AddTm
+                  ┃       │ AddTm
+                  ┃       │ AddTy
+                  ┃       │ AddTm
+                  ┃       │ AddTm
+                  ┃       │ Avail
+              495 ┃         (2,AddTm)
+              496 ┃         ,(1,AddTy)
+              497 ┃         ,(if null $ unlog $ progLog $ appProg a then 0 else 1,Un) -- TODO: expose a "log-is-null" helper from App?
+              498 ┃         ,(if null $ unlog $ redoLog $ appProg a then 0 else 1,Re) -- TODO: expose a "log-is-null" helper from App?
+              499 ┃         ,(5,Avail)
+              500 ┃                                     ]
+              501 ┃       case act of
+              502 ┃         AddTm -> do
+              503 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              504 ┃           n <- forAllT $ Gen.choice [Just . unName <$> n', pure Nothing]
+                  ┃           │ Just "a1"
+                  ┃           │ Just "a2"
+                  ┃           │ Just "a3"
+                  ┃           │ Just "a4"
+                  ┃           │ Just "a5"
+                  ┃           │ Just "a7"
+                  ┃           │ Just "a8"
+              505 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+              506 ┃           runEditAppMLogs (handleMutationRequest $ Edit [CreateDef m n]) a
+              507 ┃         AddTy -> do
+              508 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+                  ┃           │ ModuleName { unModuleName = "M" :| [ "0" ] }
+              509 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              510 ┃           n <- qualifyName m <$> forAllT n'
+                  ┃           │ "a6"
+              511 ┃           runEditAppMLogs (handleMutationRequest $ Edit [AddTypeDef n $ ASTTypeDef [] [] []]) a
+              512 ┃         Un -> runEditAppMLogs (handleMutationRequest Undo) a
+              513 ┃         Re -> runEditAppMLogs (handleMutationRequest Redo) a
+              514 ┃         Avail -> fromMaybe a <$> runRandomAvailableAction l a
+
+              This failure can be reproduced by running:
+              > recheck (Size 98) (Seed 10665341429893025564 10182452733544053075) undo redo
+
+          Use '--pattern "$NF ~ /undo redo/" --hedgehog-replay "Size 98 Seed 10665341429893025564 10182452733544053075"' to reproduce from the command-line.
+
+1 out of 1 tests failed (2.38s)
+#+end_src
+
+* cabal run -O primer-test -- -p "undo redo" --hedgehog-replay "Size 33 Seed 4268413180681694343 17092859468972210393"
+** Actions: MakeFun ; DeleteType
+** Output
+#+begin_src
+test/Test.hs
+  Tests
+    Action
+      Available
+        undo redo: FAIL (0.22s)
+            ✗ undo redo failed at test/Tests/Action/Available.hs:430:46
+              after 1 test and 7 shrinks.
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              374 ┃ runRandomAvailableAction :: Level -> App -> PropertyT WT (Maybe App)
+              375 ┃ runRandomAvailableAction l a = do
+              376 ┃       (defName,defMut,defLoc) <- maybe discard forAll (pickPos $ appProg a)
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a1"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             Ann
+                  ┃       │               (Meta
+                  ┃       │                  2
+                  ┃       │                  (Just
+                  ┃       │                     (TCEmb
+                  ┃       │                        TCBoth
+                  ┃       │                          { tcChkedAt =
+                  ┃       │                              TForall
+                  ┃       │                                ()
+                  ┃       │                                LocalName { unLocalName = "x" }
+                  ┃       │                                KType
+                  ┃       │                                (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                          , tcSynthed =
+                  ┃       │                              TForall
+                  ┃       │                                ()
+                  ┃       │                                LocalName { unLocalName = "x" }
+                  ┃       │                                KType
+                  ┃       │                                (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                          }))
+                  ┃       │                  Nothing)
+                  ┃       │               (EmptyHole
+                  ┃       │                  (Meta
+                  ┃       │                     3
+                  ┃       │                     (Just
+                  ┃       │                        (TCEmb
+                  ┃       │                           TCBoth
+                  ┃       │                             { tcChkedAt =
+                  ┃       │                                 TForall
+                  ┃       │                                   ()
+                  ┃       │                                   LocalName { unLocalName = "x" }
+                  ┃       │                                   KType
+                  ┃       │                                   (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                             , tcSynthed = TEmptyHole ()
+                  ┃       │                             }))
+                  ┃       │                     Nothing))
+                  ┃       │               (TForall
+                  ┃       │                  (Meta 4 (Just KType) Nothing)
+                  ┃       │                  LocalName { unLocalName = "x" }
+                  ┃       │                  KType
+                  ┃       │                  (TVar
+                  ┃       │                     (Meta 5 (Just KType) Nothing) LocalName { unLocalName = "x" }))
+                  ┃       │         , astDefType =
+                  ┃       │             TForall
+                  ┃       │               (Meta 6 (Just KType) Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               KType
+                  ┃       │               (TVar
+                  ┃       │                  (Meta 7 (Just KType) Nothing) LocalName { unLocalName = "x" })
+                  ┃       │         }
+                  ┃       │     , SigNode
+                  ┃       │     , 7
+                  ┃       │     )
+                  ┃       │ )
+                  ┃       │ ( GlobalName
+                  ┃       │     { qualifiedModule = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │     , baseName = "a1"
+                  ┃       │     }
+                  ┃       │ , Editable
+                  ┃       │ , Right
+                  ┃       │     ( ASTDef
+                  ┃       │         { astDefExpr =
+                  ┃       │             Hole
+                  ┃       │               (Meta
+                  ┃       │                  12
+                  ┃       │                  (Just
+                  ┃       │                     (TCEmb
+                  ┃       │                        TCBoth
+                  ┃       │                          { tcChkedAt =
+                  ┃       │                              TForall
+                  ┃       │                                ()
+                  ┃       │                                LocalName { unLocalName = "x" }
+                  ┃       │                                KType
+                  ┃       │                                (TFun () (TVar () LocalName { unLocalName = "x" }) (TEmptyHole ()))
+                  ┃       │                          , tcSynthed = TEmptyHole ()
+                  ┃       │                          }))
+                  ┃       │                  Nothing)
+                  ┃       │               (Ann
+                  ┃       │                  (Meta
+                  ┃       │                     2
+                  ┃       │                     (Just
+                  ┃       │                        (TCSynthed
+                  ┃       │                           (TForall
+                  ┃       │                              ()
+                  ┃       │                              LocalName { unLocalName = "x" }
+                  ┃       │                              KType
+                  ┃       │                              (TVar () LocalName { unLocalName = "x" }))))
+                  ┃       │                     Nothing)
+                  ┃       │                  (EmptyHole
+                  ┃       │                     (Meta
+                  ┃       │                        3
+                  ┃       │                        (Just
+                  ┃       │                           (TCEmb
+                  ┃       │                              TCBoth
+                  ┃       │                                { tcChkedAt =
+                  ┃       │                                    TForall
+                  ┃       │                                      ()
+                  ┃       │                                      LocalName { unLocalName = "x" }
+                  ┃       │                                      KType
+                  ┃       │                                      (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                , tcSynthed = TEmptyHole ()
+                  ┃       │                                }))
+                  ┃       │                        Nothing))
+                  ┃       │                  (TForall
+                  ┃       │                     (Meta 4 (Just KType) Nothing)
+                  ┃       │                     LocalName { unLocalName = "x" }
+                  ┃       │                     KType
+                  ┃       │                     (TVar
+                  ┃       │                        (Meta 5 (Just KType) Nothing) LocalName { unLocalName = "x" })))
+                  ┃       │         , astDefType =
+                  ┃       │             TForall
+                  ┃       │               (Meta 6 (Just KType) Nothing)
+                  ┃       │               LocalName { unLocalName = "x" }
+                  ┃       │               KType
+                  ┃       │               (TFun
+                  ┃       │                  (Meta 10 (Just KType) Nothing)
+                  ┃       │                  (TVar
+                  ┃       │                     (Meta 7 (Just KType) Nothing) LocalName { unLocalName = "x" })
+                  ┃       │                  (TEmptyHole (Meta 11 (Just KHole) Nothing)))
+                  ┃       │         }
+                  ┃       │     , BodyNode
+                  ┃       │     , 4
+                  ┃       │     )
+                  ┃       │ )
+              377 ┃       let defMap = fmap snd $ progAllDefs $ appProg a
+              378 ┃       let (def, loc,acts) = case defLoc of
+              379 ┃             Left d -> (d, Nothing,Available.forDef defMap l defMut defName)
+              380 ┃             Right (d,SigNode, i) -> (DefAST d, Just (SigNode, i), Available.forSig l defMut (astDefType d) i)
+              381 ┃             Right (d,BodyNode, i) -> (DefAST d, Just (BodyNode, i), Available.forBody (snd <$> progAllTypeDefs (appProg a)) l defMut (astDefExpr d) i)
+              382 ┃       case acts of
+              383 ┃         [] -> label "no offered actions" >> pure Nothing
+              384 ┃         acts' -> do
+              385 ┃           action <- forAllT $ Gen.element acts'
+                  ┃           │ NoInput MakeFun
+                  ┃           │ NoInput DeleteType
+              386 ┃           collect action
+              387 ┃           case action of
+              388 ┃             Available.NoInput act' -> do
+              389 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              390 ┃               progActs <-
+              391 ┃                 either (\e -> annotateShow e >> failure) pure $
+              392 ┃                   toProgActionNoInput (map snd $ progAllDefs $ appProg a) def' defName loc act'
+              393 ┃               Just <$> actionSucceeds (handleEditRequest progActs) a
+              394 ┃             Available.Input act' -> do
+              395 ┃               def' <- maybe (annotate "primitive def" >> failure) pure $ defAST def
+              396 ┃               Available.Options{Available.opts, Available.free} <-
+              397 ┃                 maybe (annotate "id not found" >> failure) pure $
+              398 ┃                   Available.options
+              399 ┃                     (map snd $ progAllTypeDefs $ appProg a)
+              400 ┃                     (map snd $ progAllDefs $ appProg a)
+              401 ┃                     (progCxt $ appProg a)
+              402 ┃                     l
+              403 ┃                     def'
+              404 ┃                     loc
+              405 ┃                     act'
+              406 ┃               let opts' = [Gen.element $ (Offered,) <$> opts | not (null opts)]
+              407 ┃               let opts'' =
+              408 ┃                     opts' <> case free of
+              409 ┃                       Available.FreeNone -> []
+              410 ┃                       Available.FreeVarName -> [(StudentProvided,) . flip Available.Option Nothing <$> (unName <$> genName)]
+              411 ┃                       Available.FreeInt -> [(StudentProvided,) . flip Available.Option Nothing <$> (show <$> Gen.integral (Range.linear @Integer 0 1_000_000_000))]
+              412 ┃                       Available.FreeChar -> [(StudentProvided,) . flip Available.Option Nothing . T.singleton <$> Gen.unicode]
+              413 ┃               case opts'' of
+              414 ┃                 [] -> annotate "no options" >> pure Nothing
+              415 ┃                 options -> do
+              416 ┃                   opt <- forAllT $ Gen.choice options
+              417 ┃                   progActs <- either (\e -> annotateShow e >> failure) pure $ toProgActionInput def' defName loc (snd opt) act'
+              418 ┃                   actionSucceedsOrCapture (fst opt) (handleEditRequest progActs) a
+              419 ┃   where
+              420 ┃     runEditAppMLogs ::
+              421 ┃       HasCallStack =>
+              422 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              423 ┃       App ->
+              424 ┃       PropertyT WT (Either ProgError a, App)
+              425 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              426 ┃       (r, logs) -> testNoSevereLogs logs >> pure r
+              427 ┃     actionSucceeds :: HasCallStack => EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT App
+              428 ┃     actionSucceeds m a =
+              429 ┃       runEditAppMLogs m a >>= \case
+              430 ┃         (Left err, _) -> annotateShow err >> failure
+                  ┃         │ ActionError
+                  ┃         │   (CustomFailure Delete "internal error: lost ID after typechecking")
+                  ┃         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              431 ┃         (Right _, a') -> pure a'
+              432 ┃     -- If we submit our own name rather than an offered one, then
+              433 ┃     -- we should expect that name capture/clashing may happen
+              434 ┃     actionSucceedsOrCapture :: HasCallStack => Provenance -> EditAppM (PureLog (WithSeverity ())) ProgError a -> App -> PropertyT WT (Maybe App)
+              435 ┃     actionSucceedsOrCapture p m a = do
+              436 ┃       a' <- runEditAppMLogs m a
+              437 ┃       case (p, a') of
+              438 ┃         (StudentProvided, (Left (ActionError NameCapture), _)) -> do
+              439 ┃           label "name-capture with entered name"
+              440 ┃           annotate "ignoring name capture error as was generated name, not offered one"
+              441 ┃           pure Nothing
+              442 ┃         (StudentProvided, (Left (ActionError (CaseBindsClash{})), _)) -> do
+              443 ┃           label "name-clash with entered name"
+              444 ┃           annotate "ignoring name clash error as was generated name, not offered one"
+              445 ┃           pure Nothing
+              446 ┃         (StudentProvided, (Left DefAlreadyExists{}, _)) -> do
+              447 ┃           label "rename def name clash with entered name"
+              448 ┃           annotate "ignoring def already exists error as was generated name, not offered one"
+              449 ┃           pure Nothing
+              450 ┃         (_, (Left err, _)) -> annotateShow err >> failure
+              451 ┃         (_, (Right _, a'')) -> pure $ Just a''
+
+                  ┏━━ test/Tests/Action/Available.hs ━━━
+              458 ┃ tasty_undo_redo :: Property
+              459 ┃ tasty_undo_redo = withTests 500 $
+              460 ┃   withDiscards 2000 $
+              461 ┃     propertyWT [] $ do
+              462 ┃       l <- forAllT $ Gen.element enumerate
+                  ┃       │ Beginner
+              463 ┃       cxt <- forAllT $ Gen.choice $ map sequence [[], [builtinModule], [builtinModule, pure primitiveModule]]
+                  ┃       │ []
+              464 ┃       -- We only test SmartHoles mode (which is the only supported user-facing
+              465 ┃       -- mode - NoSmartHoles is only used for internal sanity testing etc)
+              466 ┃       let annotateShow' :: HasCallStack => App -> PropertyT WT ()
+              467 ┃           annotateShow' = withFrozenCallStack $ annotateShow . (\p -> (progModules p, progLog p, redoLog p)) . appProg
+              468 ┃       a <- forAllT $ genApp SmartHoles cxt
+                  ┃       │ App
+                  ┃       │   { currentState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 8
+                  ┃       │         , nameCounter = NC 208
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports = []
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors = []
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a1"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         Ann
+                  ┃       │                                           (Meta
+                  ┃       │                                              2
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCEmb
+                  ┃       │                                                    TCBoth
+                  ┃       │                                                      { tcChkedAt =
+                  ┃       │                                                          TForall
+                  ┃       │                                                            ()
+                  ┃       │                                                            LocalName { unLocalName = "x" }
+                  ┃       │                                                            KType
+                  ┃       │                                                            (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                                      , tcSynthed =
+                  ┃       │                                                          TForall
+                  ┃       │                                                            ()
+                  ┃       │                                                            LocalName { unLocalName = "x" }
+                  ┃       │                                                            KType
+                  ┃       │                                                            (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                                      }))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           (EmptyHole
+                  ┃       │                                              (Meta
+                  ┃       │                                                 3
+                  ┃       │                                                 (Just
+                  ┃       │                                                    (TCEmb
+                  ┃       │                                                       TCBoth
+                  ┃       │                                                         { tcChkedAt =
+                  ┃       │                                                             TForall
+                  ┃       │                                                               ()
+                  ┃       │                                                               LocalName { unLocalName = "x" }
+                  ┃       │                                                               KType
+                  ┃       │                                                               (TVar
+                  ┃       │                                                                  () LocalName { unLocalName = "x" })
+                  ┃       │                                                         , tcSynthed = TEmptyHole ()
+                  ┃       │                                                         }))
+                  ┃       │                                                 Nothing))
+                  ┃       │                                           (TForall
+                  ┃       │                                              (Meta 4 (Just KType) Nothing)
+                  ┃       │                                              LocalName { unLocalName = "x" }
+                  ┃       │                                              KType
+                  ┃       │                                              (TVar
+                  ┃       │                                                 (Meta 5 (Just KType) Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x" }))
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TForall
+                  ┃       │                                           (Meta 6 (Just KType) Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           KType
+                  ┃       │                                           (TVar
+                  ┃       │                                              (Meta 7 (Just KType) Nothing)
+                  ┃       │                                              LocalName { unLocalName = "x" })
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   , initialState =
+                  ┃       │       AppState
+                  ┃       │         { idCounter = 8
+                  ┃       │         , nameCounter = NC 208
+                  ┃       │         , prog =
+                  ┃       │             Prog
+                  ┃       │               { progImports = []
+                  ┃       │               , progModules =
+                  ┃       │                   [ Module
+                  ┃       │                       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │                       , moduleTypes =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a"
+                  ┃       │                               , TypeDefAST
+                  ┃       │                                   ASTTypeDef
+                  ┃       │                                     { astTypeDefParameters = []
+                  ┃       │                                     , astTypeDefConstructors = []
+                  ┃       │                                     , astTypeDefNameHints = []
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       , moduleDefs =
+                  ┃       │                           fromList
+                  ┃       │                             [ ( "a1"
+                  ┃       │                               , DefAST
+                  ┃       │                                   ASTDef
+                  ┃       │                                     { astDefExpr =
+                  ┃       │                                         Ann
+                  ┃       │                                           (Meta
+                  ┃       │                                              2
+                  ┃       │                                              (Just
+                  ┃       │                                                 (TCEmb
+                  ┃       │                                                    TCBoth
+                  ┃       │                                                      { tcChkedAt =
+                  ┃       │                                                          TForall
+                  ┃       │                                                            ()
+                  ┃       │                                                            LocalName { unLocalName = "x" }
+                  ┃       │                                                            KType
+                  ┃       │                                                            (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                                      , tcSynthed =
+                  ┃       │                                                          TForall
+                  ┃       │                                                            ()
+                  ┃       │                                                            LocalName { unLocalName = "x" }
+                  ┃       │                                                            KType
+                  ┃       │                                                            (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                                      }))
+                  ┃       │                                              Nothing)
+                  ┃       │                                           (EmptyHole
+                  ┃       │                                              (Meta
+                  ┃       │                                                 3
+                  ┃       │                                                 (Just
+                  ┃       │                                                    (TCEmb
+                  ┃       │                                                       TCBoth
+                  ┃       │                                                         { tcChkedAt =
+                  ┃       │                                                             TForall
+                  ┃       │                                                               ()
+                  ┃       │                                                               LocalName { unLocalName = "x" }
+                  ┃       │                                                               KType
+                  ┃       │                                                               (TVar
+                  ┃       │                                                                  () LocalName { unLocalName = "x" })
+                  ┃       │                                                         , tcSynthed = TEmptyHole ()
+                  ┃       │                                                         }))
+                  ┃       │                                                 Nothing))
+                  ┃       │                                           (TForall
+                  ┃       │                                              (Meta 4 (Just KType) Nothing)
+                  ┃       │                                              LocalName { unLocalName = "x" }
+                  ┃       │                                              KType
+                  ┃       │                                              (TVar
+                  ┃       │                                                 (Meta 5 (Just KType) Nothing)
+                  ┃       │                                                 LocalName { unLocalName = "x" }))
+                  ┃       │                                     , astDefType =
+                  ┃       │                                         TForall
+                  ┃       │                                           (Meta 6 (Just KType) Nothing)
+                  ┃       │                                           LocalName { unLocalName = "x" }
+                  ┃       │                                           KType
+                  ┃       │                                           (TVar
+                  ┃       │                                              (Meta 7 (Just KType) Nothing)
+                  ┃       │                                              LocalName { unLocalName = "x" })
+                  ┃       │                                     }
+                  ┃       │                               )
+                  ┃       │                             ]
+                  ┃       │                       }
+                  ┃       │                   ]
+                  ┃       │               , progSelection = Nothing
+                  ┃       │               , progSmartHoles = SmartHoles
+                  ┃       │               , progLog = Log { unlog = [] }
+                  ┃       │               , redoLog = Log { unlog = [] }
+                  ┃       │               }
+                  ┃       │         }
+                  ┃       │   }
+              469 ┃       annotateShow' a
+                  ┃       │ ( [ Module
+                  ┃       │       { moduleName = ModuleName { unModuleName = "M" :| [ "0" ] }
+                  ┃       │       , moduleTypes =
+                  ┃       │           fromList
+                  ┃       │             [ ( "a"
+                  ┃       │               , TypeDefAST
+                  ┃       │                   ASTTypeDef
+                  ┃       │                     { astTypeDefParameters = []
+                  ┃       │                     , astTypeDefConstructors = []
+                  ┃       │                     , astTypeDefNameHints = []
+                  ┃       │                     }
+                  ┃       │               )
+                  ┃       │             ]
+                  ┃       │       , moduleDefs =
+                  ┃       │           fromList
+                  ┃       │             [ ( "a1"
+                  ┃       │               , DefAST
+                  ┃       │                   ASTDef
+                  ┃       │                     { astDefExpr =
+                  ┃       │                         Ann
+                  ┃       │                           (Meta
+                  ┃       │                              2
+                  ┃       │                              (Just
+                  ┃       │                                 (TCEmb
+                  ┃       │                                    TCBoth
+                  ┃       │                                      { tcChkedAt =
+                  ┃       │                                          TForall
+                  ┃       │                                            ()
+                  ┃       │                                            LocalName { unLocalName = "x" }
+                  ┃       │                                            KType
+                  ┃       │                                            (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                      , tcSynthed =
+                  ┃       │                                          TForall
+                  ┃       │                                            ()
+                  ┃       │                                            LocalName { unLocalName = "x" }
+                  ┃       │                                            KType
+                  ┃       │                                            (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                      }))
+                  ┃       │                              Nothing)
+                  ┃       │                           (EmptyHole
+                  ┃       │                              (Meta
+                  ┃       │                                 3
+                  ┃       │                                 (Just
+                  ┃       │                                    (TCEmb
+                  ┃       │                                       TCBoth
+                  ┃       │                                         { tcChkedAt =
+                  ┃       │                                             TForall
+                  ┃       │                                               ()
+                  ┃       │                                               LocalName { unLocalName = "x" }
+                  ┃       │                                               KType
+                  ┃       │                                               (TVar () LocalName { unLocalName = "x" })
+                  ┃       │                                         , tcSynthed = TEmptyHole ()
+                  ┃       │                                         }))
+                  ┃       │                                 Nothing))
+                  ┃       │                           (TForall
+                  ┃       │                              (Meta 4 (Just KType) Nothing)
+                  ┃       │                              LocalName { unLocalName = "x" }
+                  ┃       │                              KType
+                  ┃       │                              (TVar
+                  ┃       │                                 (Meta 5 (Just KType) Nothing) LocalName { unLocalName = "x" }))
+                  ┃       │                     , astDefType =
+                  ┃       │                         TForall
+                  ┃       │                           (Meta 6 (Just KType) Nothing)
+                  ┃       │                           LocalName { unLocalName = "x" }
+                  ┃       │                           KType
+                  ┃       │                           (TVar
+                  ┃       │                              (Meta 7 (Just KType) Nothing) LocalName { unLocalName = "x" })
+                  ┃       │                     }
+                  ┃       │               )
+                  ┃       │             ]
+                  ┃       │       }
+                  ┃       │   ]
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ , Log { unlog = [] }
+                  ┃       │ )
+              470 ┃       n <- forAll $ Gen.int $ Range.linear 1 20
+                  ┃       │ 2
+              471 ┃       a' <- iterateNM n a $ \a' -> runRandomAction l a'
+              472 ┃       annotateShow' a'
+              473 ┃       if null $ unlog $ progLog $ appProg a' -- TODO: expose a "log-is-null" helper from App?
+              474 ┃         -- It is possible for the random actions to undo everything!
+              475 ┃         then success
+              476 ┃         else do
+              477 ┃           a'' <- runEditAppMLogs (handleMutationRequest Undo) a'
+              478 ┃           annotateShow' a''
+              479 ┃           a''' <- runEditAppMLogs (handleMutationRequest Redo) a''
+              480 ┃           annotateShow' a'''
+              481 ┃           TypeCacheAlpha a' === TypeCacheAlpha a'''
+              482 ┃   where
+              483 ┃     -- TODO: dry
+              484 ┃     runEditAppMLogs ::
+              485 ┃       HasCallStack =>
+              486 ┃       EditAppM (PureLog (WithSeverity ())) ProgError a ->
+              487 ┃       App ->
+              488 ┃       PropertyT WT App
+              489 ┃     runEditAppMLogs m a = case runPureLog $ runEditAppM m a of
+              490 ┃       (r, logs) -> testNoSevereLogs logs >> case r of
+              491 ┃         (Left err, _) -> annotateShow err >> failure
+              492 ┃         (Right _, a') -> pure a'
+              493 ┃     runRandomAction l a = do
+              494 ┃       act <- forAll $ Gen.frequency $ second pure <$> [
+                  ┃       │ Avail
+                  ┃       │ Avail
+              495 ┃         (2,AddTm)
+              496 ┃         ,(1,AddTy)
+              497 ┃         ,(if null $ unlog $ progLog $ appProg a then 0 else 1,Un) -- TODO: expose a "log-is-null" helper from App?
+              498 ┃         ,(if null $ unlog $ redoLog $ appProg a then 0 else 1,Re) -- TODO: expose a "log-is-null" helper from App?
+              499 ┃         ,(5,Avail)
+              500 ┃                                     ]
+              501 ┃       case act of
+              502 ┃         AddTm -> do
+              503 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              504 ┃           n <- forAllT $ Gen.choice [Just . unName <$> n', pure Nothing]
+              505 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+              506 ┃           runEditAppMLogs (handleMutationRequest $ Edit [CreateDef m n]) a
+              507 ┃         AddTy -> do
+              508 ┃           m <- forAllT $ Gen.element $ fmap moduleName $ progModules $ appProg a
+              509 ┃           let n' = local (extendCxtByModules $ progModules $ appProg a) freshNameForCxt
+              510 ┃           n <- qualifyName m <$> forAllT n'
+              511 ┃           runEditAppMLogs (handleMutationRequest $ Edit [AddTypeDef n $ ASTTypeDef [] [] []]) a
+              512 ┃         Un -> runEditAppMLogs (handleMutationRequest Undo) a
+              513 ┃         Re -> runEditAppMLogs (handleMutationRequest Redo) a
+              514 ┃         Avail -> fromMaybe a <$> runRandomAvailableAction l a
+
+              This failure can be reproduced by running:
+              > recheck (Size 33) (Seed 4268413180681694343 17092859468972210393) undo redo
+
+          Use '--pattern "$NF ~ /undo redo/" --hedgehog-replay "Size 33 Seed 4268413180681694343 17092859468972210393"' to reproduce from the command-line.
+
+1 out of 1 tests failed (0.49s)
+#+end_src


### PR DESCRIPTION
I finally hacked together the test I have mentioned to try to flush out any undo bugs: "run a bunch of actions, then ensure can undo at the end". This did not uncover any bugs. Thus I conclude that either
- the test is inadequate: perhaps some interaction (other than taking an action listed in the test) can tick the fresh counter but not alter the log, thus when a future action is taken it has a higher ID than if the "silent" action was not taken, thus breaking replays (i.e. later undos)
- or @georgefst's hunch that the only bug is related to migrations and will only show up if we change the implementation in such a way as to change generated IDs and then try to "undo" in a saved session that was created before that change.

I am mostly opening this PR so the code is not lost. In the case that this bug does crop up again, this may be a good starting point to find it. I'm happy to do the (fairly minor) clean up to get this into a mergeable state if you think it would be a good addition to the testsuite, but I doubt I'll push for its inclusion myself.