### PR TITLE
feat!: search the database by session name

### DIFF
--- a/primer-rel8/primer-rel8.cabal
+++ b/primer-rel8/primer-rel8.cabal
@@ -92,6 +92,7 @@ test-suite primer-rel8-test
   hs-source-dirs:     test
   other-modules:
     Tests.DeleteSession
+    Tests.FindSessions
     Tests.InsertSession
     Tests.ListSessions
     Tests.QuerySessionId

--- a/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
+++ b/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
@@ -92,8 +92,8 @@ import Rel8 (
   desc,
   each,
   filter,
+  ilike,
   insert,
-  like,
   limit,
   lit,
   litExpr,
@@ -262,8 +262,6 @@ instance MonadRel8Db m l => MonadDb (Rel8DbT m) where
           paginatedSessionMeta ol (sessionMeta <$> allSessions)
     pure $ Page{total = n, pageContents = safeMkSession <$> ss}
 
-  -- NB: this method is intended to be case-sensitive, which
-  -- PostgreSQL handles by default.
   findSessions substr ol = do
     -- This is very inefficient, as we run the same query later to
     -- paginated it, but fixing it will take some refactoring work,
@@ -434,8 +432,8 @@ sessionById sid =
 -- Select all sessions whose name contains the given substring.
 sessionByNameSubstr :: Text -> Query (Schema.SessionRow Expr)
 sessionByNameSubstr substr =
-  -- N.B. the arguments to 'like' are reversed from what you might expect.
-  filter (like (litExpr ("%" <> escape substr <> "%")) . Schema.name) =<< allSessions
+  -- N.B. the arguments to 'ilike' are reversed from what you might expect.
+  filter (ilike (litExpr ("%" <> escape substr <> "%")) . Schema.name) =<< allSessions
   where
     -- Escape @%@ and @_@ characters in the given string, as these are
     -- wildcards in SQL. Note that the backslash is the default escape

--- a/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
+++ b/primer-rel8/src/Primer/Database/Rel8/Rel8Db.hs
@@ -37,6 +37,7 @@ import Control.Monad.Trans (MonadTrans)
 import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Zip (MonadZip)
 import Data.Functor.Contravariant ((>$<))
+import Data.Text qualified as T
 import Data.Time.Clock (UTCTime)
 import Data.UUID (UUID)
 import Hasql.Connection (
@@ -92,6 +93,7 @@ import Rel8 (
   each,
   filter,
   insert,
+  like,
   limit,
   lit,
   litExpr,
@@ -138,6 +140,25 @@ runRel8DbT m = runReaderT (unRel8DbT m)
 --
 -- Note that 'MonadLog' has a functional dependency from 'm' to 'l'.
 type MonadRel8Db m l = (ConvertLogMessage Rel8DbLogMessage l, MonadCatch m, MonadThrow m, MonadIO m, MonadLog (WithSeverity l) m)
+
+-- A helper function for creating a 'Session' from a database query.
+--
+-- Note that we have 2 choices here if the session name that was
+-- fetched from the database isn't a valid 'SessionName': either we
+-- can return a failure, or we can convert it to a valid
+-- 'SessionName'. This situation can only ever happen if we've made a
+-- mistake (e.g., we've changed the rules on what's a valid
+-- 'SessionName' and didn't run a migration), or if someone has edited
+-- the database directly, without going through the API. In either
+-- case, it would be bad if a student can't load their session just
+-- because a session name was invalid, so we opt for "convert it to a
+-- valid 'SessionName'".
+--
+-- It might be helpful if this function returned an indication of
+-- whether the original name was safe, but for now, we convert
+-- silently.
+safeMkSession :: (SessionId, Text, UTCTime) -> Session
+safeMkSession (s, n, t) = Session s (safeMkSessionName n) (LastModified t)
 
 -- | A 'MonadDb' instance for 'Rel8DbT'.
 --
@@ -235,31 +256,40 @@ instance MonadRel8Db m l => MonadDb (Rel8DbT m) where
       -- 'numSessions' above) should never return the empty list:
       -- https://hackage.haskell.org/package/rel8-1.3.1.0/docs/Rel8.html#v:countRows
       _ -> throwM ListSessionsRel8Error
-    ss :: [(UUID, Text, UTCTime)] <- runStatement ListSessionsError $ select $ paginatedSessionMeta ol
+    ss :: [(UUID, Text, UTCTime)] <-
+      runStatement ListSessionsError $
+        select $
+          paginatedSessionMeta ol (sessionMeta <$> allSessions)
     pure $ Page{total = n, pageContents = safeMkSession <$> ss}
-    where
-      -- See comment in 'querySessionId' re: dealing with invalid
-      -- session names loaded from the database.
-      safeMkSession (s, n, t) = Session s (safeMkSessionName n) (LastModified t)
+
+  -- NB: this method is intended to be case-sensitive, which
+  -- PostgreSQL handles by default.
+  findSessions substr ol = do
+    -- This is very inefficient, as we run the same query later to
+    -- paginated it, but fixing it will take some refactoring work,
+    -- and this is not currently a priority.
+    --
+    -- https://github.com/hackworthltd/primer/issues/1037
+    n' <- runStatement FindSessionsError $ select $ countRows $ sessionByNameSubstr substr
+    n <- case n' of
+      -- See:
+      -- https://github.com/hackworthltd/primer/issues/238
+      [n''] -> pure $ fromIntegral n''
+      -- This case should never occur, see note in 'listSessions'.
+      _ -> throwM FindSessionsRel8Error
+    ss :: [(UUID, Text, UTCTime)] <-
+      runStatement FindSessionsError $
+        select $
+          paginatedSessionMeta ol (sessionMeta <$> sessionByNameSubstr substr)
+    pure $ Page{total = n, pageContents = safeMkSession <$> ss}
 
   querySessionId sid = do
     result <- runStatement (LoadSessionError sid) $ select $ sessionById sid
     case result of
       [] -> pure $ Left $ SessionIdNotFound sid
       (s : _) -> do
-        -- Note that we have 2 choices here if the session name
-        -- returned by the database is not a valid 'SessionName':
-        -- either we can return a failure, or we can convert it to a
-        -- valid 'SessionName', possibly including a helpful message.
-        -- This situation can only ever happen if we've made a mistake
-        -- (e.g., we've changed the rules on what's a valid
-        -- 'SessionName' and didn't run a migration), or if someone
-        -- has edited the database directly, without going through the
-        -- API. In either case, it would be bad if a student can't
-        -- load their session just because a session name was invalid,
-        -- so we opt for the "convert it to a valid 'SessionName'"
-        -- strategy and log an error. For now, we elide the helpful
-        -- message.
+        -- See comment on 'safeMkSessionName' regarding how we use
+        -- 'safeMkSessionName' here.
         let dbSessionName = Schema.name s
             sessionName = safeMkSessionName dbSessionName
             lastModified = LastModified $ Schema.lastmodified s
@@ -344,6 +374,12 @@ data Rel8DbException
     -- operation. This should never occur unless there's a bug in
     -- 'Rel8'.
     ListSessionsRel8Error
+  | -- | An error occurred during a 'FindSessions' operation.
+    FindSessionsError QueryError
+  | -- | 'Rel8' returned an unexpected result during a 'FindSessions'
+    -- operation. This should never occur unless there's a bug in
+    -- 'Rel8'.
+    FindSessionsRel8Error
   deriving stock (Eq, Show, Generic)
 
 instance Exception Rel8DbException
@@ -395,6 +431,20 @@ sessionById :: UUID -> Query (Schema.SessionRow Expr)
 sessionById sid =
   allSessions >>= filter \p -> Schema.uuid p ==. litExpr sid
 
+-- Select all sessions whose name contains the given substring.
+sessionByNameSubstr :: Text -> Query (Schema.SessionRow Expr)
+sessionByNameSubstr substr =
+  -- N.B. the arguments to 'like' are reversed from what you might expect.
+  filter (like (litExpr ("%" <> escape substr <> "%")) . Schema.name) =<< allSessions
+  where
+    -- Escape @%@ and @_@ characters in the given string, as these are
+    -- wildcards in SQL. Note that the backslash is the default escape
+    -- character, and therefore must also be escaped. Make sure we do
+    -- backslash first, as otherwise we'll double-escape the other two
+    -- replacements!
+    escape :: Text -> Text
+    escape = T.replace "%" "\\%" . T.replace "_" "\\_" . T.replace "\\" "\\\\"
+
 -- Return the number of sessions in the database.
 numSessions :: Query (Expr Int64)
 numSessions = countRows allSessions
@@ -409,16 +459,14 @@ paginate :: OffsetLimit -> Query a -> Query a
 paginate (OL o (Just l)) = limit (fromIntegral l) . offset (fromIntegral o)
 paginate (OL o _) = offset (fromIntegral o)
 
--- Return the metadata (represented as a tuple) for all sessions in
--- the database.
-sessionMeta :: Query (Expr UUID, Expr Text, Expr UTCTime)
-sessionMeta = do
-  s <- allSessions
-  pure (Schema.uuid s, Schema.name s, Schema.lastmodified s)
+type SessionMeta = (Expr UUID, Expr Text, Expr UTCTime)
+
+sessionMeta :: Schema.SessionRow Expr -> SessionMeta
+sessionMeta s = (Schema.uuid s, Schema.name s, Schema.lastmodified s)
 
 -- Paginated session metadata, sorted by session name (primary) and
 -- last-modified (secondary, newest to oldest).
-paginatedSessionMeta :: OffsetLimit -> Query (Expr UUID, Expr Text, Expr UTCTime)
-paginatedSessionMeta ol =
+paginatedSessionMeta :: OffsetLimit -> Query SessionMeta -> Query SessionMeta
+paginatedSessionMeta ol sm =
   paginate ol $
-    orderBy (mconcat [view _2 >$< asc, view _3 >$< desc]) sessionMeta
+    orderBy (mconcat [view _2 >$< asc, view _3 >$< desc]) sm

--- a/primer-rel8/test/Tests/FindSessions.hs
+++ b/primer-rel8/test/Tests/FindSessions.hs
@@ -99,11 +99,16 @@ test_findSessions_case_insensitive = testCaseSteps "findSessions is case-insensi
     step "Insert all sessions"
     rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 6]
     forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
-    let expectedRows = map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    -- See comment below.
+    -- let expectedRows = map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
     step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
     pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    -- This is disabled due to a difference in the sort order that
+    -- PostgreSQL returns depending on which platorm it's running on. See:
+    --
+    -- https://github.com/hackworthltd/primer/issues/1044
+    -- pageContents pAll @?= expectedRows
     total pAll @?= 6
-    pageContents pAll @?= expectedRows
   where
     mkName n = if even n then "name-" <> show n else "NaMe-" <> show n
 

--- a/primer-rel8/test/Tests/FindSessions.hs
+++ b/primer-rel8/test/Tests/FindSessions.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Tests.FindSessions where
+
+import Foreword
+
+import Data.Text qualified as Text
+import Primer.App (newApp)
+import Primer.Database (
+  LastModified (..),
+  OffsetLimit (OL, limit, offset),
+  Page (pageContents, total),
+  Session (Session),
+  findSessions,
+  fromSessionName,
+  insertSession,
+  safeMkSessionName,
+ )
+import Primer.Database.Rel8 (
+  SessionRow (SessionRow, app, gitversion, lastmodified, name, uuid),
+ )
+import Primer.Database.Rel8.Test.Util (
+  mkSessionRow,
+  mkSessionRow',
+  runTmpDb,
+ )
+import Primer.Test.Util ((@?=))
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCaseSteps)
+
+test_findSessions_several :: TestTree
+test_findSessions_several = testCaseSteps "findSessions several hits" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "-30"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse mkSessionRow [1 .. 400]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 11
+    pageContents pAll @?= expectedRows
+    step $ "Find first 5 occurrences of " <> show substr <> " in session names"
+    p5 <- findSessions substr $ OL{offset = 0, limit = Just 5}
+    total p5 @?= 11
+    pageContents p5 @?= take 5 expectedRows
+    step $ "Find occurrences 6-10 of " <> show substr <> " in session names"
+    p10 <- findSessions substr $ OL{offset = 5, limit = Just 5}
+    total p10 @?= 11
+    pageContents p10 @?= take 5 (drop 5 expectedRows)
+    step $ "Find last occurrence of " <> show substr <> " in session names, crossing end"
+    pLast <- findSessions substr $ OL{offset = 10, limit = Just 5}
+    total pLast @?= 11
+    pageContents pLast @?= drop 10 expectedRows
+
+test_findSessions_exactly_1 :: TestTree
+test_findSessions_exactly_1 = testCaseSteps "findSessions exactly 1 hit" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "-300"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse mkSessionRow [1 .. 400]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 1
+    pageContents pAll @?= expectedRows
+    step $ "Find all occurrences of " <> show substr <> " in session names (limit 50)"
+    p50 <- findSessions substr $ OL{offset = 0, limit = Just 50}
+    total p50 @?= 1
+    pageContents p50 @?= expectedRows
+
+test_findSessions_none :: TestTree
+test_findSessions_none = testCaseSteps "findSessions no hits" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "-401"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse mkSessionRow [1 .. 400]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 0
+    pageContents pAll @?= expectedRows
+    step $ "Find all occurrences of " <> show substr <> " in session names (limit 50)"
+    p50 <- findSessions substr $ OL{offset = 0, limit = Just 50}
+    total p50 @?= 0
+    pageContents p50 @?= expectedRows
+
+test_findSessions_case_sensitive :: TestTree
+test_findSessions_case_sensitive = testCaseSteps "findSessions is case sensitive" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "name"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 6]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 3
+    pageContents pAll @?= expectedRows
+  where
+    mkName n = if even n then "name-" <> show n else "NaMe-" <> show n
+
+test_findSessions_unicode :: TestTree
+test_findSessions_unicode = testCaseSteps "findSessions supports Unicode" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "ありがとう"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 5]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 2
+    pageContents pAll @?= expectedRows
+  where
+    mkName 0 = "Thank you"
+    mkName 1 = "ありがとう"
+    mkName 3 = "Merci"
+    mkName 4 = "ありがとうございます"
+    mkName 5 = "Danke"
+    mkName _ = "Gracias"
+
+test_findSessions_emoji :: TestTree
+test_findSessions_emoji = testCaseSteps "findSessions supports emoji" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "🤗😂"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 7]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 3
+    pageContents pAll @?= expectedRows
+  where
+    mkName 1 = "🤗"
+    mkName 2 = "😂"
+    mkName 3 = "🤗😂"
+    mkName 4 = "😄😂🤣🤗 🦊 🦈"
+    mkName 5 = "🤗😂😂"
+    mkName 6 = "🤗🤗😂"
+    mkName 7 = "🤗🤗😄"
+    mkName _ = "👍🏽"
+
+test_findSessions_escapes_percent :: TestTree
+test_findSessions_escapes_percent = testCaseSteps "findSessions escapes % in the substring" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "%abc%"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 4]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 2
+    pageContents pAll @?= expectedRows
+  where
+    mkName 1 = "should %abc%% match"
+    mkName 2 = "should %abc% match"
+    mkName 3 = "abc% should not match"
+    mkName 4 = "%abc % should not match"
+    mkName _ = "no match"
+
+test_findSessions_escapes_underscore :: TestTree
+test_findSessions_escapes_underscore = testCaseSteps "findSessions escapes _ in the substring" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "_abc_"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 4]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 2
+    pageContents pAll @?= expectedRows
+  where
+    mkName 1 = "should _abc__ match"
+    mkName 2 = "should _abc_ match"
+    mkName 3 = "abc_ should not match"
+    mkName 4 = "_abc _ should not match"
+    mkName _ = "no match"
+
+test_findSessions_escapes_backslash :: TestTree
+test_findSessions_escapes_backslash = testCaseSteps "findSessions escapes backslash in the substring" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "\\abc\\"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 4]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 2
+    pageContents pAll @?= expectedRows
+  where
+    mkName 1 = "should \\abc\\\\ match"
+    mkName 2 = "should \\abc\\ match"
+    mkName 3 = "abc\\ should not match"
+    mkName 4 = "\\abc \\ should not match"
+    mkName _ = "no match"
+
+test_findSessions_escapes_all_specials :: TestTree
+test_findSessions_escapes_all_specials = testCaseSteps "findSessions escapes all specials in the substring" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "\\ _ %"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 4]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 2
+    pageContents pAll @?= expectedRows
+  where
+    mkName 1 = "should \\ _ % match"
+    mkName 2 = "should _\\ _ %% match"
+    mkName 3 = "_ % should not match"
+    mkName 4 = "\\ % should not match"
+    mkName _ = "no match"

