### PR TITLE
fix: Downgrade Hedgehog to version 1.1

### DIFF
--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -194,7 +194,7 @@ test-suite service-test
     , aeson-pretty
     , base
     , bytestring
-    , hedgehog                                          ^>=1.2
+    , hedgehog                                          ^>=1.1
     , hedgehog-quickcheck                               ^>=0.1.1
     , hspec                                             ^>=2.10
     , openapi3
@@ -209,7 +209,7 @@ test-suite service-test
     , tasty                                             ^>=1.4.1
     , tasty-discover                                    ^>=5.0
     , tasty-golden                                      ^>=2.3.5
-    , tasty-hedgehog                                    ^>=1.4
+    , tasty-hedgehog                                    ^>=1.3
     , tasty-hspec                                       ^>=1.2.0.1
     , tasty-hunit                                       ^>=0.10.0
     , text

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -163,13 +163,13 @@ library primer-hedgehog
   build-depends:
     , base
     , containers
-    , hedgehog        ^>=1.2
+    , hedgehog        ^>=1.1
     , mmorph          ^>=1.2.0
     , mtl
     , primer
     , primer-testlib
     , tasty-discover  ^>=5.0
-    , tasty-hedgehog  ^>=1.4
+    , tasty-hedgehog  ^>=1.3
 
 library primer-testlib
   visibility:         public


### PR DESCRIPTION
Fixes an issue where Hedgehog sometimes fails to replay correctly in the presence of discards, particularly in our `tasty_available_actions_accepted` test: https://github.com/hedgehogqa/haskell-hedgehog/issues/487.