### PR TITLE
ci: drop Criterion HTML results

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -350,7 +350,6 @@
           # controlled environment, and this gives us that
           # flexibility.
           benchmarks = {
-            inherit (pkgs) primer-benchmark-results-html;
             inherit (pkgs) primer-benchmark-results-json;
             inherit (pkgs) primer-criterion-results-github-action-benchmark;
           }
@@ -749,7 +748,6 @@
               # include these in the flake's `packages` output,
               # because we don't want them to be built/run when CI
               # evaluates the `hydraJobs` or `ciJobs` outputs.
-              inherit (benchmarks) primer-benchmark-results-html;
               inherit (benchmarks) primer-benchmark-results-json;
               inherit (benchmarks) primer-criterion-results-github-action-benchmark;
               inherit (benchmarks) primer-benchmark-results-github-action-benchmark;

--- a/nix/pkgs/benchmarks/default.nix
+++ b/nix/pkgs/benchmarks/default.nix
@@ -5,18 +5,6 @@
 let
   lastEnvChangeFile = pkgs.writeText "lastEnvChange" lastEnvChange;
 
-  # Generate Primer benchmark results as HTML.
-  primer-benchmark-results-html = (pkgs.runCommand "primer-benchmark-results-html" { }
-    ''
-      ${pkgs.coreutils}/bin/mkdir -p $out
-      cp ${lastEnvChangeFile} $out/lastEnvChange
-      ${primer-benchmark}/bin/primer-benchmark --output $out/results.html --regress cpuTime:iters --regress allocated:iters --regress numGcs:iters +RTS -T
-    ''
-  ).overrideAttrs
-    (drv: {
-      requiredSystemFeatures = (drv.requiredSystemFeatures or [ ]) ++ [ "benchmark" ];
-    });
-
   # Generate Primer benchmark results as JSON.
   primer-benchmark-results-json = (pkgs.runCommand "primer-benchmark-results-json" { }
     ''
@@ -69,7 +57,8 @@ let
     '';
 in
 {
-  inherit primer-benchmark-results-html
-    primer-benchmark-results-json primer-criterion-results-github-action-benchmark
+  inherit
+    primer-benchmark-results-json
+    primer-criterion-results-github-action-benchmark
     primer-benchmark-results-github-action-benchmark;
 }


### PR DESCRIPTION
We never use these, and they require an otherwise completely redundant
benchmark run, which takes a fair amount of time.

Note that I tried to use `criterion-report` to generate the HTML
results from the Criterion JSON run output, but it doesn't work for
some reason:

```
./result/bin/criterion-report report /nix/store/6rd2xgrrv1lrziad8jlla68r5rd9c2sd-primer-benchmark-results-json/results.json results.html --template json
Error reading file: /nix/store/6rd2xgrrv1lrziad8jlla68r5rd9c2sd-primer-benchmark-results-json/results.json
  "Error in $: cannot unpack array of length 10 into a tuple of length 3"
```

Signed-off-by: Drew Hess <src@drewhess.com>
