### PR TITLE
fix: Offer action to make function application in beginner mode

### DIFF
--- a/primer/src/Primer/Action/Available.hs
+++ b/primer/src/Primer/Action/Available.hs
@@ -266,6 +266,7 @@ forExpr tydefs l expr =
     universalActions = case l of
       Beginner ->
         [ Input MakeLam
+        , NoInput MakeApp
         ]
       Intermediate ->
         [ Input MakeLam


### PR DESCRIPTION
@dhess just pointed out this surprising behaviour. But actually, it turns out the behaviour was intentional, in an effort to keep beginner mode _extremely_ simple: https://github.com/hackworthltd/vonnegut/pull/830:

> We remove "Apply function" and its smart/fully saturated variant actions from the list of actions available in beginner level. The assumption is that beginner lessons will focus on defining & using types, and defining functions using pattern matching, before the student moves on to function application and evaluation.