### PR TITLE
chore: bump eval step limit in the OpenAPI to 300 steps

### DIFF
--- a/primer-service/src/Primer/Servant/OpenAPI.hs
+++ b/primer-service/src/Primer/Servant/OpenAPI.hs
@@ -85,7 +85,7 @@ data SessionsAPI mode = SessionsAPI
   deriving stock (Generic)
 
 -- | A static bound on the maximum requested timeout for evaluation endpoint
-type EvalFullStepLimit = 100
+type EvalFullStepLimit = 300
 
 -- | The session-specific bits of the API.
 data SessionAPI mode = SessionAPI

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -1448,7 +1448,7 @@
                         "schema": {
                             "exclusiveMaximum": false,
                             "exclusiveMinimum": false,
-                            "maximum": 100,
+                            "maximum": 300,
                             "minimum": 0,
                             "type": "integer"
                         }


### PR DESCRIPTION
It's unfortunate that this is baked into the OpenAPI spec file. What we should probably do is bump it to something much larger than we could feasibly want (for now), and then provide a command-line setting to the server which will provide the real limit, only at runtime.