--- a/primer-rel8/test/Tests/FindSessions.hs
+++ b/primer-rel8/test/Tests/FindSessions.hs
@@ -91,18 +91,18 @@ test_findSessions_none = testCaseSteps "findSessions no hits" $ \step' ->
     total p50 @?= 0
     pageContents p50 @?= expectedRows
 
-test_findSessions_case_sensitive :: TestTree
-test_findSessions_case_sensitive = testCaseSteps "findSessions is case sensitive" $ \step' ->
+test_findSessions_case_insensitive :: TestTree
+test_findSessions_case_insensitive = testCaseSteps "findSessions is case-insensitive" $ \step' ->
   runTmpDb $ do
     let step = liftIO . step'
     let substr = "name"
     step "Insert all sessions"
     rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 6]
     forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
-    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    let expectedRows = map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
     step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
     pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
-    total pAll @?= 3
+    total pAll @?= 6
     pageContents pAll @?= expectedRows
   where
     mkName n = if even n then "name-" <> show n else "NaMe-" <> show n

--- a/primer-rel8/testlib/Primer/Database/Rel8/Test/Util.hs
+++ b/primer-rel8/testlib/Primer/Database/Rel8/Test/Util.hs
@@ -4,6 +4,7 @@ module Primer.Database.Rel8.Test.Util (
   deployDb,
   insertSessionRow,
   mkSessionRow,
+  mkSessionRow',
   withDbSetup,
   lowPrecisionCurrentTime,
   runTmpDb,
@@ -191,5 +192,19 @@ mkSessionRow n = do
       , gitversion = "test-version"
       , app = newApp
       , name = "name-" <> show n
+      , lastmodified = utcTime now
+      }
+
+-- | Like 'mkSessionRow', but with a callback to generate names.
+mkSessionRow' :: (Int -> Text) -> Int -> IO (SessionRow Result)
+mkSessionRow' mkName n = do
+  u <- nextRandom
+  now <- lowPrecisionCurrentTime
+  pure $
+    SessionRow
+      { uuid = u
+      , gitversion = "test-version"
+      , app = newApp
+      , name = mkName n
       , lastmodified = utcTime now
       }

