### PR TITLE
chore: build HLS from haskell.nix again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -365,23 +365,6 @@
         "type": "github"
       }
     },
-    "haskell-language-server": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1682523907,
-        "narHash": "sha256-2iLUGL4l9gIFmdRZpmnnUmGe14N8eDf7Ytq8zuwk2X0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "cda1325241365896f24d1a09899b8e8e787f9c7b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "cda1325241365896f24d1a09899b8e8e787f9c7b",
-        "type": "github"
-      }
-    },
     "haskell-nix": {
       "inputs": {
         "HTTP": "HTTP",
@@ -886,7 +869,6 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "hacknix": "hacknix",
-        "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix",
         "nixpkgs": [
           "haskell-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,6 @@
     nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
     hacknix.inputs.nixpkgs.follows = "nixpkgs";
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
-
-    # HLS is broken again in haskell.nix. Also, we need to build it
-    # from git to get the fourmolu 0.12.0.0 support.
-    haskell-language-server.url = "github:haskell/haskell-language-server/cda1325241365896f24d1a09899b8e8e787f9c7b";
-    haskell-language-server.flake = false;
   };
 
   outputs = inputs@ { flake-parts, ... }:
@@ -394,24 +389,6 @@
                 inherit version;
               });
 
-              # HLS is broken in haskell.nix.
-              hls = final.haskell-nix.cabalProject'
-                {
-                  compiler-nix-name = ghcVersion;
-                  src = inputs.haskell-language-server;
-                  sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
-
-                  modules = [
-                    {
-                      packages.haskell-language-server.flags = {
-                        floskell = false;
-                        stylishHaskell = false;
-                        ormolu = false;
-                      };
-                    }
-                  ];
-                };
-
               primer = final.haskell-nix.cabalProject {
                 compiler-nix-name = ghcVersion;
                 src = ./.;
@@ -518,9 +495,7 @@
 
                   tools = {
                     ghcid = "latest";
-
-                    # Broken again, sigh.
-                    #haskell-language-server = "latest";
+                    haskell-language-server = "latest";
 
                     implicit-hie = "latest";
 
@@ -570,9 +545,6 @@
                     restore-local-db
                     connect-local-db
                     delete-all-local-sessions
-
-                    # Until working again in haskell.nix.
-                    hls.hsPkgs.haskell-language-server.components.exes.haskell-language-server
                   ]);
 
                   shellHook = ''
@@ -774,3 +746,4 @@
         };
     };
 }
+

--- a/flake.nix
+++ b/flake.nix
@@ -495,7 +495,10 @@
 
                   tools = {
                     ghcid = "latest";
-                    haskell-language-server = "latest";
+                    haskell-language-server = {
+                      version = "latest";
+                      configureArgs = "--flags=-stylishhaskell";
+                    };
 
                     implicit-hie = "latest";
 


### PR DESCRIPTION
HLS 2.0.0.0 is out, let's try again.
