### PR TITLE
feat: optionally do not evaluate under binders (except lets)

### DIFF
--- a/primer-api/src/Primer/API.hs
+++ b/primer-api/src/Primer/API.hs
@@ -226,7 +226,7 @@ import Primer.Def (
   defAST,
  )
 import Primer.Def qualified as Def
-import Primer.Eval (NormalOrderOptions (UnderBinders))
+import Primer.Eval (NormalOrderOptions (StopAtBinders))
 import Primer.Eval.Redex (Dir (Chk), EvalLog)
 import Primer.EvalFull (TerminationBound)
 import Primer.JSON (
@@ -1142,7 +1142,7 @@ evalFull' = curry4 $ logAPI (noError EvalFull') $ \(sid, lim, closed, d) ->
             { evalFullReqExpr = e
             , evalFullCxtDir = Chk
             , evalFullMaxSteps = fromMaybe 10 lim
-            , evalFullOptions = fromMaybe UnderBinders closed
+            , evalFullOptions = fromMaybe StopAtBinders closed
             }
       pure $ case x of
         App.EvalFullRespTimedOut e' -> EvalFullRespTimedOut $ viewTreeExpr e'

--- a/primer-api/src/Primer/API.hs
+++ b/primer-api/src/Primer/API.hs
@@ -226,6 +226,7 @@ import Primer.Def (
   defAST,
  )
 import Primer.Def qualified as Def
+import Primer.Eval (NormalOrderOptions (UnderBinders))
 import Primer.Eval.Redex (Dir (Chk), EvalLog)
 import Primer.EvalFull (TerminationBound)
 import Primer.JSON (
@@ -412,7 +413,7 @@ data APILog
   | GenerateNames (ReqResp (SessionId, ((GVarName, ID), Either (Maybe (Type' ())) (Maybe (Kind' ())))) (Either ProgError [Name.Name]))
   | EvalStep (ReqResp (SessionId, EvalReq) (Either ProgError EvalResp))
   | EvalFull (ReqResp (SessionId, EvalFullReq) (Either ProgError App.EvalFullResp))
-  | EvalFull' (ReqResp (SessionId, Maybe TerminationBound, GVarName) EvalFullResp)
+  | EvalFull' (ReqResp (SessionId, Maybe TerminationBound, Maybe NormalOrderOptions, GVarName) EvalFullResp)
   | FlushSessions (ReqResp () ())
   | CreateDef (ReqResp (SessionId, ModuleName, Maybe Text) Prog)
   | CreateTypeDef (ReqResp (SessionId, TyConName, [ValConName]) Prog)
@@ -1117,16 +1118,18 @@ evalFull' ::
   (MonadIO m, MonadThrow m, MonadAPILog l m, ConvertLogMessage EvalLog l) =>
   SessionId ->
   Maybe TerminationBound ->
+  Maybe NormalOrderOptions ->
   GVarName ->
   PrimerM m EvalFullResp
-evalFull' = curry3 $ logAPI (noError EvalFull') $ \(sid, lim, d) ->
-  noErr <$> liftQueryAppM (q lim d) sid
+evalFull' = curry4 $ logAPI (noError EvalFull') $ \(sid, lim, closed, d) ->
+  noErr <$> liftQueryAppM (q lim closed d) sid
   where
     q ::
       Maybe TerminationBound ->
+      Maybe NormalOrderOptions ->
       GVarName ->
       QueryAppM (PureLog (WithSeverity l)) Void EvalFullResp
-    q lim d = do
+    q lim closed d = do
       -- We don't care about uniqueness of this ID, and we do not want to
       -- disturb any FreshID state, since that could break undo/redo.
       -- The reason we don't care about uniqueness is that this node will never
@@ -1139,6 +1142,7 @@ evalFull' = curry3 $ logAPI (noError EvalFull') $ \(sid, lim, d) ->
             { evalFullReqExpr = e
             , evalFullCxtDir = Chk
             , evalFullMaxSteps = fromMaybe 10 lim
+            , evalFullOptions = fromMaybe UnderBinders closed
             }
       pure $ case x of
         App.EvalFullRespTimedOut e' -> EvalFullRespTimedOut $ viewTreeExpr e'

