### PR TITLE
feat: Annotate offered variables which match the required type

### DIFF
--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -344,7 +344,7 @@ instance Arbitrary Available.InputAction where
 instance Arbitrary Available.Action where
   arbitrary = either Available.NoInput Available.Input <$> arbitrary
 instance Arbitrary Available.Option where
-  arbitrary = Available.Option <$> arbitrary <*> arbitrary
+  arbitrary = Available.Option <$> arbitrary <*> arbitrary <*> arbitrary
 instance Arbitrary Available.FreeInput where
   arbitrary = arbitraryBoundedEnum
 instance Arbitrary Available.Options where

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -471,12 +471,16 @@
                         "minItems": 1,
                         "type": "array"
                     },
+                    "matchesType": {
+                        "type": "boolean"
+                    },
                     "option": {
                         "type": "string"
                     }
                 },
                 "required": [
-                    "option"
+                    "option",
+                    "matchesType"
                 ],
                 "type": "object"
             },

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -58,6 +58,7 @@ module Primer.Typecheck (
   localTmVars,
   localTyVars,
   enhole,
+  eqType,
 ) where
 
 import Foreword

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -325,9 +325,9 @@ tasty_available_actions_accepted = withTests 500 $
               let opts'' =
                     opts' <> case free of
                       Available.FreeNone -> []
-                      Available.FreeVarName -> [(StudentProvided,) . flip Available.Option Nothing <$> (unName <$> genName)]
-                      Available.FreeInt -> [(StudentProvided,) . flip Available.Option Nothing <$> (show <$> genInt)]
-                      Available.FreeChar -> [(StudentProvided,) . flip Available.Option Nothing . T.singleton <$> genChar]
+                      Available.FreeVarName -> [(StudentProvided,) . (\t -> Available.Option t Nothing False) <$> (unName <$> genName)]
+                      Available.FreeInt -> [(StudentProvided,) . (\t -> Available.Option t Nothing False) <$> (show <$> genInt)]
+                      Available.FreeChar -> [(StudentProvided,) . (\t -> Available.Option t Nothing False) . T.singleton <$> genChar]
               case opts'' of
                 [] -> annotate "no options" >> success
                 options -> do
@@ -433,7 +433,7 @@ unit_sat_con_1 =
     Intermediate
     (emptyHole `ann` (tEmptyHole `tfun` tEmptyHole))
     (InExpr [Child1])
-    (Right (MakeCon, Option "Cons" $ Just $ unName <$> unModuleName builtinModuleName))
+    (Right (MakeCon, Option "Cons" (Just $ unName <$> unModuleName builtinModuleName) False))
     (hole (con cCons [emptyHole, emptyHole]) `ann` (tEmptyHole `tfun` tEmptyHole))
 
 unit_sat_con_2 :: Assertion
@@ -443,7 +443,7 @@ unit_sat_con_2 =
     Intermediate
     (emptyHole `ann` ((tcon tList `tapp` tcon tNat) `tfun` (tcon tList `tapp` tcon tNat)))
     (InExpr [Child1])
-    (Right (MakeCon, Option "Cons" $ Just $ unName <$> unModuleName builtinModuleName))
+    (Right (MakeCon, Option "Cons" (Just $ unName <$> unModuleName builtinModuleName) False))
     (hole (con cCons [emptyHole, emptyHole]) `ann` ((tcon tList `tapp` tcon tNat) `tfun` (tcon tList `tapp` tcon tNat)))
 
 -- The various @let@ constructs inherit the directionality of their body.
@@ -650,7 +650,7 @@ offeredNamesTest initial moves act name =
     Expert
     initial
     moves
-    (Right (act, Option name Nothing))
+    (Right (act, Option name Nothing False))
 
 -- Note that lambdas are the only form which we have interesting name info when
 -- we initially create them.

