### PR TITLE
ci: add the ability to push any `primer-service` branch to ghcr.io

### DIFF
--- a/.github/workflows/push-to-ghcr.yaml
+++ b/.github/workflows/push-to-ghcr.yaml
@@ -1,6 +1,7 @@
 name: Push Docker image to ghcr.io
 
 on:
+  workflow_dispatch:
   push:
 
     # NOTE: if you want to add a branch here other than `main`, please


### PR DESCRIPTION
In other words, add `workflow_dispatch` to
`.github/workflows/push-to-ghcr.yaml`.

Signed-off-by: Drew Hess <src@drewhess.com>
