### PR TITLE
fix: letrec metadata

### DIFF
--- a/primer/src/Primer/Action.hs
+++ b/primer/src/Primer/Action.hs
@@ -10,6 +10,8 @@ module Primer.Action (
   applyActionsToTypeSig,
   applyActionsToExpr,
   moveExpr,
+  enterType,
+  moveType,
   uniquifyDefName,
   toProgActionInput,
   toProgActionNoInput,

--- a/primer/src/Primer/Action/Available.hs
+++ b/primer/src/Primer/Action/Available.hs
@@ -376,8 +376,8 @@ options typeDefs defs cxt level def mNodeSel = \case
   MakeForall ->
     freeVar <$> genNames (Right Nothing)
   RenameForall -> do
-    TypeNode t <- findNode
-    freeVar <$> genNames (Right $ t ^. _typeMetaLens % _type)
+    TypeNode (TForall _ _ k _) <- findNode
+    freeVar <$> genNames (Right $ Just k)
   RenameDef ->
     pure $ freeVar []
   where

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -680,7 +680,9 @@ check t = \case
     a' <- local ctx' $ check (forgetTypeMetadata tA') a
     -- Extend the context with the binding, and synthesise the body
     b' <- local ctx' $ check t b
-    pure $ Letrec (annotate (TCChkedAt t) i) x a' tA' b'
+    -- NB here: if b were synthesisable, we bubble that information up to the
+    -- let, saying @typeOf b'@ rather than @TCChkedAt t@ (consistently with Let)
+    pure $ Letrec (annotate (typeOf b') i) x a' tA' b'
   Case i e brs -> do
     (eT, e') <- synth e
     let caseMeta = annotate (TCChkedAt t) i

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -88,6 +88,7 @@ import Primer.Core.DSL (
   lAM,
   lam,
   let_,
+  letrec,
   lvar,
   tEmptyHole,
   tapp,
@@ -564,3 +565,12 @@ unit_rename_let_names =
     "p"
     (letType "x" (tcon tBool `tfun` tcon tBool) $ emptyHole)
 -}
+
+unit_rename_letrec_names :: Assertion
+unit_rename_letrec_names =
+  offeredNamesTest
+    (letrec "x" emptyHole (tcon tBool) emptyHole)
+    []
+    RenameLet
+    "p"
+    (letrec "p" emptyHole (tcon tBool) emptyHole)

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -545,3 +545,22 @@ unit_rename_let_names =
     RenameLet
     "p"
     (let_ "p" (emptyHole `ann` tcon tBool) emptyHole)
+
+{-
+-- TODO: reinstate once the TC handles let type!
+-- See https://github.com/hackworthltd/primer/issues/5
+--unit_rename_lettype_names :: Assertion
+--unit_rename_lettype_names = do
+  offeredNamesTest
+    (letType "x" (tcon tBool) emptyHole)
+    []
+    RenameLet
+    "p"
+    (letType "p" (tcon tBool) emptyHole)
+  offeredNamesTest
+    (letType "x" (tcon tBool `tfun` tcon tBool) $ emptyHole)
+    []
+    RenameLet
+    "p"
+    (letType "x" (tcon tBool `tfun` tcon tBool) $ emptyHole)
+-}

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -135,8 +135,8 @@ import System.FilePath ((</>))
 import Tasty (Property, withDiscards, withTests)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden (goldenVsString)
-import Test.Tasty.HUnit (Assertion, assertBool, assertFailure, (@?=))
-import Tests.Action.Prog (defaultEmptyProg, expectSuccess, findGlobalByName, progActionTest)
+import Test.Tasty.HUnit (Assertion, assertFailure, (@?=))
+import Tests.Action.Prog (defaultEmptyProg, findGlobalByName, mkEmptyTestApp, runAppTestM)
 import Tests.Typecheck (
   TypeCacheAlpha (TypeCacheAlpha),
   runTypecheckTestM,
@@ -427,6 +427,30 @@ offeredActionTest ::
   S Expr ->
   Assertion
 offeredActionTest sh l inputExpr position action expectedOutput = do
+  offeredActionTest' sh l inputExpr position action >>= \case
+    Left err -> assertFailure $ show err
+    Right result -> clearMeta result @?= clearMeta (create' expectedOutput)
+
+-- Helper for offeredActionTest'
+data OAT
+  = ActionNotOffered Available.Action [Available.Action]
+  | OptionNotOffered Option [Option]
+  | ErrorRunningAction ProgError
+  deriving stock (Show)
+
+-- Looks at actions offered for the given position and distinguishes the following cases
+-- - the requested action is not offered
+-- - the requested action is offered, but the requested option is not offered
+-- - the action (and possible option) were offered, but running them resulted in an error
+-- - the action (and possible option) were offered, and running succeeds
+offeredActionTest' ::
+  SmartHoles ->
+  Level ->
+  S Expr ->
+  MovementList ->
+  Either NoInputAction (InputAction, Option) ->
+  IO (Either OAT Expr)
+offeredActionTest' sh l inputExpr position action = do
   let progRaw = create' $ do
         ms <- sequence [builtinModule]
         prog0 <- defaultEmptyProg
@@ -466,36 +490,32 @@ offeredActionTest sh l inputExpr position action expectedOutput = do
   let defs = foldMap' moduleDefsQualified modules
   let offered = Available.forBody cxt.typeDefs l Editable expr id
   let options = Available.options cxt.typeDefs defs cxt l exprDef (Just (BodyNode, id))
-  let assertElem msg x xs =
-        assertBool
-          ( msg
-              <> show x
-              <> " is not an element of "
-              <> show xs
-          )
-          (x `elem` xs)
-  let assertOffered a = assertElem "Requested action not offered: " a offered
   action' <- case action of
-    Left a -> do
-      assertOffered $ Available.NoInput a
-      pure $ toProgActionNoInput (foldMap' moduleDefsQualified $ progModules prog) exprDef exprDefName (Just (BodyNode, id)) a
+    Left a ->
+      pure $
+        if Available.NoInput a `elem` offered
+          then Right $ toProgActionNoInput (foldMap' moduleDefsQualified $ progModules prog) exprDef exprDefName (Just (BodyNode, id)) a
+          else Left $ ActionNotOffered (Available.NoInput a) offered
     Right (a, o) -> do
-      assertOffered $ Available.Input a
-      case options a of
-        Nothing -> assertFailure "Available.options returned Nothing"
-        Just os -> do
-          assertElem "Requested option not offered: " o os.opts
-          pure $ toProgActionInput exprDef exprDefName (Just (BodyNode, id)) o a
-  action'' <- case action' of
+      if Available.Input a `elem` offered
+        then case options a of
+          Nothing -> assertFailure "Available.options returned Nothing"
+          Just os ->
+            pure $
+              if o `elem` os.opts
+                then Right $ toProgActionInput exprDef exprDefName (Just (BodyNode, id)) o a
+                else Left $ OptionNotOffered o os.opts
+        else pure $ Left $ ActionNotOffered (Available.Input a) offered
+  action'' <- for action' $ \case
     Left err -> assertFailure $ show err
     Right a -> pure a
-  let expected = create' expectedOutput
-  progActionTest (pure prog) action'' $ expectSuccess $ \_ prog' ->
-    let result = pure . astDefExpr <=< defAST <=< findGlobalByName prog' $ exprDefName
-     in -- Compare result to input, ignoring any difference in metadata
-        -- NB: we don't compare up-to-alpha, as names should be determined by the
-        -- actions on-the-nose
-        fmap clearMeta result @?= Just (clearMeta expected)
+  x <- for action'' $ \action''' -> do
+    let result = fmap astDefExpr . defAST <=< flip findGlobalByName exprDefName
+    let assertJust = maybe (assertFailure "Lost 'main' after action") pure
+    (res, _) <- runAppTestM (nextProgID prog) (mkEmptyTestApp prog) (handleEditRequest action''')
+    rr <- traverse (assertJust . result) res
+    pure $ first ErrorRunningAction rr
+  pure $ join x
 
 -- Correct names offered when running actions
 -- NB: Bools are offered names "p", "q"; functions get "f","g"; nats get "i","j","n","m"

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, RenameLet),
+  InputAction (MakeCon, MakeLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -482,6 +482,15 @@ offeredNamesTest initial moves act name =
     initial
     moves
     (Right (act, Option name Nothing))
+
+unit_make_lam_names :: Assertion
+unit_make_lam_names =
+  offeredNamesTest
+    (emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+    [Child1]
+    MakeLam
+    "i"
+    (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
 
 -- nb: renaming let cares about the type of the bound var, not of the let
 unit_rename_let_names :: Assertion

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLAM, MakeLam, RenameLam, RenameLet),
+  InputAction (MakeCon, MakeLAM, MakeLam, RenameLAM, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -516,6 +516,21 @@ unit_make_LAM_names = do
     (emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
     [Child1]
     MakeLAM
+    "f"
+    (lAM "f" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+
+unit_rename_LAM_names :: Assertion
+unit_rename_LAM_names = do
+  offeredNamesTest
+    (lAM "x" emptyHole `ann` tforall "a" KType (tcon tBool))
+    [Child1]
+    RenameLAM
+    "α"
+    (lAM "α" emptyHole `ann` tforall "a" KType (tcon tBool))
+  offeredNamesTest
+    (lAM "x" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+    [Child1]
+    RenameLAM
     "f"
     (lAM "f" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
 

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -39,7 +39,7 @@ import Primer.Action (
  )
 import Primer.Action.Available (
   InputAction (MakeCon, MakeLAM, MakeLam, RenameForall, RenameLAM, RenameLam, RenameLet),
-  NoInputAction (Raise),
+  NoInputAction (MakeCase, Raise),
   Option (Option),
  )
 import Primer.Action.Available qualified as Available
@@ -82,6 +82,7 @@ import Primer.Core.DSL (
   S,
   ann,
   app,
+  case_,
   con,
   create',
   emptyHole,
@@ -399,6 +400,35 @@ unit_sat_con_2 =
     (Right (MakeCon, Option "Cons" $ Just $ unName <$> unModuleName builtinModuleName))
     (hole (con cCons [emptyHole, emptyHole] `ann` tEmptyHole) `ann` ((tcon tList `tapp` tcon tNat) `tfun` (tcon tList `tapp` tcon tNat)))
 
+-- The various @let@ constructs inherit the directionality of their body.
+-- This is a regression test, as in the past this was the case for @let@ but not @letrec@.
+-- Note that @MakeCase@ is only offered for synthesisable terms.
+unit_case_let :: Assertion
+unit_case_let = do
+  let testOffered :: HasCallStack => S Expr -> Assertion
+      testOffered e =
+        offeredActionTest
+          SmartHoles
+          Intermediate
+          e
+          (InExpr [])
+          (Left MakeCase)
+          (case_ e [])
+  testOffered (let_ "x" emptyHole emptyHole)
+  -- testOffered (letType "a" tEmptyHole emptyHole) -- TODO: add this test when the typechecker supports letType
+  testOffered (letrec "x" emptyHole tEmptyHole emptyHole)
+  let testNotOffered :: HasCallStack => S Expr -> Assertion
+      testNotOffered e =
+        offeredActionTestNotOffered
+          SmartHoles
+          Intermediate
+          e
+          (InExpr [])
+          MakeCase
+  testNotOffered (let_ "x" emptyHole $ lam "y" $ lvar "y")
+  -- testNotOffered (letType "a" tEmptyHole $ lam "y" $ lvar "y") -- TODO: add this test when the typechecker supports letType
+  testNotOffered (letrec "x" emptyHole tEmptyHole $ lam "y" $ lvar "y")
+
 data MovementList
   = InExpr [Movement]
   | InType [Movement] [Movement]
@@ -430,6 +460,20 @@ offeredActionTest sh l inputExpr position action expectedOutput = do
   offeredActionTest' sh l inputExpr position action >>= \case
     Left err -> assertFailure $ show err
     Right result -> clearMeta result @?= clearMeta (create' expectedOutput)
+
+offeredActionTestNotOffered ::
+  HasCallStack =>
+  SmartHoles ->
+  Level ->
+  S Expr ->
+  MovementList ->
+  NoInputAction ->
+  Assertion
+offeredActionTestNotOffered sh l inputExpr position action = do
+  offeredActionTest' sh l inputExpr position (Left action) >>= \case
+    Left ActionNotOffered{} -> pure ()
+    Left err -> assertFailure $ show err
+    Right _ -> assertFailure "action was unexpectedly offered"
 
 -- Helper for offeredActionTest'
 data OAT

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -486,6 +486,8 @@ offeredNamesTest initial moves act name =
     moves
     (Right (act, Option name Nothing))
 
+-- Note that lambdas are the only form which we have interesting name info when
+-- we initially create them.
 unit_make_lam_names :: Assertion
 unit_make_lam_names =
   offeredNamesTest

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -38,7 +38,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLAM, MakeLam, RenameLAM, RenameLam, RenameLet),
+  InputAction (MakeCon, MakeLAM, MakeLam, RenameForall, RenameLAM, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -597,3 +597,18 @@ unit_rename_letrec_names =
     (letrec "p" emptyHole (tcon tBool) emptyHole)
 
 -- There is no unit_rename_pattern_names as can only move to a pattern by ID, which is awkward here
+
+unit_rename_forall_names :: Assertion
+unit_rename_forall_names = do
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" KType (tcon tBool))
+    ([] `InType` [])
+    RenameForall
+    "α"
+    (emptyHole `ann` tforall "α" KType (tcon tBool))
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+    ([] `InType` [])
+    RenameForall
+    "f"
+    (emptyHole `ann` tforall "f" (KFun KType KType) (tcon tBool))

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -574,3 +574,5 @@ unit_rename_letrec_names =
     RenameLet
     "p"
     (letrec "p" emptyHole (tcon tBool) emptyHole)
+
+-- There is no unit_rename_pattern_names as can only move to a pattern by ID, which is awkward here

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLam, RenameLet),
+  InputAction (MakeCon, MakeLam, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -489,6 +489,15 @@ unit_make_lam_names =
     (emptyHole `ann` (tcon tNat `tfun` tcon tBool))
     [Child1]
     MakeLam
+    "i"
+    (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+
+unit_rename_lam_names :: Assertion
+unit_rename_lam_names =
+  offeredNamesTest
+    (lam "x" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+    [Child1]
+    RenameLam
     "i"
     (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
 

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -612,3 +612,22 @@ unit_rename_forall_names = do
     RenameForall
     "f"
     (emptyHole `ann` tforall "f" (KFun KType KType) (tcon tBool))
+
+{-
+-- TODO: reinstate once the TC handles let type!
+-- See https://github.com/hackworthltd/primer/issues/5
+--unit_rename_tlet_names :: Assertion
+--unit_rename_tlet_names = do
+  offeredNamesTest
+    (emptyHole `ann` tlet "a" (tcon tNat) tEmptyHole)
+    ([] `InType` [])
+    RenameLet
+    "α"
+    (emptyHole `ann` tlet "α" (tcon tNat) tEmptyHole)
+  offeredNamesTest
+    (emptyHole `ann` tlet "a" (tcon tList) tEmptyHole)
+    ([] `InType` [])
+    RenameLet
+    "f"
+    (emptyHole `ann` tlet "f" (tcon tList) tEmptyHole)
+-}

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -36,7 +36,7 @@ import Primer.Action (
   toProgActionNoInput,
  )
 import Primer.Action.Available (
-  InputAction (MakeCon, MakeLam, RenameLam, RenameLet),
+  InputAction (MakeCon, MakeLAM, MakeLam, RenameLam, RenameLet),
   NoInputAction (Raise),
   Option (Option),
  )
@@ -68,6 +68,7 @@ import Primer.Core (
   GlobalName (baseName, qualifiedModule),
   HasID (_id),
   ID,
+  Kind (KFun, KType),
   ModuleName (ModuleName, unModuleName),
   getID,
   mkSimpleModuleName,
@@ -84,12 +85,14 @@ import Primer.Core.DSL (
   emptyHole,
   gvar,
   hole,
+  lAM,
   lam,
   let_,
   lvar,
   tEmptyHole,
   tapp,
   tcon,
+  tforall,
   tfun,
  )
 import Primer.Core.Utils (
@@ -500,6 +503,21 @@ unit_rename_lam_names =
     RenameLam
     "i"
     (lam "i" emptyHole `ann` (tcon tNat `tfun` tcon tBool))
+
+unit_make_LAM_names :: Assertion
+unit_make_LAM_names = do
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" KType (tcon tBool))
+    [Child1]
+    MakeLAM
+    "α"
+    (lAM "α" emptyHole `ann` tforall "a" KType (tcon tBool))
+  offeredNamesTest
+    (emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
+    [Child1]
+    MakeLAM
+    "f"
+    (lAM "f" emptyHole `ann` tforall "a" (KFun KType KType) (tcon tBool))
 
 -- nb: renaming let cares about the type of the bound var, not of the let
 unit_rename_let_names :: Assertion

--- a/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
@@ -41,15 +41,11 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "z"
+                                { option = "p"
                                 , context = Nothing
                                 }
                             , Option
-                                { option = "x1"
-                                , context = Nothing
-                                }
-                            , Option
-                                { option = "y1"
+                                { option = "q"
                                 , context = Nothing
                                 }
                             ]

--- a/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
@@ -63,15 +63,11 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "z"
+                                { option = "p"
                                 , context = Nothing
                                 }
                             , Option
-                                { option = "x1"
-                                , context = Nothing
-                                }
-                            , Option
-                                { option = "y1"
+                                { option = "q"
                                 , context = Nothing
                                 }
                             ]

--- a/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
@@ -42,15 +42,11 @@ Output
                     ( Options
                         { opts =
                             [ Option
-                                { option = "z"
+                                { option = "p"
                                 , context = Nothing
                                 }
                             , Option
-                                { option = "x1"
-                                , context = Nothing
-                                }
-                            , Option
-                                { option = "y1"
+                                { option = "q"
                                 , context = Nothing
                                 }
                             ]


### PR DESCRIPTION
Consider (some sort of) a `let` in a checkable position, whose body is
synthesisable, e.g. `(λx. let y = ... in xor x y) : Bool -> Bool`. Prior to
this commit, our treatment of metadata between `let` and `letrec` was
inconsistent:
- they both treat the body `xor x y` the same: checking it against
  `Bool`, finding it is synthesises `Bool` and then giving it a `TCEmb`
  metadata.
- a `let` node would then get the same metadata
- a `letrec` node would only get `TCChkedAt` metadata

This is visible to a consumer of our API: what actions we offer differ,
see the added test.