### PR TITLE
RFC/To-think-about: are these usages of Gen.justT potentially problematic?

### DIFF
--- a/primer/gen/Primer/Gen/Core/Typed.hs
+++ b/primer/gen/Primer/Gen/Core/Typed.hs
@@ -225,7 +225,7 @@ genSyns ty = do
       (e, _) <- genSyn
       pure (Hole () e, TEmptyHole ())
     genSpine :: WT (Maybe (GenT WT (ExprG, TypeG)))
-    genSpine = fmap (fmap Gen.justT) genSpineHeadFirst
+    genSpine = fmap (fmap justT) genSpineHeadFirst
     genSpineHeadFirst :: WT (Maybe (GenT WT (Maybe (ExprG, TypeG))))
     -- todo: maybe add some lets in as post-processing? I could even add them to the locals for generation in the head
     genSpineHeadFirst = do
@@ -453,7 +453,7 @@ genChk ty = do
           else Just $ do
             (tc, td) <- Gen.element adts
             let t = mkTAppCon tc (TEmptyHole () <$ typeDefParameters td)
-            (e, brs) <- Gen.justT $ do
+            (e, brs) <- justT $ do
               (e, eTy) <- genSyns t -- NB: this could return something only consistent with t, e.g. if t=List ?, could get eT=? Nat
               vcs' <- instantiateValCons eTy
               fmap (e,) <$> case vcs' of


### PR DESCRIPTION
I'm opening this mostly so I don't forget about it. This may (or may not) be the root cause of test runs (rarely) oom-ing

This commit should either
- stay roughly the same, but with an explanatory commit message
- or morph into adding some comments as to why these 'Gen.justT' are fine

Note that these have been here since the beginning, and justT was introduced when genAPP was written 'genAPP = justT $ do ...'