### PR TITLE
fix: Output checked type in `getSelectionTypeOrKind` if none is synthed

### DIFF
--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -97,7 +97,7 @@ import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Zip (MonadZip)
 import Data.Map qualified as Map
 import Data.Tuple.Extra (curry3)
-import Optics (ifoldr, over, preview, to, traverseOf, view, (%), (^.), _Just)
+import Optics (afailing, ifoldr, over, preview, to, traverseOf, view, (%), (^.), _Just)
 import Primer.API.NodeFlavor qualified as Flavor
 import Primer.API.RecordPair (RecordPair (RecordPair))
 import Primer.Action (ActionError, ProgAction, toProgActionInput, toProgActionNoInput)
@@ -168,6 +168,7 @@ import Primer.Core (
   unLocalName,
   unsafeMkLocalName,
   _bindMeta,
+  _chkedAt,
   _exprMetaLens,
   _synthed,
   _type,
@@ -1326,7 +1327,7 @@ getSelectionTypeOrKind = curry $ logAPI (noError GetTypeOrKind) $ \(sid, sel0) -
     viewExprType :: ExprMeta -> TypeOrKind
     viewExprType = Type . fromMaybe trivialTree . viewExprType'
     viewExprType' :: ExprMeta -> Maybe Tree
-    viewExprType' = preview $ _type % _Just % _synthed % to (viewTreeType' . mkIds)
+    viewExprType' = preview $ _type % _Just % (_synthed `afailing` _chkedAt) % to (viewTreeType' . mkIds)
     -- We prefix ids to keep them unique from other ids in the emitted program
     mkIds :: Type' () -> Type' Text
     mkIds = over _typeMeta (("seltype-" <>) . show . getID) . create' . generateTypeIDs


### PR DESCRIPTION
This fixes an issue when using this functionality in our frontend to display the type of the currently-selected node: the fallback `trivialTree` was displayed for nodes in checkable positions (lambdas, constructors).

@brprice would be better placed than I am to explain why we originally ignored this part of the typecache in #1050, or whether this is quite the right approach. But in his absence, and with the Zurihac push, I'd suggest we merge this anyway. I doubt there are any serious downsides.