### PR TITLE
feat: annotate offered valcons that match the selection's type

### DIFF
--- a/primer/src/Primer/Typecheck.hs
+++ b/primer/src/Primer/Typecheck.hs
@@ -37,6 +37,7 @@ module Primer.Typecheck (
   TypeDefError (..),
   getTypeDefInfo,
   getTypeDefInfo',
+  allNonPrimValCons,
   lookupConstructor,
   instantiateValCons,
   instantiateValCons',
@@ -184,6 +185,7 @@ import Primer.Typecheck.TypeError (TypeError (..))
 import Primer.Typecheck.Utils (
   TypeDefError (TDIHoleType, TDINotADT, TDINotSaturated, TDIPrim, TDIUnknown),
   TypeDefInfo (TypeDefInfo),
+  allNonPrimValCons,
   getGlobalBaseNames,
   getGlobalNames,
   getTypeDefInfo,

--- a/primer/src/Primer/Typecheck/Utils.hs
+++ b/primer/src/Primer/Typecheck/Utils.hs
@@ -13,6 +13,7 @@ module Primer.Typecheck.Utils (
   _typecache,
   getGlobalNames,
   getGlobalBaseNames,
+  allNonPrimValCons,
 ) where
 
 import Foreword
@@ -42,14 +43,18 @@ import Primer.TypeDef (
  )
 import Primer.Typecheck.Cxt (Cxt, globalCxt, typeDefs)
 
+-- | Given a 'TypeDefMap', for each value constructor of a
+-- non-primitive typedef in the map, tuple the value constructor up
+-- with its type constructor name and its corresponding AST.
+allNonPrimValCons :: TypeDefMap -> [(ValCon (), TyConName, ASTTypeDef ())]
+allNonPrimValCons tydefs = do
+  (tc, TypeDefAST td) <- M.assocs tydefs
+  vc <- astTypeDefConstructors td
+  pure (vc, tc, td)
+
 -- We assume that constructor names are unique, returning the first one we find
 lookupConstructor :: TypeDefMap -> ValConName -> Maybe (ValCon (), TyConName, ASTTypeDef ())
-lookupConstructor tyDefs c =
-  let allCons = do
-        (tc, TypeDefAST td) <- M.assocs tyDefs
-        vc <- astTypeDefConstructors td
-        pure (vc, tc, td)
-   in find ((== c) . valConName . fst3) allCons
+lookupConstructor tyDefs c = find ((== c) . valConName . fst3) $ allNonPrimValCons tyDefs
 
 data TypeDefError
   = TDIHoleType -- a type hole

--- a/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Beginner-Editable.fragment
@@ -1299,13 +1299,13 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
-                                , matchesType = False
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
-                                , matchesType = False
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "Zero"

--- a/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Expert-Editable.fragment
@@ -2435,13 +2435,13 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
-                                , matchesType = False
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
-                                , matchesType = False
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "Left"

--- a/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
+++ b/primer/test/outputs/available-actions/M.comprehensive/Intermediate-Editable.fragment
@@ -1671,13 +1671,13 @@ Output
                                 { option = "True"
                                 , context = Just
                                     ( "Builtins" :| [] )
-                                , matchesType = False
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "False"
                                 , context = Just
                                     ( "Builtins" :| [] )
-                                , matchesType = False
+                                , matchesType = True
                                 }
                             , Option
                                 { option = "Left"


### PR DESCRIPTION
This is an extension of https://github.com/hackworthltd/primer/pull/1045, which itself was a proof of concept/best effort to annotate variables that match the type of a hole up to alpha. Here we extend this feature to non-primitive value constructors.

This implementation uses `valConType` to extract the value constructor's type. For the record, the documentation for `conInfo`, which also uses `valConType`, reads as follows:

> the type an eta-expanded version of this constructor would check against e.g. `Cons`'s "type" is `∀a. a -> List a -> List a`.