### PR TITLE
feat: add support for explicit CORS origins

### DIFF
--- a/nix/pkgs/scripts/primer-service-entrypoint.sh
+++ b/nix/pkgs/scripts/primer-service-entrypoint.sh
@@ -12,6 +12,17 @@ environment variables:
 
 - SQLITE_DB: A path to a SQLite database file.
 
+- CORS_ALLOW_ORIGIN: A comma-separated list of one or more CORS
+  origins to allow; e.g.,
+  "https://app.example.com,https://dev.example.com". Each origin in
+  the list must be formatted per RFC 6454. (Note that the service does
+  not use a validating parser, and may exhibit unexpected behavior if
+  one or more origins aren't correctly formatted.) The origins "*" and
+  "null" are not permitted. If this variable isn't set, then the
+  service will respond to CORS preflight requests with the wildcard
+  ("*") origin, which effectively precludes any possibility of using
+  the service behind an authenticating proxy.
+
 - SERVICE_PORT: A TCP port number on which the Primer service
   listens for HTTP connections. This variable is required.
 
@@ -90,7 +101,9 @@ else
     fi
 fi
 
-
+if [ -n "${CORS_ALLOW_ORIGIN+x}" ]; then
+    EXTRA_PRIMER_SERVICE_ARGS="$EXTRA_PRIMER_SERVICE_ARGS --cors-allow-origin $CORS_ALLOW_ORIGIN"
+fi
 
 # shellcheck disable=SC2086
 exec primer-service serve "$PRIMER_VERSION" --port "$SERVICE_PORT" $EXTRA_PRIMER_SERVICE_ARGS +RTS -T


### PR DESCRIPTION
With this change, we can now serve cross-origin requests for Primer
resources from behind an authentication proxy (or similar). Prior to
this change, we could not, because `Access-Control-Allow-Origin` was
always returned as `*`, and no legitimate browser will send
cross-origin cookies or auth-related headers in that case.

By default, the CORS behavior of `primer-service` is the same as
before:

* The server replies with `Access-Control-Allow-Origin: *`.

* The server does not set the `Vary: Origin` header.

* The server does not require that the client set the `Origin:`
header.

However, when `primer-service` is invoked with the
`--cors-allow-origin` flag (or the `CORS_ALLOW_ORIGIN` environment
variable is passed to the Docker container), the operator can now
specify explicit allowed origins, which will cause the browser to send
authentication cookies and auth-related headers when requests are
initiated from any such allowed origin (assuming that other
CORS-related requirements are met; e.g., same-site checks).

Additionally, when this new flag is used and explicit allowed origins
are specified:

* The server sets the `Vary: Origin` header, as recommended by
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#access-control-allow-origin

* The server requires that the client set the `Origin:` header, or
else it responds with HTTP status 400 and denies the request.

Future work could potentially include bypassing CORS checks on
publicly-available resources. Wai supports this, but we don't
currently take advantage of it: it's all or nothing.

Note that this change does *not* mean that our authentication
challenges are solved. The service doesn't perform any checks to
ensure that the provided authentication information from the client is
legitimate: that job is outsourced to an authentication proxy, or
similar service. Essentially all this change does is signal to
browsers that when requests are initiated from frontend applications
hosted on allowed origins, the browser should send authentication info
with each request to the backend service.

Signed-off-by: Drew Hess <src@drewhess.com>