--- a/primer-api/test/Tests/API.hs
+++ b/primer-api/test/Tests/API.hs
@@ -48,6 +48,7 @@ import Primer.Database (
   fromSessionName,
  )
 import Primer.Def (astDefExpr, astDefType, defAST)
+import Primer.Eval (NormalOrderOptions (UnderBinders))
 import Primer.Examples (
   comprehensive,
   even3App,
@@ -462,7 +463,7 @@ test_eval_undo =
       sid <- newSession $ NewSessionReq "a new session" True
       let scope = mkSimpleModuleName "Main"
       step "eval"
-      void $ evalFull' sid (Just 100) $ qualifyName scope "main"
+      void $ evalFull' sid (Just 100) (Just UnderBinders) $ qualifyName scope "main"
       step "insert λ"
       let getMain = do
             p <- getProgram sid

--- a/primer-benchmark/src/Benchmarks.hs
+++ b/primer-benchmark/src/Benchmarks.hs
@@ -21,6 +21,7 @@ import Primer.App (
  )
 import Primer.App.Utils (forgetProgTypecache)
 import Primer.Eval (
+  NormalOrderOptions (UnderBinders),
   RunRedexOptions (RunRedexOptions, pushAndElide),
   ViewRedexOptions (ViewRedexOptions, aggressiveElision, groupedLets),
  )
@@ -102,16 +103,17 @@ benchmarks =
       ]
   ]
   where
+    evalOptionsN = UnderBinders
     evalOptionsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
     evalOptionsR = RunRedexOptions{pushAndElide = True}
     evalTestMPureLogs e maxEvals =
       evalTestM (maxID e) $
         runPureLogT $
-          evalFull @EvalLog evalOptionsV evalOptionsR builtinTypes (defMap e) maxEvals Syn (expr e)
+          evalFull @EvalLog evalOptionsN evalOptionsV evalOptionsR builtinTypes (defMap e) maxEvals Syn (expr e)
     evalTestMDiscardLogs e maxEvals =
       evalTestM (maxID e) $
         runDiscardLogT $
-          evalFull @EvalLog evalOptionsV evalOptionsR builtinTypes (defMap e) maxEvals Syn (expr e)
+          evalFull @EvalLog evalOptionsN evalOptionsV evalOptionsR builtinTypes (defMap e) maxEvals Syn (expr e)
 
     benchExpected f g e n b = EnvBench e n $ \e' ->
       NF

--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -82,6 +82,7 @@ import Primer.Database (
   Session,
   SessionName,
  )
+import Primer.Eval (NormalOrderOptions)
 import Primer.JSON (CustomJSON (CustomJSON), PrimerJSON)
 import Primer.Name (Name)
 import Servant.API (FromHttpApiData (parseQueryParam), ToHttpApiData (toQueryParam))
@@ -197,6 +198,11 @@ deriving anyclass instance ToParamSchema Level
 instance FromHttpApiData Level where
   parseQueryParam = parseQueryParamRead "level"
 instance ToHttpApiData Level where
+  toQueryParam = show
+deriving anyclass instance ToParamSchema NormalOrderOptions
+instance FromHttpApiData NormalOrderOptions where
+  parseQueryParam = parseQueryParamRead "NormalOrderOptions"
+instance ToHttpApiData NormalOrderOptions where
   toQueryParam = show
 parseQueryParamRead :: Read a => Text -> Text -> Either Text a
 parseQueryParamRead m t = maybeToEither ("unknown " <> m <> ": " <> t) $ readMaybe t

--- a/primer-service/src/Primer/Servant/OpenAPI.hs
+++ b/primer-service/src/Primer/Servant/OpenAPI.hs
@@ -23,6 +23,7 @@ import Primer.Core (GVarName, ModuleName)
 import Primer.Database (
   SessionId,
  )
+import Primer.Eval (NormalOrderOptions)
 import Primer.Finite (Finite)
 import Primer.JSON (CustomJSON (CustomJSON), FromJSON, PrimerJSON, ToJSON)
 import Primer.OpenAPI ()
@@ -124,6 +125,7 @@ data SessionAPI mode = SessionAPI
           :> Summary "Evaluate the named definition to normal form (or time out)"
           :> OperationId "eval-full"
           :> QueryParam "stepLimit" (Finite 0 EvalFullStepLimit)
