### PR TITLE
chore: add more files to Haskell source filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,14 +142,23 @@
                 in ! (
                   baseName == ".buildkite" ||
                   baseName == ".github" ||
+                  baseName == "CODE_OF_CONDUCT.md" ||
+                  baseName == "CONTRIBUTING.md" ||
+                  baseName == "DCO.md" ||
+                  baseName == "Makefile" ||
+                  baseName == "README.md" ||
+                  baseName == "SECURITY.md" ||
                   pkgs.lib.hasPrefix "cabal.project.local" baseName ||
+                  baseName == "ci-benchmarks.nix" ||
+                  baseName == "ci.nix" ||
+                  baseName == "default.nix" ||
+                  baseName == "docs" ||
+                  baseName == "flake-compat.nix" ||
                   baseName == "flake.lock" ||
                   baseName == "flake.nix" ||
-                  baseName == "README.md" ||
-                  baseName == "CONTRIBUTING.md" ||
-                  baseName == "docs" ||
                   baseName == "nix" ||
                   baseName == "nixos-tests" ||
+                  baseName == "shell.nix" ||
                   baseName == "sqitch"
                 );
             in


### PR DESCRIPTION
Closes https://github.com/hackworthltd/primer/issues/1013

These files don't contribute to a Cabal build or Haskell-related
check, so we don't want changes to them to trigger extraneous Nix
builds.

Signed-off-by: Drew Hess <src@drewhess.com>
