### PR TITLE
fix: bugreport.sh support for git worktrees

### DIFF
--- a/bugreport.sh
+++ b/bugreport.sh
@@ -41,7 +41,7 @@ if [ "$#" -ne 0 ]; then
     exit 1
 fi
 
-if ! [ -d .git ] || ! [ -d primer-service ] || ! [ -d sqitch ]; then
+if ! [ -e .git ] || ! [ -d primer-service ] || ! [ -d sqitch ]; then
     echo "Please run this script from the root of the Primer repository." >&2
     exit 2
 fi


### PR DESCRIPTION
In a linked worktree, `.git` is a regular file, whose contents records the location of the main worktree.