### PR TITLE
fix: change `getTypeOrKind` OpenAPI endpoint from `GET` to `POST`

### DIFF
--- a/primer-service/src/Primer/Servant/OpenAPI.hs
+++ b/primer-service/src/Primer/Servant/OpenAPI.hs
@@ -104,7 +104,7 @@ data SessionAPI mode = SessionAPI
           :> Summary "Get the type/kind of a particular node"
           :> OperationId "getTypeOrKind"
           :> ReqBody '[JSON] Selection
-          :> Get '[JSON] TypeOrKind
+          :> Post '[JSON] TypeOrKind
   , createDefinition ::
       mode
         :- "def"

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -1618,7 +1618,7 @@
             }
         },
         "/openapi/sessions/{sessionId}/selection": {
-            "get": {
+            "post": {
                 "operationId": "getTypeOrKind",
                 "parameters": [
                     {


### PR DESCRIPTION
Though this method is technically a `GET`, we've found that OpenAPI
clients often don't support complex bodies in `GET` methods, and this
one requires that we pass a `Selection`. So, just as with the
`getAvailableActions` OpenAPI endpoint, we make `getTypeOrKind` a faux
`POST`.

Signed-off-by: Drew Hess <src@drewhess.com>
