### PR TITLE
ci: add a Buildkite job to push to our public Cachix cache

### DIFF
--- a/.buildkite/public-cache-push.yaml
+++ b/.buildkite/public-cache-push.yaml
@@ -1,0 +1,28 @@
+agents:
+  public: "true"
+  os: "linux"
+
+env:
+  CACHIX_CACHE_NAME: hackworthltd
+  CACHIX_CONFIG_PATH: /var/lib/cachix/hackworthltd/cachix.dhall
+
+steps:
+  - label: ":nixos: Archive Nix flake inputs to public cache"
+    command: |
+      cachix --config "$CACHIX_CONFIG_PATH" watch-exec "$CACHE_NAME" -- nix flake archive .#
+
+  - label: ":nixos: Push build to public cache"
+    command: |
+      cachix --config "$CACHIX_CONFIG_PATH" watch-exec "$CACHE_NAME" -- nix-build -A ciJobs
+
+  - wait
+
+  - label: ":nixos: :linux: Cache Nix shell to public cache"
+    command: |
+      cachix --config "$CACHIX_CONFIG_PATH" watch-exec "$CACHE_NAME" -- nix develop --print-build-logs --profile /tmp/primer --command echo "done"
+
+  - label: ":nixos: :macos: Cache Nix shell to public cache"
+    command: |
+      cachix --config "$CACHIX_CONFIG_PATH" watch-exec "$CACHE_NAME" -- nix develop --print-build-logs --profile /tmp/primer --command echo "done"
+    agents:
+      os: "darwin"


### PR DESCRIPTION
Note: this is configured (in Buildkite) only to run on pushes to
`main`, so PR build artifacts will not be present in our public Cachix
cache, on purpose.

Closes #942 