### PR TITLE
fix: generate well-typed terms with saturated constructors

### DIFF
--- a/primer/gen/Primer/Gen/Core/Typed.hs
+++ b/primer/gen/Primer/Gen/Core/Typed.hs
@@ -385,19 +385,7 @@ genChk ty = do
             cons -> Just $ do
               let cons' =
                     M.toList cons <&> \(c, (params, fldsTys0)) -> do
-                      indicesMap <- for params $ \(p, k) -> (p,) <$> genWTType k
-                      -- NB: it is vital to use simultaneous substitution here.
-                      -- Consider the case where we have a local type variable @a@
-                      -- in scope, say because we have already generated a
-                      -- @Λa. ...@, and we are considering the case of the @MkPair@
-                      -- constructor for the type @data Pair a b = MkPair a b@.
-                      -- The two "a"s (locally Λ-bound and from the typedef) refer
-                      -- to completely different things. We may well generate the
-                      -- substitution [a :-> Bool, b :-> a]. We must then say that
-                      -- the fields of the @MkPair@ constructor are @Bool@ and (the
-                      -- locally-bound) @a@. We must do a simultaneous substitution
-                      -- to avoid substituting @b@ into @a@ and then further into
-                      -- @Bool@.
+                      let indicesMap = (,TEmptyHole ()) . fst <$> params
                       fldsTys <- traverse (substTySimul $ M.fromList indicesMap) fldsTys0
                       flds <- traverse (Gen.small . genChk) fldsTys
                       pure $ Con () c flds


### PR DESCRIPTION
The generators and the typechecker disagreed about typing rules of consttructors which themselves are checked against a hole type. For example, in `? ∋ MkPair s t`, the typechecker would check that `? ∋ s` and `? ∋ t`, whereas the generator would pick two arbitrary types (of kind `KType`) `A` and `B` and generate arguments `s` and `t` such that `A ∋ s` and `B ∋ t`. This disagreement results in (rare) test failures of `tasty_synth_well_typed_extcxt` etc.

An (slightly simplified) example of a failure is:
- `tasty_synth_well_typed_extcxt` calls `genSyn`
- the generator attempts to generate something of type `?`
- it decides to use a constructor `MkPair`, and since we are working at a hole type, it wants to generate two arguments of arbitrary types.
- it decides to generate the first argument at type `Int` and generates an empty hole for the term
- it decides to generate the second argument at type `Bool -> Char`
- we generate a lambda to start this second argument, `λx . ...`, and move on to generating the body aiming for type `Char`, in an extended context where `x : Bool` is in scope.
- this body is generated to be a `case` on `x`, and thus has two branches, one for `True` and one for `False`.
- the bodies of the branches (i.e. their RHSs) are generated as holes
- overall, we have something like `MkPair ? (λx. case x of True -> ? ; False -> ?)`
- However, the typechecker will reject `? ∋ MkPair ? (λx. case x of True -> ? ; False -> ?)`, since it will spawn the subproblem `x : ? ⊢ case x of True -> ? ; False -> ?` which is ill-typed, since pattern matches on terms of hole type must have exactly zero branches. (Note that the typechecker believes `x : ?`, but the generator thought `x : Bool`.)

This disagreement arose when constructors were changed to not store their indices. Prior to this change we would have generated something like
`MkPair @Int @(Bool -> Char) ? (λx. case x of True -> ? ; False -> ?)`, which would be well-typed.