+          :> QueryParam "closed" NormalOrderOptions
           :> ReqBody '[JSON] GVarName
           :> Post '[JSON] EvalFullResp
   , undo ::

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -1493,7 +1493,8 @@
                         "required": false,
                         "schema": {
                             "enum": [
-                                "UnderBinders"
+                                "UnderBinders",
+                                "StopAtBinders"
                             ],
                             "type": "string"
                         }

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -1486,6 +1486,17 @@
                             "minimum": 0,
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "closed",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "UnderBinders"
+                            ],
+                            "type": "string"
+                        }
                     }
                 ],
                 "requestBody": {
@@ -1509,7 +1520,7 @@
                         "description": ""
                     },
                     "400": {
-                        "description": "Invalid `body` or `stepLimit`"
+                        "description": "Invalid `body` or `closed` or `stepLimit`"
                     },
                     "404": {
                         "description": "`sessionId` not found"

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -486,6 +486,7 @@ data EvalFullReq = EvalFullReq
   { evalFullReqExpr :: Expr
   , evalFullCxtDir :: Dir -- is this expression in a syn/chk context, so we can tell if is an embedding.
   , evalFullMaxSteps :: TerminationBound
+  , evalFullOptions :: Eval.NormalOrderOptions
   }
   deriving stock (Eq, Show, Read, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON EvalFullReq
@@ -594,12 +595,12 @@ handleEvalFullRequest ::
   (MonadQueryApp m e, MonadLog (WithSeverity l) m, ConvertLogMessage EvalLog l) =>
   EvalFullReq ->
   m EvalFullResp
-handleEvalFullRequest (EvalFullReq{evalFullReqExpr, evalFullCxtDir, evalFullMaxSteps}) = do
+handleEvalFullRequest (EvalFullReq{evalFullReqExpr, evalFullCxtDir, evalFullMaxSteps, evalFullOptions}) = do
   app <- ask
   let prog = appProg app
   let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
   let optsR = RunRedexOptions{pushAndElide = True}
-  result <- runFreshM app $ evalFull optsV optsR (allTypes prog) (allDefs prog) evalFullMaxSteps evalFullCxtDir evalFullReqExpr
+  result <- runFreshM app $ evalFull evalFullOptions optsV optsR (allTypes prog) (allDefs prog) evalFullMaxSteps evalFullCxtDir evalFullReqExpr
   pure $ case result of
     Left (TimedOut e) -> EvalFullRespTimedOut e
     Right nf -> EvalFullRespNormal nf

--- a/primer/test/Tests/Eval/Utils.hs
+++ b/primer/test/Tests/Eval/Utils.hs
@@ -4,6 +4,7 @@ module Tests.Eval.Utils (
   genDirTm,
   testModules,
   hasTypeLets,
+  hasHoles,
 ) where
 
 import Foreword
@@ -15,12 +16,12 @@ import Hedgehog (PropertyT)
 import Hedgehog.Gen qualified as Gen
 import Primer.Core (
   Expr,
-  Expr' (LetType),
+  Expr' (EmptyHole, Hole, LetType),
   ID,
   Kind' (KType),
   ModuleName (ModuleName),
   Type,
-  Type' (TLet),
+  Type' (TEmptyHole, THole, TLet),
  )
 import Primer.Core.DSL (create', lam, lvar, tcon, tfun)
 import Primer.Core.Utils (forgetMetadata, forgetTypeMetadata, generateIDs)
@@ -98,3 +99,12 @@ hasTypeLets e =
   not $
     null [() | LetType{} <- universe e]
       && null [() | TLet{} <- universeBi @_ @Type e]
+
+-- | Does this expression have any holes?
+hasHoles :: Expr -> Bool
+hasHoles e =
+  not $
+    null [() | Hole{} <- universe e]
+      && null [() | EmptyHole{} <- universe e]
+      && null [() | THole{} <- universeBi @_ @Type e]
+      && null [() | TEmptyHole{} <- universeBi @_ @Type e]

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -42,6 +42,7 @@ import Primer.Core.DSL
 import Primer.Core.Utils (
   exprIDs,
   forgetMetadata,
+  generateIDs,
  )
 import Primer.Def (DefMap)
 import Primer.Eval
@@ -51,7 +52,7 @@ import Primer.Examples qualified as Examples (
   map',
   odd,
  )
-import Primer.Gen.Core.Typed (WT, forAllT, isolateWT, propertyWT)
+import Primer.Gen.Core.Typed (WT, forAllT, genChk, isolateWT, propertyWT)
 import Primer.Log (runPureLogT)
 import Primer.Module (
   Module (Module, moduleDefs, moduleName, moduleTypes),
@@ -120,7 +121,7 @@ import Tasty (
  )
 import Test.Tasty.HUnit (Assertion, assertBool, assertFailure, (@?=))
 import Tests.Action.Prog (readerToState)
-import Tests.Eval.Utils (genDirTm, hasTypeLets, testModules, (~=))
+import Tests.Eval.Utils (genDirTm, hasHoles, hasTypeLets, testModules, (~=))
 import Tests.Gen.Core.Typed (checkTest)
 import Tests.Typecheck (runTypecheckTestM, runTypecheckTestMWithPrims)
 
@@ -566,6 +567,235 @@ unit_tlet_self_capture = do
         r <~==> expect
    in mapM_ test (zip [0 ..] expected)
 
+-- When doing closed eval (i.e. don't go under binders), pushing a @let@
+-- through a binder is not considered to be "under" that binder, else
+-- @(let x=t1 in λy.t2 : S -> T) t3@ would be stuck.
+unit_closed_let_beta :: Assertion
+unit_closed_let_beta =
+  let ((expr, expected), maxID) = create $ do
+        e0 <-
+          let_
+            "x"
+            (con0 cFalse `ann` tcon tBool)
+            ( lam "y" (con cCons [lvar "x", lvar "y"])
+                `ann` (tcon tBool `tfun` (tcon tList `tapp` tcon tBool))
+            )
+            `app` con0 cTrue
+        e1 <-
+          let_
+            "x"
+            (con0 cFalse `ann` tcon tBool)
+            ( lam
+                "y"
+                (con cCons [lvar "x", lvar "y"])
+            )
+            `ann` (tcon tBool `tfun` (tcon tList `tapp` tcon tBool))
+            `app` con0 cTrue
+        e2 <-
+          lam
+            "y"
+            ( let_
+                "x"
+                (con0 cFalse `ann` tcon tBool)
+                (con cCons [lvar "x", lvar "y"])
+            )
+            `ann` (tcon tBool `tfun` (tcon tList `tapp` tcon tBool))
+            `app` con0 cTrue
+        e3 <-
+          let_
+            "y"
+            (con0 cTrue `ann` tcon tBool)
+            ( let_
+                "x"
+                (con0 cFalse `ann` tcon tBool)
+                (con cCons [lvar "x", lvar "y"])
+            )
+            `ann` (tcon tList `tapp` tcon tBool)
+        e4 <-
+          con
+            cCons
+            [ let_
+                "x"
+                (con0 cFalse `ann` tcon tBool)
+                (lvar "x")
+            , let_
+                "y"
+                (con0 cTrue `ann` tcon tBool)
+                (lvar "y")
+            ]
+            `ann` (tcon tList `tapp` tcon tBool)
+        e5 <-
+          con
+            cCons
+            [ con0 cFalse `ann` tcon tBool
+            , let_
+                "y"
+                (con0 cTrue `ann` tcon tBool)
+                (lvar "y")
+            ]
+            `ann` (tcon tList `tapp` tcon tBool)
+        e6 <-
+          con
+            cCons
+            [ con0 cFalse
+            , let_
+                "y"
+                (con0 cTrue `ann` tcon tBool)
+                (lvar "y")
+            ]
+            `ann` (tcon tList `tapp` tcon tBool)
+        e7 <-
+          con
+            cCons
+            [ con0 cFalse
+            , con0 cTrue `ann` tcon tBool
+            ]
+            `ann` (tcon tList `tapp` tcon tBool)
+        e8 <-
+          con
+            cCons
+            [ con0 cFalse
+            , con0 cTrue
+            ]
+            `ann` (tcon tList `tapp` tcon tBool)
+        pure (e0, map (Left . TimedOut) [e0, e1, e2, e3, e4, e5, e6, e7, e8] ++ [Right e8])
+      test (n, expect) = do
+        r <- evalFullTestClosed GroupedLets maxID mempty mempty n Syn expr
+        r <~==> expect
+   in mapM_ test (zip [0 ..] expected)
+
+-- Closed eval and handling groups of @let@s singlely work together
+unit_closed_single_lets :: Assertion
+unit_closed_single_lets =
+  let ((expr, expected), maxID) = create $ do
+        e0 <-
+          let_ "x" (con0 cFalse) $
+            let_ "y" (con0 cTrue) $
+              con
+                cMakePair
+                [ lvar "x"
+                , lvar "y"
+                ]
+        e1 <-
+          let_ "x" (con0 cFalse) $
+            con
+              cMakePair
+              [ lvar "x"
+              , let_ "y" (con0 cTrue) $ lvar "y"
+              ]
+        e2 <-
+          con
+            cMakePair
+            [ let_ "x" (con0 cFalse) $ lvar "x"
+            , let_ "y" (con0 cTrue) $ lvar "y"
+            ]
+        e3 <-
+          con
+            cMakePair
+            [ con0 cFalse
+            , let_ "y" (con0 cTrue) $ lvar "y"
+            ]
+        e4 <-
+          con
+            cMakePair
+            [ con0 cFalse
+            , con0 cTrue
+            ]
+        pure (e0, map (Left . TimedOut) [e0, e1, e2, e3, e4] ++ [Right e4])
+      test (n, expect) = do
+        r <- evalFullTestClosed SingleLets maxID mempty mempty n Syn expr
+        r <~==> expect
+   in mapM_ test (zip [0 ..] expected)
+
+-- One reason for not evaluating under binders is to avoid a size blowup when
+-- evaluating a recursive definition. For example, the unsaturated
+-- `map @Bool @Bool not` would keep unrolling the recursive mentions of `map`.
+-- (If it were applied to a concrete list, the beta redexes would be reduced instead.)
+-- Since top-level definitions and recursive lets are essentially the same, one may
+-- worry that we have the same issue with @letrec@. This test shows that closed eval
+-- handles that case also.
+unit_closed_letrec_binder :: Assertion
+unit_closed_letrec_binder =
+  let ((expr, expected), maxID) = create $ do
+        e0 <-
+          letrec "x" (list_ [lvar "x", lvar "x"]) (tcon tBool) $
+            lam "y" $
+              lvar "x"
+        e1 <-
+          lam "y" $
+            letrec "x" (list_ [lvar "x", lvar "x"]) (tcon tBool) $
+              lvar "x"
+        pure (e0, map (Left . TimedOut) [e0, e1] ++ [Right e1])
+      test (n, expect) = do
+        r <- evalFullTestClosed GroupedLets maxID mempty mempty n Syn expr
+        r <~==> expect
+   in mapM_ test (zip [0 ..] expected)
+
+-- closed eval stops at binders
+unit_closed_binders :: Assertion
+unit_closed_binders = do
+  let isNormalIffClosed e = do
+        let (e', i) = create e
+        evalFullTestClosed GroupedLets i mempty mempty 1 Syn e' >>= \case
+          Left (TimedOut _) -> assertFailure $ "not normal form, for closed eval, grouped lets: " <> show e'
+          Right _ -> pure ()
+        evalFullTestClosed SingleLets i mempty mempty 1 Syn e' >>= \case
+          Left (TimedOut _) -> assertFailure $ "not normal form, for closed eval, single lets: " <> show e'
+          Right _ -> pure ()
+        evalFullTest i mempty mempty 1 Syn e' >>= \case
+          Left (TimedOut _) -> pure ()
+          Right _ -> assertFailure $ "unexpectedly a normal form, for open eval: " <> show e'
+      r = let_ "x" emptyHole $ lvar "x"
+  isNormalIffClosed $ lam "x" r
+  isNormalIffClosed $ lAM "a" r
+  isNormalIffClosed $ case_ emptyHole [branch cTrue [("x", Nothing)] r]
+  -- For consistency, we also do not reduce inside case branches even if they do not bind
+  isNormalIffClosed $ case_ emptyHole [branch cTrue [] r]
+
+-- closed eval still pushes lets through binders
+unit_closed_subst :: Assertion
+unit_closed_subst = do
+  let isReducible e = do
+        let (e', i) = create e
+        evalFullTestClosed GroupedLets i mempty mempty 1 Syn e' >>= \case
+          Left (TimedOut _) -> pure ()
+          Right _ -> assertFailure $ "unexpectedly a normal form: " <> show e'
+      l = let_ "x" emptyHole
+      v = lvar "x"
+  isReducible $ l $ lam "y" v
+  isReducible $ l $ lAM "a" v
+  isReducible $ l $ case_ emptyHole [branch cTrue [("x", Nothing)] v]
+  isReducible $ l $ case_ emptyHole [branch cTrue [] v]
+
+-- For (closed, hole free) terms of base types, open and closed evaluation
+-- agree.  We require hole-free-ness, as holes create stuck terms similar to
+-- free variables. Note that we get the same reduction sequence, not only that
+-- they reduce to the same value.
+tasty_open_closed_agree_base_types :: Property
+tasty_open_closed_agree_base_types = withDiscards 1000 $
+  propertyWT testModules $ do
+    let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+    let optsR = RunRedexOptions{pushAndElide = True}
+    ty <- forAllT $ Gen.element @[] [tBool, tNat, tInt]
+    tm' <- forAllT $ genChk $ TCon () ty
+    tm <- generateIDs tm'
+    when (hasHoles tm) discard
+    tds <- asks typeDefs
+    let globs = foldMap' moduleDefsQualified $ create' $ sequence testModules
+    let reductionSequence closed expr n =
+          (expr :)
+            <$> if n <= (0 :: Integer)
+              then pure []
+              else
+                evalFull @EvalLog closed optsV optsR tds globs 1 Chk expr >>= \case
+                  Left (TimedOut expr') -> reductionSequence closed expr' (n - 1)
+                  Right _ -> pure []
+    (openSeq, openLogs) <- lift $ isolateWT $ runPureLogT $ reductionSequence UnderBinders tm 100
+    testNoSevereLogs openLogs
+    (closedSeq, closedLogs) <- lift $ isolateWT $ runPureLogT $ reductionSequence StopAtBinders tm 100
+    testNoSevereLogs closedLogs
+    openSeq === closedSeq
+
 -- TODO: examples with holes
 
 -- TODO: most of these property tests could benefit from generating an
@@ -588,7 +818,7 @@ resumeTest mods dir t = do
   let globs = foldMap' moduleDefsQualified mods
   tds <- asks typeDefs
   n <- forAllT $ Gen.integral $ Range.linear 2 1000 -- Arbitrary limit here
-  closed <- forAllT $ Gen.element @[] [UnderBinders]
+  closed <- forAllT $ Gen.frequency [(10, pure UnderBinders), (1, pure StopAtBinders)]
   -- NB: We need to run this first reduction in an isolated context
   -- as we need to avoid it changing the fresh-name-generator state
   -- for the next run (sMid and sTotal). This is because reduction may need
@@ -1016,7 +1246,7 @@ tasty_type_preservation = withTests 1000 $
                 s' <- checkTest ty s
                 forgetMetadata s === forgetMetadata s' -- check no smart holes happened
       maxSteps <- forAllT $ Gen.integral $ Range.linear 1 1000 -- Arbitrary limit here
-      closed <- forAllT $ Gen.element @[] [UnderBinders]
+      closed <- forAllT $ Gen.frequency [(10, pure UnderBinders), (1, pure StopAtBinders)]
       (steps, s) <- failWhenSevereLogs $ evalFullStepCount @EvalLog closed optsV optsR tds globs maxSteps dir t
       annotateShow steps
       annotateShow s
@@ -1543,7 +1773,7 @@ tasty_unique_ids = withTests 1000 $
       let globs = foldMap' moduleDefsQualified $ create' $ sequence testModules
       tds <- asks typeDefs
       (dir, t1, _) <- genDirTm
-      closed <- forAllT $ Gen.element @[] [UnderBinders]
+      closed <- forAllT $ Gen.frequency [(10, pure UnderBinders), (1, pure StopAtBinders)]
       let go n t
             | n == (0 :: Int) = pure ()
             | otherwise = do
@@ -1633,6 +1863,21 @@ evalFullTestExactSteps id_ tydefs globals n d e = do
       case t of
         Left t' -> assertFailure $ "Unexpected timeout: " <> show t'
         Right t' -> pure t'
+
+data GroupedLets = GroupedLets | SingleLets
+
+evalFullTestClosed :: GroupedLets -> ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> IO (Either EvalFullError Expr)
+evalFullTestClosed gl id_ tydefs globals n d e = do
+  let optsN = StopAtBinders
+  let gl' = case gl of
+        GroupedLets -> True
+        SingleLets -> False
+  let optsV = ViewRedexOptions{groupedLets = gl', aggressiveElision = True}
+  let optsR = RunRedexOptions{pushAndElide = True}
+  let (r, logs) = evalTestM id_ $ runPureLogT $ evalFull @EvalLog optsN optsV optsR tydefs globals n d e
+  assertNoSevereLogs logs
+  distinctIDs r
+  pure r
 
 evalFullTasty :: MonadTest m => ID -> TypeDefMap -> DefMap -> TerminationBound -> Dir -> Expr -> m (Either EvalFullError Expr)
 evalFullTasty id_ tydefs globals n d e = do

--- a/primer/test/Tests/Prelude/Utils.hs
+++ b/primer/test/Tests/Prelude/Utils.hs
@@ -8,6 +8,7 @@ import Optics (over)
 import Primer.Core (Expr, GVarName, Type)
 import Primer.Core.DSL (apps', create', gvar)
 import Primer.Eval (
+  NormalOrderOptions (UnderBinders),
   RunRedexOptions (RunRedexOptions, pushAndElide),
   ViewRedexOptions (ViewRedexOptions, aggressiveElision, groupedLets),
  )
@@ -53,11 +54,12 @@ functionOutput f args = functionOutput' f (map Left args)
 -- Tests a prelude function with a combination of Expr/Type arguments to be applied
 functionOutput' :: GVarName -> [Either (TestM Expr) (TestM Type)] -> TerminationBound -> Either EvalFullError Expr
 functionOutput' f args depth =
-  let optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
+  let optsN = UnderBinders
+      optsV = ViewRedexOptions{groupedLets = True, aggressiveElision = True}
       optsR = RunRedexOptions{pushAndElide = True}
       (r, logs) = evalTestM 0 $ runPureLogT $ do
         e <- apps' (gvar f) $ bimap lift lift <$> args
-        evalFull @EvalLog optsV optsR ty def n d e
+        evalFull @EvalLog optsN optsV optsR ty def n d e
       severe = Seq.filter isSevereLog logs
    in if null severe
         then r

--- a/primer/test/Tests/Undo.hs
+++ b/primer/test/Tests/Undo.hs
@@ -24,7 +24,7 @@ import Primer.Core (
   qualifyName,
  )
 import Primer.Def (astDefExpr, defAST)
-import Primer.Eval (Dir (Syn))
+import Primer.Eval (Dir (Syn), NormalOrderOptions (UnderBinders))
 import Primer.Module (
   moduleDefsQualified,
   moduleName,
@@ -73,6 +73,7 @@ unit_redo_eval =
               { App.evalFullReqExpr = Var (Meta 0 Nothing Nothing) (GlobalVarRef $ qualifyName scope "main")
               , App.evalFullCxtDir = Syn
               , App.evalFullMaxSteps = 10
+              , App.evalFullOptions = UnderBinders
               }
       edit1 = handleEditRequest action1
       edit2 = handleEditRequest . action2


### PR DESCRIPTION
This change means our EvalFull is "closed evaluation", rather than "open evaluation". The main reason to do this is so that evaluations of programs-in-construction (especially recursive ones) do not pointlessly blow up in size: if `even` and `odd` are defined recursively, then evaluating `even`  would evaluate under the lambda and inside case branches, expanding `odd` and recursing; when it eventually times out one would have a big tree with many unrolled copies of `even` and `odd`, which is not very illuminating. 

Note that we do not evaluate in the RHS of pattern match branches which bind variables, for the same reason as we do not evaluate under lambdas; for consistency we also do not evaluate in the RHS of branches which do not bind variables.