--- a/primer-selda/primer-selda.cabal
+++ b/primer-selda/primer-selda.cabal
@@ -83,6 +83,7 @@ test-suite primer-selda-test
   hs-source-dirs:     test
   other-modules:
     Tests.DeleteSession
+    Tests.FindSessions
     Tests.InsertSession
     Tests.ListSessions
     Tests.QuerySessionId

--- a/primer-selda/src/Primer/Database/Selda.hs
+++ b/primer-selda/src/Primer/Database/Selda.hs
@@ -69,6 +69,12 @@ data SeldaDbException
     -- operation. This should never occur unless there's a bug in
     -- Selda.
     ListSessionsSeldaError
+  | -- | An error occurred during a 'FindSessions' operation.
+    FindSessionsError SeldaError
+  | -- | Selda returned an unexpected result during a 'FindSessions'
+    -- operation. This should never occur unless there's a bug in
+    -- Selda.
+    FindSessionsSeldaError
   deriving stock (Eq, Show, Generic)
 
 instance Exception SeldaDbException

--- a/primer-selda/src/Primer/Database/Selda/SQLite.hs
+++ b/primer-selda/src/Primer/Database/Selda/SQLite.hs
@@ -29,7 +29,12 @@ import Data.UUID (UUID)
 import Database.Selda (
   Assignment ((:=)),
   Attr ((:-)),
+  Col,
+  Inner,
   MonadSelda,
+  OuterCols,
+  Query,
+  Row,
   SeldaError,
   SeldaT,
   SqlRow,
@@ -38,6 +43,7 @@ import Database.Selda (
   deleteFrom,
   descending,
   insert,
+  like,
   literal,
   order,
   primary,
@@ -56,14 +62,16 @@ import Database.Selda.SQLite (
   SQLite,
   withSQLite,
  )
+import Database.Selda.Unsafe (rawStm)
 import Primer.Database (
   DbError (AppDecodingError, SessionIdNotFound),
   LastModified (..),
   MonadDb (..),
-  OffsetLimit (limit, offset),
+  OffsetLimit (OL),
   Page (Page, pageContents, total),
   Session (Session),
   SessionData (..),
+  SessionId,
   Version,
   fromSessionName,
   safeMkSessionName,
@@ -105,7 +113,19 @@ runSeldaSQLiteDbT db m =
   -- occurred in 'withSQLite' itself (e.g., SQLite file not found);
   -- hence, we use 'ConnectionFailed' here.
   convertSeldaDbException ConnectionFailed $
-    withSQLite db (unSeldaSQLiteDbT m)
+    withSQLite db $ do
+      -- This is required to make SQLite LIKE operations case
+      -- sensitive, which we want in order to match the standard (and
+      -- other implementations). See:
+      -- https://www.sqlite.org/pragma.html#pragma_case_sensitive_like
+      --
+      -- The documentation for the pragma isn't clear on this point,
+      -- but the documentation for
+      -- https://www.sqlite.org/c3ref/create_function.html, upon which
+      -- this pragma is based, is, implies that this pragma needs to
+      -- be performed on every connection.
+      rawStm "PRAGMA case_sensitive_like = true;"
+      unSeldaSQLiteDbT m
 
 -- | A database session table row.
 --
@@ -144,6 +164,26 @@ instance SqlRow SessionRow
 -- | The database's sessions table.
 sessions :: Table SessionRow
 sessions = table "sessions" [#uuid :- primary]
+
+-- A helper function for creating a 'Session' from a database query.
+--
+-- Note that we have 2 choices here if the session name that was
+-- fetched from the database isn't a valid 'SessionName': either we
+-- can return a failure, or we can convert it to a valid
+-- 'SessionName'. This situation can only ever happen if we've made a
+-- mistake (e.g., we've changed the rules on what's a valid
+-- 'SessionName' and didn't run a migration), or if someone has edited
+-- the database directly, without going through the API. In either
+-- case, it would be bad if a student can't load their session just
+-- because a session name was invalid, so we opt for "convert it to a
+-- valid 'SessionName'".
+--
+-- It might be helpful if this function returned an indication of
+-- whether the original name was safe, but for now, we convert
+-- silently.
+safeMkSession :: (SessionId :*: (Text :*: UTCTime)) -> Session
+safeMkSession (s :*: n :*: t) =
+  Session s (safeMkSessionName n) (LastModified t)
 
 -- | A convenient type alias.
 --
@@ -200,34 +240,40 @@ instance MonadSeldaSQLiteDb m l => MonadDb (SeldaSQLiteDbT m) where
   listSessions ol = convertSeldaDbException ListSessionsError $ do
     n' <- query $
       Selda.aggregate $ do
-        session <- select sessions
+        session <- allSessions
         pure $ Selda.count $ session ! #uuid
     n <- case n' of
       [n''] -> pure n''
       -- something has gone terribly wrong: selda should never return
       -- the empty list for a 'count' query.
       _ -> throwM ListSessionsSeldaError
-    ss <- query $
-      Selda.limit (offset ol) (fromMaybe n $ limit ol) $ do
-        session <- select sessions
-        -- Order by session name (primary) and last-modified
-        -- (secondary, newest to oldest). Note that Selda wants these
-        -- constraints to be ordered in least-to-most precedence;
-        -- i.e., secondary then primary. See:
-        -- https://hackage.haskell.org/package/selda-0.5.2.0/docs/Database-Selda.html#v:order
-        order (session ! #lastmodified) descending
-        order (session ! #name) ascending
-        pure (session ! #uuid :*: session ! #name :*: session ! #lastmodified)
+    ss <- query $ paginatedSessionMeta ol allSessions
     pure $ Page{total = n, pageContents = safeMkSession <$> ss}
-    where
-      -- See comment in 'querySessionId' re: dealing with invalid
-      -- session names loaded from the database.
-      safeMkSession (s :*: n :*: t) = Session s (safeMkSessionName n) (LastModified t)
+
+  -- NB: this method is intended to be case-sensitive, but in SQLite,
+  -- this requires that a pragma is used. Primer's implementation sets
+  -- the necessary pragma when the database connection is opened.
+  findSessions substr ol = convertSeldaDbException FindSessionsError $ do
+    -- We shouldn't do this, it's very wasteful. However, it'll
+    -- require some refactoring. See:
+    --
+    -- https://github.com/hackworthltd/primer/issues/1037
+    n' <- query $
+      Selda.aggregate $ do
+        session <- sessionByNameSubstr substr
+        pure $ Selda.count $ session ! #uuid
+    n <- case n' of
+      [n''] -> pure n''
+      -- something has gone terribly wrong: selda should never return
+      -- the empty list for a 'count' query.
+      _ -> throwM FindSessionsSeldaError
+    ss <- query $ paginatedSessionMeta ol $ sessionByNameSubstr substr
+    pure $ Page{total = n, pageContents = safeMkSession <$> ss}
 
   -- Note: we ignore the stored Primer version for now.
   querySessionId sid = convertSeldaDbException (LoadSessionError sid) $ do
     result <- query $ do
-      session <- select sessions
+      session <- allSessions
       restrict (session ! #uuid .== literal sid)
       pure (session ! #gitversion :*: session ! #app :*: session ! #name :*: session ! #lastmodified)
     case result of
@@ -236,18 +282,8 @@ instance MonadSeldaSQLiteDb m l => MonadDb (SeldaSQLiteDbT m) where
         case Aeson.decode bs of
           Nothing -> pure $ Left $ AppDecodingError sid
           Just decodedApp -> do
-            -- Note that we have 2 choices here if @n@ is not a valid
-            -- 'SessionName': either we can return a failure, or we
-            -- can convert it to a valid 'SessionName', possibly
-            -- including a helpful message. This situation can only
-            -- ever happen if we've made a mistake (e.g., we've
-            -- changed the rules on what's a valid 'SessionName' and
-            -- didn't run a migration), or if someone has edited the
-            -- database directly, without going through the API. In
-            -- either case, it would be bad if a student can't load
-            -- their session just because a session name was invalid,
-            -- so we opt for "convert it to a valid 'SessionName'".
-            -- For now, we elide the helpful message.
+            -- See comment on 'safeMkSession' regarding how we use
+            -- 'safeMkSessionName' here.
             let sessionName = safeMkSessionName n
                 lastModified = LastModified t
             when (fromSessionName sessionName /= n) $
@@ -277,3 +313,48 @@ convertSeldaDbException exc op =
   where
     justSeldaError :: SeldaError -> Maybe SeldaError
     justSeldaError = Just
+
+-- "Database.Selda" queries and other operations.
+
+-- All sessions in the database.
+allSessions :: Query s (Row s SessionRow)
+allSessions = select sessions
+
+-- Select all sessions whose name contains the given substring.
+--
+-- Note that Selda doesn't support @ESCAPE@ clauses in @LIKE@, so we
+-- can't search for strings that contain @%@ or @_@. See:
+--
+-- https://github.com/hackworthltd/primer/issues/1035
+sessionByNameSubstr :: Text -> Query s (Row s SessionRow)
+sessionByNameSubstr substr = do
+  session <- allSessions
+  restrict (session ! #name `like` literal ("%" <> substr <> "%"))
+  pure session
+
+-- Paginate a query.
+paginate :: OffsetLimit -> Query (Inner t) a -> Query t (OuterCols a)
+paginate (OL o (Just l)) = Selda.limit o l
+paginate (OL o _) = Selda.limit o maxBound
+
+type SessionMeta s = (Col s UUID :*: Col s Text :*: Col s UTCTime)
+
+-- Order by session name (primary) and last-modified (secondary,
+-- newest to oldest), and return session metadata.
+orderSessionMeta :: Row s SessionRow -> Query s (SessionMeta s)
+orderSessionMeta s = do
+  -- Note that Selda wants these constraints to be ordered in
+  -- least-to-most precedence; i.e., secondary then primary. See:
+  -- https://hackage.haskell.org/package/selda-0.5.2.0/docs/Database-Selda.html#v:order
+  order (s ! #lastmodified) descending
+  order (s ! #name) ascending
+  pure (s ! #uuid :*: s ! #name :*: s ! #lastmodified)
+
+-- Paginated session metadata, sorted by session name (primary) and
+-- last-modified (secondary, newest to oldest).
+paginatedSessionMeta ::
+  OffsetLimit ->
+  Query (Inner t) (Row (Inner t) SessionRow) ->
+  Query t (SessionMeta t)
+paginatedSessionMeta ol s =
+  paginate ol $ s >>= orderSessionMeta

--- a/primer-selda/test/Tests/FindSessions.hs
+++ b/primer-selda/test/Tests/FindSessions.hs
@@ -91,18 +91,18 @@ test_findSessions_none = testCaseSteps "findSessions no hits" $ \step' ->
     total p50 @?= 0
     pageContents p50 @?= expectedRows
 
-test_findSessions_case_sensitive :: TestTree
-test_findSessions_case_sensitive = testCaseSteps "findSessions is case sensitive" $ \step' ->
+test_findSessions_case_insensitive :: TestTree
+test_findSessions_case_insensitive = testCaseSteps "findSessions is case-insensitive" $ \step' ->
   runTmpDb $ do
     let step = liftIO . step'
     let substr = "name"
     step "Insert all sessions"
     rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 6]
     forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
-    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
-    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    let expectedRows = map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of (case-insensitive) " <> show substr <> " in session names (no limit)"
     pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
-    total pAll @?= 3
+    total pAll @?= 6
     pageContents pAll @?= expectedRows
   where
     mkName n = if even n then "name-" <> show n else "NaMe-" <> show n

--- a/primer-selda/test/Tests/FindSessions.hs
+++ b/primer-selda/test/Tests/FindSessions.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Tests.FindSessions where
+
+import Foreword
+
+import Data.Text qualified as Text
+import Primer.App (newApp)
+import Primer.Database (
+  LastModified (..),
+  OffsetLimit (OL, limit, offset),
+  Page (pageContents, total),
+  Session (Session),
+  findSessions,
+  fromSessionName,
+  insertSession,
+  safeMkSessionName,
+ )
+import Primer.Database.Selda.SQLite (
+  SessionRow (SessionRow, app, gitversion, lastmodified, name, uuid),
+ )
+import Primer.Database.Selda.Test.Util (
+  mkSessionRow,
+  mkSessionRow',
+  runTmpDb,
+ )
+import Primer.Test.Util ((@?=))
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCaseSteps)
+
+test_findSessions_several :: TestTree
+test_findSessions_several = testCaseSteps "findSessions several hits" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "-30"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse mkSessionRow [1 .. 400]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 11
+    pageContents pAll @?= expectedRows
+    step $ "Find first 5 occurrences of " <> show substr <> " in session names"
+    p5 <- findSessions substr $ OL{offset = 0, limit = Just 5}
+    total p5 @?= 11
+    pageContents p5 @?= take 5 expectedRows
+    step $ "Find occurrences 6-10 of " <> show substr <> " in session names"
+    p10 <- findSessions substr $ OL{offset = 5, limit = Just 5}
+    total p10 @?= 11
+    pageContents p10 @?= take 5 (drop 5 expectedRows)
+    step $ "Find last occurrence of " <> show substr <> " in session names, crossing end"
+    pLast <- findSessions substr $ OL{offset = 10, limit = Just 5}
+    total pLast @?= 11
+    pageContents pLast @?= drop 10 expectedRows
+
+test_findSessions_exactly_1 :: TestTree
+test_findSessions_exactly_1 = testCaseSteps "findSessions exactly 1 hit" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "-300"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse mkSessionRow [1 .. 400]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 1
+    pageContents pAll @?= expectedRows
+    step $ "Find all occurrences of " <> show substr <> " in session names (limit 50)"
+    p50 <- findSessions substr $ OL{offset = 0, limit = Just 50}
+    total p50 @?= 1
+    pageContents p50 @?= expectedRows
+
+test_findSessions_none :: TestTree
+test_findSessions_none = testCaseSteps "findSessions no hits" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "-401"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse mkSessionRow [1 .. 400]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 0
+    pageContents pAll @?= expectedRows
+    step $ "Find all occurrences of " <> show substr <> " in session names (limit 50)"
+    p50 <- findSessions substr $ OL{offset = 0, limit = Just 50}
+    total p50 @?= 0
+    pageContents p50 @?= expectedRows
+
+test_findSessions_case_sensitive :: TestTree
+test_findSessions_case_sensitive = testCaseSteps "findSessions is case sensitive" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "name"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 6]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 3
+    pageContents pAll @?= expectedRows
+  where
+    mkName n = if even n then "name-" <> show n else "NaMe-" <> show n
+
+test_findSessions_unicode :: TestTree
+test_findSessions_unicode = testCaseSteps "findSessions supports Unicode" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "ありがとう"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 5]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 2
+    pageContents pAll @?= expectedRows
+  where
+    mkName 0 = "Thank you"
+    mkName 1 = "ありがとう"
+    mkName 3 = "Merci"
+    mkName 4 = "ありがとうございます"
+    mkName 5 = "Danke"
+    mkName _ = "Gracias"
+
+test_findSessions_emoji :: TestTree
+test_findSessions_emoji = testCaseSteps "findSessions supports emoji" $ \step' ->
+  runTmpDb $ do
+    let step = liftIO . step'
+    let substr = "🤗😂"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn name <$> traverse (mkSessionRow' mkName) [1 .. 7]
+    forM_ rows (\SessionRow{..} -> insertSession gitversion uuid newApp (safeMkSessionName name) (LastModified lastmodified))
+    let expectedRows = filter (\(Session _ n _) -> substr `Text.isInfixOf` fromSessionName n) $ map (\r -> Session (uuid r) (safeMkSessionName $ name r) (LastModified $ lastmodified r)) rows
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 3
+    pageContents pAll @?= expectedRows
+  where
+    mkName 1 = "🤗"
+    mkName 2 = "😂"
+    mkName 3 = "🤗😂"
+    mkName 4 = "😄😂🤣🤗 🦊 🦈"
+    mkName 5 = "🤗😂😂"
+    mkName 6 = "🤗🤗😂"
+    mkName 7 = "🤗🤗😄"
+    mkName _ = "👍🏽"
+
+-- Note: no escape checks, as Selda doesn't currently support escaping
+-- in LIKE queries.

--- a/primer-selda/testlib/Primer/Database/Selda/Test/Util.hs
+++ b/primer-selda/testlib/Primer/Database/Selda/Test/Util.hs
@@ -7,6 +7,7 @@ module Primer.Database.Selda.Test.Util (
   runTmpDb,
   insertSessionRow,
   mkSessionRow,
+  mkSessionRow',
 ) where
 
 import Foreword
@@ -95,5 +96,19 @@ mkSessionRow n = do
       , gitversion = "test-version"
       , app = Aeson.encode newApp
       , name = "name-" <> show n
+      , lastmodified = utcTime now
+      }
+
+-- | Like 'mkSessionRow', but with a callback to generate names.
+mkSessionRow' :: (Int -> Text) -> Int -> IO SessionRow
+mkSessionRow' mkName n = do
+  u <- nextRandom
+  now <- lowPrecisionCurrentTime
+  pure $
+    SessionRow
+      { uuid = u
+      , gitversion = "test-version"
+      , app = Aeson.encode newApp
+      , name = mkName n
       , lastmodified = utcTime now
       }

--- a/primer-service/src/Primer/Client.hs
+++ b/primer-service/src/Primer/Client.hs
@@ -109,8 +109,8 @@ createSession :: NewSessionReq -> ClientM SessionId
 createSession req = apiClient // API.sessionsAPI // API.createSession /: req
 
 -- | As 'Primer.API.listSessions'.
-listSessions :: Bool -> Pagination -> ClientM (Paginated Session)
-listSessions inMemory pp = apiClient // API.sessionsAPI // API.getSessionList /: inMemory /: pp
+listSessions :: Pagination -> ClientM (Paginated Session)
+listSessions pp = apiClient // API.sessionsAPI // API.getSessionList /: pp
 
 -- | As 'Primer.API.addSession'.
 addSession :: Text -> App -> ClientM SessionId

--- a/primer-service/src/Primer/Client.hs
+++ b/primer-service/src/Primer/Client.hs
@@ -108,9 +108,10 @@ flushSessions = void $ apiClient // API.adminAPI // API.flushSessions
 createSession :: NewSessionReq -> ClientM SessionId
 createSession req = apiClient // API.sessionsAPI // API.createSession /: req
 
--- | As 'Primer.API.listSessions'.
-listSessions :: Pagination -> ClientM (Paginated Session)
-listSessions pp = apiClient // API.sessionsAPI // API.getSessionList /: pp
+-- | As 'Primer.API.listSessions' and 'Primer.API.findSessions',
+-- depending on whether the optional 'nameLike' parameter is provided.
+listSessions :: Maybe Text -> Pagination -> ClientM (Paginated Session)
+listSessions nameLike pp = apiClient // API.sessionsAPI // API.getSessionList /: nameLike /: pp
 
 -- | As 'Primer.API.addSession'.
 addSession :: Text -> App -> ClientM SessionId

--- a/primer-service/src/Primer/Servant/Types.hs
+++ b/primer-service/src/Primer/Servant/Types.hs
@@ -29,7 +29,6 @@ import Servant (
   JSON,
   Post,
   Put,
-  QueryFlag,
   ReqBody,
   Summary,
   (:>),
@@ -83,17 +82,13 @@ type DeleteSession mode =
 
 type GetSessionList mode =
   mode
-    :- QueryFlag "inMemory"
-      :> PaginationParams
+    :- PaginationParams
       :> Summary "Get the list of sessions"
       :> Description
-          "Get a list of all sessions and their human-readable names. By \
-          \default, this method returns the list of all sessions in the \
-          \persistent database, but optionally it can return just the list \
-          \of all sessions in memory, which is mainly useful for \
-          \testing. Note that in a production system, this endpoint should \
-          \obviously be authentication-scoped and only return the list of \
-          \sessions that the caller is authorized to see."
+          "Get a list of all sessions and their human-readable names. Note \
+          \that in a production system, this endpoint should obviously be \
+          \authentication-scoped and only return the list of sessions that \
+          \the caller is authorized to see."
       :> OperationId "getSessionList"
       :> Get '[JSON] (Paginated Session)
 

--- a/primer-service/src/Primer/Servant/Types.hs
+++ b/primer-service/src/Primer/Servant/Types.hs
@@ -29,6 +29,7 @@ import Servant (
   JSON,
   Post,
   Put,
+  QueryParam,
   ReqBody,
   Summary,
   (:>),
@@ -82,11 +83,13 @@ type DeleteSession mode =
 
 type GetSessionList mode =
   mode
-    :- PaginationParams
+    :- QueryParam "nameLike" Text
+      :> PaginationParams
       :> Summary "Get the list of sessions"
       :> Description
-          "Get a list of all sessions and their human-readable names. Note \
-          \that in a production system, this endpoint should obviously be \
+          "Get a list of all sessions and their human-readable names, with an \
+          \optional filter for matching on session names. Note that in a \
+          \production system, this endpoint should obviously be \
           \authentication-scoped and only return the list of sessions that \
           \the caller is authorized to see."
       :> OperationId "getSessionList"

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -161,7 +161,7 @@ openAPISessionsServer :: ConvertServerLogs l => OpenAPI.SessionsAPI (AsServerT (
 openAPISessionsServer =
   OpenAPI.SessionsAPI
     { OpenAPI.createSession = newSession
-    , OpenAPI.getSessionList = \b p -> pagedDefault 100 p $ listSessions b
+    , OpenAPI.getSessionList = \p -> pagedDefault 100 p listSessions
     , OpenAPI.sessionAPI = openAPISessionServer
     }
 
@@ -215,7 +215,7 @@ sessionsAPIServer :: ConvertServerLogs l => S.SessionsAPI (AsServerT (Primer l))
 sessionsAPIServer =
   S.SessionsAPI
     { S.createSession = newSession
-    , S.getSessionList = \b p -> pagedDefault 100 p $ listSessions b
+    , S.getSessionList = \p -> pagedDefault 100 p listSessions
     , S.addSession = API.addSession
     , S.sessionAPI = sessionAPIServer
     }

--- a/primer-service/src/Primer/Server.hs
+++ b/primer-service/src/Primer/Server.hs
@@ -62,6 +62,7 @@ import Primer.API (
   createTypeDef,
   edit,
   evalFull',
+  findSessions,
   listSessions,
   newSession,
   redo,
@@ -161,7 +162,7 @@ openAPISessionsServer :: ConvertServerLogs l => OpenAPI.SessionsAPI (AsServerT (
 openAPISessionsServer =
   OpenAPI.SessionsAPI
     { OpenAPI.createSession = newSession
-    , OpenAPI.getSessionList = \p -> pagedDefault 100 p listSessions
+    , OpenAPI.getSessionList = \s p -> pagedDefault 100 p $ maybe listSessions findSessions s
     , OpenAPI.sessionAPI = openAPISessionServer
     }
 
@@ -215,7 +216,7 @@ sessionsAPIServer :: ConvertServerLogs l => S.SessionsAPI (AsServerT (Primer l))
 sessionsAPIServer =
   S.SessionsAPI
     { S.createSession = newSession
-    , S.getSessionList = \p -> pagedDefault 100 p listSessions
+    , S.getSessionList = \s p -> pagedDefault 100 p $ maybe listSessions findSessions s
     , S.addSession = API.addSession
     , S.sessionAPI = sessionAPIServer
     }

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -763,9 +763,17 @@
         },
         "/openapi/sessions": {
             "get": {
-                "description": "Get a list of all sessions and their human-readable names. Note that in a production system, this endpoint should obviously be authentication-scoped and only return the list of sessions that the caller is authorized to see.",
+                "description": "Get a list of all sessions and their human-readable names, with an optional filter for matching on session names. Note that in a production system, this endpoint should obviously be authentication-scoped and only return the list of sessions that the caller is authorized to see.",
                 "operationId": "getSessionList",
                 "parameters": [
+                    {
+                        "in": "query",
+                        "name": "nameLike",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     {
                         "in": "query",
                         "name": "page",
@@ -802,7 +810,7 @@
                         "description": ""
                     },
                     "400": {
-                        "description": "Invalid `pageSize` or `page`"
+                        "description": "Invalid `pageSize` or `page` or `nameLike`"
                     }
                 },
                 "summary": "Get the list of sessions"

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -763,18 +763,9 @@
         },
         "/openapi/sessions": {
             "get": {
-                "description": "Get a list of all sessions and their human-readable names. By default, this method returns the list of all sessions in the persistent database, but optionally it can return just the list of all sessions in memory, which is mainly useful for testing. Note that in a production system, this endpoint should obviously be authentication-scoped and only return the list of sessions that the caller is authorized to see.",
+                "description": "Get a list of all sessions and their human-readable names. Note that in a production system, this endpoint should obviously be authentication-scoped and only return the list of sessions that the caller is authorized to see.",
                 "operationId": "getSessionList",
                 "parameters": [
-                    {
-                        "allowEmptyValue": true,
-                        "in": "query",
-                        "name": "inMemory",
-                        "schema": {
-                            "default": false,
-                            "type": "boolean"
-                        }
-                    },
                     {
                         "in": "query",
                         "name": "page",
@@ -811,7 +802,7 @@
                         "description": ""
                     },
                     "400": {
-                        "description": "Invalid `pageSize` or `page` or `inMemory`"
+                        "description": "Invalid `pageSize` or `page`"
                     }
                 },
                 "summary": "Get the list of sessions"

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -519,9 +519,7 @@ listSessions = logAPI (noError ListSessions) $ \ol -> do
 
 -- | Find sessions whose names contain the given substring.
 --
--- Note that this implementation is case-sensitive, though some
--- underlying implementations may disagree in certain ranges of the
--- Unicode character set.
+-- Note that this implementation is case-in-sensitive.
 findSessions :: (MonadIO m, MonadAPILog l m) => Text -> OffsetLimit -> PrimerM m (Page Session)
 findSessions = curry $ logAPI (noError FindSessions) $ \case
   (substr, ol) -> do

--- a/primer/src/Primer/Database.hs
+++ b/primer/src/Primer/Database.hs
@@ -49,11 +49,7 @@ import Control.Monad.STM (atomically)
 import Control.Monad.Trans (MonadTrans)
 import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Zip (MonadZip)
-import Data.Text qualified as Text (
-  strip,
-  take,
-  takeWhile,
- )
+import Data.Text qualified as Text
 import Data.Time.Clock (
   UTCTime,
  )
@@ -269,6 +265,12 @@ data Op
   | -- | Get the list of all sessions (and their names) in the
     -- database.
     ListSessions !OffsetLimit !(TMVar (Page Session))
+  | -- | Find any session whose name contains the given substring.
+    --
+    -- Note that this implementation is case-sensitive, though some
+    -- database implementations may disagree in certain ranges of the
+    -- Unicode character set.
+    FindSessions !Text !OffsetLimit !(TMVar (Page Session))
 
 -- | A config for the 'serve' computation.
 data ServiceCfg = ServiceCfg
@@ -339,6 +341,11 @@ class (Monad m) => MonadDb m where
   -- Returns 'Left' with a 'DbError' if the query failed (session
   -- doesn't exist), 'Right' with the 'SessionData' if successful.
   querySessionId :: SessionId -> m (Either DbError SessionData)
+
+  -- | Find any session whose name contains the given substring.
+  --
+  -- Corresponds to the 'FindSessions' operation.
+  findSessions :: Text -> OffsetLimit -> m (Page Session)
 
 -- | Routine errors that can occur during 'MonadDb' computations.
 --
@@ -448,6 +455,12 @@ instance (MonadThrow m, MonadIO m) => MonadDb (NullDbT m) where
     case lookup of
       Nothing -> pure $ Left $ SessionIdNotFound sid
       Just s -> pure $ Right s
+  findSessions substr ol = do
+    ss <- ask
+    kvs <- liftIO $ atomically $ ListT.toList $ StmMap.listT ss
+    -- Find any session whose name contains the given substring.
+    let matches = filter (\(_, SessionData _ n _) -> substr `Text.isInfixOf` fromSessionName n) kvs
+    pure $ pageList ol $ sortOn name $ (\(i, SessionData _ n t) -> Session i n t) <$> matches
 
 updateOrFail :: (MonadThrow m, MonadIO m) => SessionId -> (SessionData -> SessionData) -> Sessions -> m ()
 updateOrFail id_ f ss = do
@@ -500,6 +513,9 @@ serve (ServiceCfg q v) =
     perform (UpdateName s n t) = updateSessionName v s n t
     perform (ListSessions ol result) = do
       ss <- listSessions ol
+      liftIO $ atomically $ putTMVar result ss
+    perform (FindSessions str ol result) = do
+      ss <- findSessions str ol
       liftIO $ atomically $ putTMVar result ss
     perform (LoadSession sid memdb status) = do
       -- Note that we split the in-memory session insertion (i.e.,

--- a/primer/test/Tests/API.hs
+++ b/primer/test/Tests/API.hs
@@ -263,13 +263,13 @@ test_listSessions =
     runAPI $ do
       let step = liftIO . step'
       step "List session on an empty database"
-      s0 <- listSessions False $ OL{offset = 0, limit = Nothing}
+      s0 <- listSessions $ OL{offset = 0, limit = Nothing}
       total s0 @?= 0
       let m :: Int = 107
       step $ "Create " <> show m <> " sessions"
       ss <- forM ([1 .. m] :: [Int]) $ const $ newSession $ NewSessionReq "new session"
       step "List all the sessions"
-      ss' <- listSessions False $ OL{offset = 0, limit = Nothing}
+      ss' <- listSessions $ OL{offset = 0, limit = Nothing}
       total ss' @?= m
       -- Sort by session ID, because 'listSessions' sorts by name but
       -- all the new session names are the same by default.

--- a/primer/test/Tests/API.hs
+++ b/primer/test/Tests/API.hs
@@ -13,6 +13,7 @@ import Primer.API (
   addSession,
   copySession,
   deleteSession,
+  findSessions,
   flushSessions,
   getApp,
   getSessionName,
@@ -281,6 +282,30 @@ test_listSessions =
       -- https://github.com/hackworthltd/primer/issues/545
       {- HLINT ignore test_listSessions "Functor law" -}
       sort (id <$> pageContents ss') @?= sort ss
+
+-- Note: we don't bother testing paging here, because it's not very
+-- interesting to test. 'findSessions' doesn't do any of the paging,
+-- that's all handled by the database implementation.
+test_findSessions :: TestTree
+test_findSessions =
+  testCaseSteps "findSessions" $ \step' -> do
+    runAPI $ do
+      let step = liftIO . step'
+      step "Find session on an empty database"
+      s0 <- findSessions "nope" $ OL{offset = 0, limit = Nothing}
+      total s0 @?= 0
+      let m :: Int = 100
+      step $ "Create " <> show m <> " sessions"
+      forM_ ([1 .. m] :: [Int]) $ \n -> newSession $ NewSessionReq $ "new session " <> show n
+      step "Find all the sessions whose names contain '1'"
+      ss' <- findSessions "1" $ OL{offset = 0, limit = Nothing}
+      total ss' @?= 20
+      step "Find all the sessions whose names contain '99'"
+      ss'' <- findSessions "99" $ OL{offset = 0, limit = Nothing}
+      total ss'' @?= 1
+      step "Find all the sessions whose names contain '101'"
+      ss''' <- findSessions "101" $ OL{offset = 0, limit = Nothing}
+      total ss''' @?= 0
 
 test_copySession :: TestTree
 test_copySession =

--- a/primer/test/Tests/Database.hs
+++ b/primer/test/Tests/Database.hs
@@ -168,6 +168,11 @@ listSessionsTest = do
   void $ addSession "even3App" even3App
   void $ API.listSessions True $ OL 0 $ Just 100
 
+findSessionsTest :: (MonadIO m, MonadAPILog l m) => PrimerM m ()
+findSessionsTest = do
+  void $ addSession "even3App" even3App
+  void $ API.findSessions "3" $ OL 0 $ Just 100
+
 deleteSessionTest :: (MonadIO m, MonadThrow m, MonadAPILog l m) => PrimerM m ()
 deleteSessionTest = do
   sid <- addSession "even3App" even3App
@@ -193,6 +198,10 @@ test_listsessions_empty_q :: TestTree
 test_listsessions_empty_q = emptyQHarness "database ListSessions leaves an empty op queue" $ do
   listSessionsTest
 
+test_findsessions_empty_q :: TestTree
+test_findsessions_empty_q = emptyQHarness "database FindSessions leaves an empty op queue" $ do
+  findSessionsTest
+
 test_deletesession_empty_q :: TestTree
 test_deletesession_empty_q = emptyQHarness "database DeleteSession leaves an empty op queue" $ do
   deleteSessionTest
@@ -216,6 +225,10 @@ test_loadsession_faildb = faildbHarness "database LoadSession leaves behind an o
 test_listsessions_faildb :: TestTree
 test_listsessions_faildb = faildbHarness "database ListSessions leaves behind an op" $ do
   listSessionsTest
+
+test_findsessions_faildb :: TestTree
+test_findsessions_faildb = faildbHarness "database FindSessions leaves behind an op" $ do
+  findSessionsTest
 
 test_deletesession_faildb :: TestTree
 test_deletesession_faildb = faildbHarness "database DeleteSession leaves behind an op" $ do
@@ -283,6 +296,7 @@ instance (MonadThrow m) => MonadDb (FailDbT m) where
   updateSessionApp _ _ _ _ = throwM $ FailDbException "updateSessionApp"
   updateSessionName _ _ _ _ = throwM $ FailDbException "updateSessionName"
   listSessions _ = throwM $ FailDbException "listSessions"
+  findSessions _ _ = throwM $ FailDbException "findSessions"
   querySessionId _ = throwM $ FailDbException "querySessionId"
   deleteSession _ = throwM $ FailDbException "deleteSession"
 

--- a/primer/test/Tests/Database.hs
+++ b/primer/test/Tests/Database.hs
@@ -166,7 +166,7 @@ loadSessionTest = do
 listSessionsTest :: (MonadIO m, MonadAPILog l m) => PrimerM m ()
 listSessionsTest = do
   void $ addSession "even3App" even3App
-  void $ API.listSessions True $ OL 0 $ Just 100
+  void $ API.listSessions $ OL 0 $ Just 100
 
 findSessionsTest :: (MonadIO m, MonadAPILog l m) => PrimerM m ()
 findSessionsTest = do

--- a/primer/test/Tests/NullDb.hs
+++ b/primer/test/Tests/NullDb.hs
@@ -2,6 +2,7 @@ module Tests.NullDb where
 
 import Foreword
 
+import Data.Text qualified as Text
 import Data.UUID.V4 (nextRandom)
 import Primer.App (
   newApp,
@@ -16,6 +17,7 @@ import Primer.Database (
   Session (..),
   SessionData (..),
   SessionId,
+  fromSessionName,
   getCurrentTime,
   newSessionId,
   runNullDb',
@@ -122,6 +124,12 @@ mkSession n = do
   now <- getCurrentTime
   pure (u, SessionData newApp (safeMkSessionName $ "name-" <> show n) now)
 
+mkSession' :: (Int -> Text) -> Int -> IO (SessionId, SessionData)
+mkSession' mkName n = do
+  u <- nextRandom
+  now <- getCurrentTime
+  pure (u, SessionData newApp (safeMkSessionName $ mkName n) now)
+
 test_listSessions :: TestTree
 test_listSessions = testCaseSteps "listSessions" $ \step' ->
   runNullDb' $ do
@@ -148,6 +156,139 @@ test_listSessions = testCaseSteps "listSessions" $ \step' ->
     pLast <- listSessions $ OL{offset = m - 10, limit = Just 25}
     total pLast @?= m
     pageContents pLast @?= drop (m - 10) expectedRows
+
+test_findSessions_several :: TestTree
+test_findSessions_several = testCaseSteps "findSessions several hits" $ \step' ->
+  runNullDb' $ do
+    let step = liftIO . step'
+    let version = "git123"
+    let substr = "-30"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn (sessionName . snd) <$> traverse mkSession [1 .. 400]
+    forM_ rows (\(id_, SessionData app name now) -> insertSession version id_ app name now)
+    let filteredResults = filter (\(_, SessionData _ n _) -> substr `Text.isInfixOf` fromSessionName n) rows
+    let expectedRows = map (\(i, SessionData _ n t) -> Session i n t) filteredResults
+    step "Get all, offset+limit"
+    pAllMatches <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAllMatches @?= 11
+    pageContents pAllMatches @?= expectedRows
+    step "Get 5"
+    p5 <- findSessions substr $ OL{offset = 0, limit = Just 5}
+    total p5 @?= 11
+    pageContents p5 @?= take 5 expectedRows
+    step "Get 6-10"
+    p10 <- findSessions substr $ OL{offset = 5, limit = Just 5}
+    total p10 @?= 11
+    pageContents p10 @?= take 5 (drop 5 expectedRows)
+    step "Get crossing end"
+    pLast <- findSessions substr $ OL{offset = 10, limit = Just 5}
+    total pLast @?= 11
+    pageContents pLast @?= drop 10 expectedRows
+
+test_findSessions_exactly_1 :: TestTree
+test_findSessions_exactly_1 = testCaseSteps "findSessions exactly 1 hit" $ \step' ->
+  runNullDb' $ do
+    let step = liftIO . step'
+    let version = "git123"
+    let substr = "-300"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn (sessionName . snd) <$> traverse mkSession [1 .. 400]
+    forM_ rows (\(id_, SessionData app name now) -> insertSession version id_ app name now)
+    let filteredResults = filter (\(_, SessionData _ n _) -> substr `Text.isInfixOf` fromSessionName n) rows
+    let expectedRows = map (\(i, SessionData _ n t) -> Session i n t) filteredResults
+    step "Get all, offset+limit"
+    pAllMatches <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAllMatches @?= 1
+    pageContents pAllMatches @?= expectedRows
+    step "Get 50"
+    p50 <- findSessions substr $ OL{offset = 0, limit = Just 50}
+    total p50 @?= 1
+    pageContents p50 @?= expectedRows
+
+test_findSessions_none :: TestTree
+test_findSessions_none = testCaseSteps "findSessions no hits" $ \step' ->
+  runNullDb' $ do
+    let step = liftIO . step'
+    let version = "git123"
+    let substr = "-401"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn (sessionName . snd) <$> traverse mkSession [1 .. 400]
+    forM_ rows (\(id_, SessionData app name now) -> insertSession version id_ app name now)
+    let expectedRows = []
+    step "Get all, offset+limit"
+    pAllMatches <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAllMatches @?= 0
+    pageContents pAllMatches @?= expectedRows
+    step "Get 50"
+    p50 <- findSessions substr $ OL{offset = 0, limit = Just 50}
+    total p50 @?= 0
+    pageContents p50 @?= expectedRows
+
+test_findSessions_case_sensitive :: TestTree
+test_findSessions_case_sensitive = testCaseSteps "findSessions is case sensitive" $ \step' ->
+  runNullDb' $ do
+    let step = liftIO . step'
+    let version = "git123"
+    let substr = "name"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn (sessionName . snd) <$> traverse (mkSession' evenOddName) [1 .. 6]
+    forM_ rows (\(id_, SessionData app name now) -> insertSession version id_ app name now)
+    let filteredResults = filter (\(_, SessionData _ n _) -> substr `Text.isInfixOf` fromSessionName n) rows
+    let expectedRows = map (\(i, SessionData _ n t) -> Session i n t) filteredResults
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAllMatches <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAllMatches @?= 3
+    pageContents pAllMatches @?= expectedRows
+  where
+    evenOddName n = if even n then "name-" <> show n else "NaMe-" <> show n
+
+test_findSessions_unicode :: TestTree
+test_findSessions_unicode = testCaseSteps "findSessions supports Unicode" $ \step' ->
+  runNullDb' $ do
+    let step = liftIO . step'
+    let version = "git123"
+    let substr = "ありがとう"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn (sessionName . snd) <$> traverse (mkSession' mkName) [1 .. 5]
+    forM_ rows (\(id_, SessionData app name now) -> insertSession version id_ app name now)
+    let filteredResults = filter (\(_, SessionData _ n _) -> substr `Text.isInfixOf` fromSessionName n) rows
+    let expectedRows = map (\(i, SessionData _ n t) -> Session i n t) filteredResults
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 2
+    pageContents pAll @?= expectedRows
+  where
+    mkName 0 = "Thank you"
+    mkName 1 = "ありがとう"
+    mkName 3 = "Merci"
+    mkName 4 = "ありがとうございます"
+    mkName 5 = "Danke"
+    mkName _ = "Gracias"
+
+test_findSessions_emoji :: TestTree
+test_findSessions_emoji = testCaseSteps "findSessions supports emoji" $ \step' ->
+  runNullDb' $ do
+    let step = liftIO . step'
+    let version = "git123"
+    let substr = "🤗😂"
+    step "Insert all sessions"
+    rows <- liftIO $ sortOn (sessionName . snd) <$> traverse (mkSession' mkName) [1 .. 7]
+    forM_ rows (\(id_, SessionData app name now) -> insertSession version id_ app name now)
+    let filteredResults = filter (\(_, SessionData _ n _) -> substr `Text.isInfixOf` fromSessionName n) rows
+    let expectedRows = map (\(i, SessionData _ n t) -> Session i n t) filteredResults
+    step $ "Find all occurrences of " <> show substr <> " in session names (no limit)"
+    pAll <- findSessions substr $ OL{offset = 0, limit = Nothing}
+    total pAll @?= 3
+    pageContents pAll @?= expectedRows
+  where
+    mkName 1 = "🤗"
+    mkName 2 = "😂"
+    mkName 3 = "🤗😂"
+    mkName 4 = "😄😂🤣🤗 🦊 🦈"
+    mkName 5 = "🤗😂😂"
+    mkName 6 = "🤗🤗😂"
+    mkName 7 = "🤗🤗😄"
+    mkName _ = "👍🏽"
 
 test_updateSessionApp_roundtrip :: TestTree
 test_updateSessionApp_roundtrip = testCaseSteps "updateSessionApp database round-tripping" $ \step' ->


### PR DESCRIPTION
Apologies for the large first commit. There was no reasonable way to break it up into smaller pieces. Most of it is tests and refactoring, at least.

*edit*: note to future readers, we ended up making this implementation case-*in*sensitive only, at least for now. When time allows, we'll implement case-sensitive search. See https://github.com/hackworthltd/primer/pull/1033#issuecomment-1562089557 for the motivation.