### PR TITLE
chore: change occurrences of "user" -> "student"

### DIFF
--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -602,7 +602,7 @@ data Name = Name
 
 -- | The contents of a node.
 data NodeBody
-  = -- | A "normal" node, usually with user-generated text, such as a variable or constructor name.
+  = -- | A "normal" node, usually with student-generated text, such as a variable or constructor name.
     TextBody (RecordPair Flavor.NodeFlavorTextBody Name)
   | -- | A node containing a value constructor inhabiting a primitive type.
     PrimBody (RecordPair Flavor.NodeFlavorPrimBody PrimCon)

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -415,7 +415,7 @@ newtype Log = Log {unlog :: [[ProgAction]]}
 defaultLog :: Log
 defaultLog = Log mempty
 
--- | Describes what interface element the user has selected.
+-- | Describes what interface element the student has selected.
 -- A definition in the left hand nav bar, and possibly a node in that definition.
 data Selection = Selection
   { selectedDef :: GVarName
@@ -1074,7 +1074,7 @@ replay = mapM_ handleEditRequest
 -- operations on the application.
 --
 -- Note we do not want @MonadFresh Name m@, as @fresh :: m Name@ has
--- no way of avoiding user-specified names. Instead, use 'freshName'.
+-- no way of avoiding student-specified names. Instead, use 'freshName'.
 type MonadEditApp l e m = (MonadLog (WithSeverity l) m, MonadEdit m e, MonadState App m)
 
 -- | A shorthand for constraints needed when doing low-level mutation

--- a/primer/src/Primer/Builtins.hs
+++ b/primer/src/Primer/Builtins.hs
@@ -1,5 +1,5 @@
 -- | This module defines some builtin types that are used to seed initial programs.
---   The definitions here are no different than ones than a user can create, except
+--   The definitions here are no different than ones than a student can create, except
 --   for the fact that some of the primitive functions (see "Primer.Primitives")
 --   refer to these types.
 module Primer.Builtins (

--- a/primer/src/Primer/Subst.hs
+++ b/primer/src/Primer/Subst.hs
@@ -27,7 +27,7 @@ substTySimul sub
     avoid = foldMap' freeVarsTy sub
     -- We must avoid this binder @m@ capturing a free variable in (some rhs of) @sub@
     -- (e.g. @substTy [a :-> T b] (∀b.b a)@ should give @∀c.c (T b)@, and not @∀b.b (T b)@)
-    -- The generated names will not enter the user's program, so we don't need to worry about shadowing, only variable capture
+    -- The generated names will not enter the student's program, so we don't need to worry about shadowing, only variable capture
     subUnderBinder m t = do
       let sub' = M.delete m sub
       (m', sub'') <-

--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -582,7 +582,7 @@ ensureJust _ (Just x) = x
 -- There is a hard-wired map 'primConName' which associates each PrimCon to
 -- its PrimTypeDef (by name -- PrimTypeDefs have hardwired names).
 -- However, these PrimTypeDefs may or may not be in the Cxt.
--- If they are not (and in that case, also if a user has defined some
+-- If they are not (and in that case, also if a student has defined some
 -- other type with the same name), we should reject the use of the
 -- primitive constructor.
 -- Essentially, PrimCons are always-in-scope terms whose type is one of

--- a/primer/src/Primer/Typecheck/TypeError.hs
+++ b/primer/src/Primer/Typecheck/TypeError.hs
@@ -23,7 +23,7 @@ data TypeError
     -- This error catches both under- and over-saturation.
     UnsaturatedConstructor ValConName
   | -- | Cannot use a PrimCon when either no type of the appropriate name is
-    -- in scope, or it is a user-defined type
+    -- in scope, or it is a student-defined type
     PrimitiveTypeNotInScope TyConName
   | CannotSynthesiseType Expr
   | InconsistentTypes (Type' ()) (Type' ())

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -258,7 +258,7 @@ tasty_available_actions_accepted = withTests 500 $
     propertyWT [] $ do
       l <- forAllT $ Gen.element enumerate
       cxt <- forAllT $ Gen.choice $ map sequence [[], [builtinModule], [builtinModule, pure primitiveModule]]
-      -- We only test SmartHoles mode (which is the only supported user-facing
+      -- We only test SmartHoles mode (which is the only supported student-facing
       -- mode - NoSmartHoles is only used for internal sanity testing etc)
       a <- forAllT $ genApp SmartHoles cxt
       let allDefs = progAllDefs $ appProg a


### PR DESCRIPTION
Per the terminology we've been using since the project's inception.
We've done a good job with this overall, we've just missed a
few. (Note that there are still a few occurrences of "user" in the
code base and project documentation, but those uses don't refer to
people who're using Primer, which is the use case we care about.)

Signed-off-by: Drew Hess <src@drewhess.com>