--- a/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
@@ -19,18 +19,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -43,10 +47,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -64,14 +70,17 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -91,14 +100,17 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -117,18 +129,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -140,14 +156,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -166,14 +185,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -193,14 +215,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -221,14 +246,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -247,14 +275,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -273,14 +304,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -292,10 +326,12 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -309,16 +345,19 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -348,14 +387,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -367,10 +409,12 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -384,16 +428,19 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -423,18 +470,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -453,18 +504,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -476,18 +531,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -506,14 +565,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -532,14 +594,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -559,14 +624,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -585,14 +653,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -611,14 +682,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -637,10 +711,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -652,10 +728,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -674,14 +752,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -700,14 +781,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -727,14 +811,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -747,11 +834,13 @@ Output
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -770,14 +859,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -797,14 +889,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -823,18 +918,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -851,14 +950,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -871,6 +973,7 @@ Output
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -883,6 +986,7 @@ Output
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -901,14 +1005,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -928,14 +1035,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -955,14 +1065,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -982,14 +1095,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1001,18 +1117,22 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1026,16 +1146,19 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1065,14 +1188,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1092,14 +1218,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1119,14 +1248,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1138,18 +1270,22 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1163,16 +1299,19 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1226,41 +1365,49 @@ Output
                                 { option = "Bool"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Either"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "List"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Maybe"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nat"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Pair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Char"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Int"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1488,41 +1635,49 @@ Output
                                 { option = "Bool"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Either"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "List"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Maybe"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nat"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Pair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Char"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Int"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone

--- a/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
@@ -19,18 +19,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -45,14 +49,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -65,10 +72,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -86,14 +95,17 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -108,14 +120,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -135,14 +150,17 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -156,14 +174,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -183,18 +204,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -208,14 +233,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -228,14 +256,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -254,14 +285,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -276,14 +310,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -303,14 +340,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -325,14 +365,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -353,14 +396,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -375,14 +421,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -401,14 +450,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -422,14 +474,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -449,14 +504,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -468,15 +526,18 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -490,56 +551,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -552,6 +624,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -575,14 +648,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -594,14 +670,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -615,14 +694,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -642,14 +724,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -661,15 +746,18 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -683,56 +771,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -745,6 +844,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -768,14 +868,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -787,14 +890,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -808,14 +914,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -835,18 +944,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -860,14 +973,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -887,18 +1003,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -912,14 +1032,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -932,18 +1055,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -962,14 +1089,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -983,14 +1113,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1003,14 +1136,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1029,14 +1165,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1051,14 +1190,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1078,14 +1220,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1099,14 +1244,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1126,14 +1274,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1147,14 +1298,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1174,14 +1328,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1195,14 +1352,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1215,14 +1375,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1241,10 +1404,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1258,14 +1423,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1278,10 +1446,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1300,14 +1470,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1321,14 +1494,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1348,14 +1524,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1370,14 +1549,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1397,14 +1579,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1417,11 +1602,13 @@ Output
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1435,14 +1622,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1462,14 +1652,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1484,14 +1677,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1511,14 +1707,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1532,14 +1731,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1559,18 +1761,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1587,14 +1793,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1607,6 +1816,7 @@ Output
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1619,6 +1829,7 @@ Output
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1632,14 +1843,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1659,14 +1873,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1681,14 +1898,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1708,14 +1928,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1730,14 +1953,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1757,14 +1983,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1779,14 +2008,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1806,14 +2038,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1825,23 +2060,28 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1855,56 +2095,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1917,6 +2168,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1940,14 +2192,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1959,14 +2214,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1980,14 +2238,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2007,14 +2268,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2029,14 +2293,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2056,14 +2323,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2078,14 +2348,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2105,14 +2378,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2124,23 +2400,28 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -2154,56 +2435,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -2216,6 +2508,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -2239,14 +2532,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2258,14 +2554,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2279,14 +2578,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2308,14 +2610,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2335,14 +2640,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2362,14 +2670,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2396,41 +2707,49 @@ Output
                                 { option = "Bool"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Either"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "List"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Maybe"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nat"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Pair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Char"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Int"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -2443,14 +2762,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2470,14 +2792,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2497,14 +2822,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2525,14 +2853,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2544,14 +2875,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2572,14 +2906,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2600,14 +2937,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2628,14 +2968,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2656,14 +2999,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2684,14 +3030,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2712,14 +3061,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2740,14 +3092,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2768,14 +3123,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2796,14 +3154,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2823,14 +3184,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2851,14 +3215,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2870,14 +3237,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2898,14 +3268,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2926,14 +3299,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2954,14 +3330,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -2982,14 +3361,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3010,14 +3392,17 @@ Output
                             [ Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "α1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3041,14 +3426,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3068,14 +3456,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3096,14 +3487,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3115,14 +3509,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3143,14 +3540,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3171,14 +3571,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3199,14 +3602,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3227,14 +3633,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3254,6 +3663,7 @@ Output
                             [ Option
                                 { option = "a"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -3266,41 +3676,49 @@ Output
                                 { option = "Bool"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Either"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "List"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Maybe"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nat"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Pair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Char"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Int"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -3313,14 +3731,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -3340,14 +3761,17 @@ Output
                             [ Option
                                 { option = "α"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "β"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "γ"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName

--- a/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
@@ -19,18 +19,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -44,10 +48,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -65,14 +71,17 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -93,14 +102,17 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -120,18 +132,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -144,14 +160,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -170,14 +189,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -198,14 +220,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -227,14 +252,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -254,14 +282,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -281,14 +312,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -300,15 +334,18 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -322,56 +359,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -384,6 +432,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -407,14 +456,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -426,14 +478,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -453,14 +508,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -472,15 +530,18 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -494,56 +555,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -556,6 +628,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -579,14 +652,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -598,14 +674,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -625,18 +704,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -656,18 +739,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -680,18 +767,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -710,14 +801,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -737,14 +831,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -765,14 +862,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -792,14 +892,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -819,14 +922,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -846,10 +952,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -862,10 +970,12 @@ Output
                             [ Option
                                 { option = "p"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "q"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -884,14 +994,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -911,14 +1024,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -939,14 +1055,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -959,11 +1078,13 @@ Output
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -983,14 +1104,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1011,14 +1135,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1038,18 +1165,22 @@ Output
                             [ Option
                                 { option = "j"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "m"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1066,14 +1197,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1086,6 +1220,7 @@ Output
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1098,6 +1233,7 @@ Output
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1117,14 +1253,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1145,14 +1284,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1173,14 +1315,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1201,14 +1346,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1220,23 +1368,28 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1250,56 +1403,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1312,6 +1476,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1335,14 +1500,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1354,14 +1522,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1381,14 +1552,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1409,14 +1583,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1437,14 +1614,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1456,23 +1636,28 @@ Output
                             [ Option
                                 { option = "x"
                                 , context = Nothing
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "y"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "i"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "n"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1486,56 +1671,67 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Left"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Right"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nil"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Cons"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nothing"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Just"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Zero"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Succ"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "MakePair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1548,6 +1744,7 @@ Output
                                 { option = "comprehensive"
                                 , context = Just
                                     ( "M" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1571,14 +1768,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1590,14 +1790,17 @@ Output
                             [ Option
                                 { option = "z"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "x1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "y1"
                                 , context = Nothing
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeVarName
@@ -1641,41 +1844,49 @@ Output
                                 { option = "Bool"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Either"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "List"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Maybe"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nat"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Pair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Char"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Int"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone
@@ -1903,41 +2114,49 @@ Output
                                 { option = "Bool"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Either"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "List"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Maybe"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Nat"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Pair"
                                 , context = Just
                                     ( "Builtins" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Char"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             , Option
                                 { option = "Int"
                                 , context = Just
                                     ( "Primitives" :| [] )
+                                , matchesType = False
                                 }
                             ]
                         , free = FreeNone


### PR DESCRIPTION
This is very much a proof-of-concept, but it works.

The corresponding changes in our frontend needed to make use of this are as simple as:
```
--- a/src/components/ActionPanel/index.tsx
+++ b/src/components/ActionPanel/index.tsx
@@ -102,7 +102,9 @@ export const ActionPanel = ({
                     <div className="mb-3 pt-2">
                       <ActionInput
                         sort={state.opts.free}
-                        onSubmit={(option) => onOption({ option })}
+                        onSubmit={(option) =>
+                          onOption({ option, matchesType: false })
+                        }
                       ></ActionInput>
                     </div>
                   )}
@@ -111,7 +113,9 @@ export const ActionPanel = ({
                       <li key={JSON.stringify(option)}>
                         <button
                           className={classNames(
-                            buttonClassesPrimary,
+                            option.matchesType
+                              ? buttonClassesSecondary
+                              : buttonClassesPrimary,
                             "w-full p-2 mt-2"
                           )}
                           onClick={(_) => onOption(option)}
```

This does make me wonder whether we should separate the type we use for notifying the client of which options are available, from the type we accept back from the client. Currently we use `Option` for both, but it doesn't make much sense really to expect the client to return a `matchesType` value, particularly for a freely-entered name as here. Similarly, the changes to tests here are mostly meaningless.