### PR TITLE
feat!: support creating new sessions without importing the Prelude

### DIFF
--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -374,6 +374,6 @@ instance Arbitrary EvalFullResp where
 instance Arbitrary CreateTypeDefBody where
   arbitrary = CreateTypeDefBody <$> arbitrary <*> arbitrary <*> arbitrary
 instance Arbitrary NewSessionReq where
-  arbitrary = NewSessionReq <$> arbitrary
+  arbitrary = NewSessionReq <$> arbitrary <*> arbitrary
 instance Arbitrary TypeOrKind where
   arbitrary = hedgehog $ G.choice [Type <$> genTree, Kind <$> genTree]

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -282,12 +282,16 @@
             },
             "NewSessionReq": {
                 "properties": {
+                    "importPrelude": {
+                        "type": "boolean"
+                    },
                     "name": {
                         "type": "string"
                     }
                 },
                 "required": [
-                    "name"
+                    "name",
+                    "importPrelude"
                 ],
                 "type": "object"
             },

--- a/primer/src/Primer/API.hs
+++ b/primer/src/Primer/API.hs
@@ -127,6 +127,7 @@ import Primer.App (
   handleMutationRequest,
   handleQuestion,
   newApp,
+  newEmptyApp,
   progAllDefs,
   progAllTypeDefs,
   progAllTypeDefsMeta,
@@ -445,6 +446,9 @@ data NewSessionReq = NewSessionReq
   -- ^ The name of the new session. Note that this field is just a
   -- hint: the API may choose a different name if the given name is
   -- invalid.
+  , importPrelude :: Bool
+  -- ^ If 'True', the new session will import the entire Prelude
+  -- automatically.
   }
   deriving stock (Show, Read, Eq, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON NewSessionReq
@@ -458,7 +462,9 @@ data NewSessionReq = NewSessionReq
 -- when this occurs. Query the returned session ID to determine the
 -- actual session name that was assigned.
 newSession :: (MonadIO m, MonadAPILog l m) => NewSessionReq -> PrimerM m SessionId
-newSession = logAPI (noError NewSession) $ \(NewSessionReq n) -> addSession n newApp
+newSession = logAPI (noError NewSession) $ \(NewSessionReq n p) -> addSession n $ app p
+  where
+    app p = if p then newApp else newEmptyApp
 
 -- | Given an 'App' and a proposed session name as 'Text', create a
 -- new session with the given app and name, and return the session ID.

--- a/primer/test/Tests/API.hs
+++ b/primer/test/Tests/API.hs
@@ -171,7 +171,7 @@ test_newSession_roundtrip =
     runAPI $ do
       let step = liftIO . step'
       step "Create a new session"
-      sid <- newSession $ NewSessionReq "new session"
+      sid <- newSession $ NewSessionReq "new session" True
       step "Get its name"
       name <- getSessionName sid
       name @?= "new session"
@@ -190,7 +190,7 @@ test_newSession_duplicate_names =
     runAPI $ do
       let step = liftIO . step'
       let sessionName = "my new session"
-      let newSessionReq = NewSessionReq sessionName
+      let newSessionReq = NewSessionReq sessionName True
       step "Create a new session"
       sid <- newSession newSessionReq
       step "Get its name"
@@ -208,12 +208,12 @@ test_newSession_invalid_names =
     runAPI $ do
       let step = liftIO . step'
       step "Create a new session with an empty name"
-      sid <- newSession $ NewSessionReq ""
+      sid <- newSession $ NewSessionReq "" True
       step "Get its actual name"
       name <- getSessionName sid
       name @?= fromSessionName defaultSessionName
       step "Create a new session with a name full of whitespace"
-      sid2 <- newSession $ NewSessionReq "      \t  \n"
+      sid2 <- newSession $ NewSessionReq "      \t  \n" True
       step "Get its actual name"
       name2 <- getSessionName sid2
       name2 @?= fromSessionName defaultSessionName
@@ -224,18 +224,18 @@ test_newSession_modified_names =
     runAPI $ do
       let step = liftIO . step'
       step "Create a new session with a name with leading whitespace"
-      sid <- newSession $ NewSessionReq "    this is a session name"
+      sid <- newSession $ NewSessionReq "    this is a session name" True
       step "Get its actual name"
       name <- getSessionName sid
       name @?= "this is a session name"
       step "Create a new session with a name with an embedded newline"
-      sid2 <- newSession $ NewSessionReq "this is\na session name"
+      sid2 <- newSession $ NewSessionReq "this is\na session name" True
       step "Get its actual name"
       name2 <- getSessionName sid2
       name2 @?= "this is"
       let tooLong = toS . concat $ replicate 7 ['0' .. '9']
       step "Create a new session with a name that is too long"
-      sid3 <- newSession $ NewSessionReq tooLong
+      sid3 <- newSession $ NewSessionReq tooLong True
       step "Get its actual name"
       name3 <- getSessionName sid3
       name3 @?= Text.take 64 tooLong
@@ -267,7 +267,7 @@ test_listSessions =
       total s0 @?= 0
       let m :: Int = 107
       step $ "Create " <> show m <> " sessions"
-      ss <- forM ([1 .. m] :: [Int]) $ const $ newSession $ NewSessionReq "new session"
+      ss <- forM ([1 .. m] :: [Int]) $ const $ newSession $ NewSessionReq "new session" True
       step "List all the sessions"
       ss' <- listSessions $ OL{offset = 0, limit = Nothing}
       total ss' @?= m
@@ -296,7 +296,7 @@ test_findSessions =
       total s0 @?= 0
       let m :: Int = 100
       step $ "Create " <> show m <> " sessions"
-      forM_ ([1 .. m] :: [Int]) $ \n -> newSession $ NewSessionReq $ "new session " <> show n
+      forM_ ([1 .. m] :: [Int]) $ \n -> newSession $ NewSessionReq ("new session " <> show n) True
       step "Find all the sessions whose names contain '1'"
       ss' <- findSessions "1" $ OL{offset = 0, limit = Nothing}
       total ss' @?= 20
@@ -396,7 +396,7 @@ test_renameSession =
     runAPI $ do
       let step = liftIO . step'
       step "Create a session"
-      sid <- newSession $ NewSessionReq "testing"
+      sid <- newSession $ NewSessionReq "testing" True
       step "Change its name"
       name <- renameSession sid "new name"
       step "Get the session's name"
@@ -418,7 +418,7 @@ test_renameSession_invalid_name =
     runAPI $ do
       let step = liftIO . step'
       step "rename a session"
-      sid <- newSession $ NewSessionReq "xyz"
+      sid <- newSession $ NewSessionReq "xyz" True
       void $ renameSession sid "abcd"
       step "rename it again with an invalid name"
       name <- renameSession sid ""
@@ -430,7 +430,7 @@ test_renameSession_too_long =
   testCaseSteps "renameSession with a too long name" $ \step' -> do
     runAPI $ do
       let step = liftIO . step'
-      sid <- newSession $ NewSessionReq "a new session"
+      sid <- newSession $ NewSessionReq "a new session" True
       -- Note: we cut off session names rather arbitrarily at 64 characters.
       step "rename a session with a name longer than 64 characters"
       name <- renameSession sid $ toS $ replicate 65 'a'


### PR DESCRIPTION
Note that, out of a need for expediency, there are currently not any
unit tests for the new scenario, but it's a trivial change.

BREAKING CHANGE: this adds a parameter to the `newSession` and
`createSession` APIs.

Signed-off-by: Drew Hess <src@drewhess.com>
