### PR TITLE
perf: strictify Meta's ID field

### DIFF
--- a/primer/src/Primer/Core/Meta.hs
+++ b/primer/src/Primer/Core/Meta.hs
@@ -63,7 +63,7 @@ newtype ID = ID {unID :: Int}
   deriving newtype (ToJSONKey, FromJSONKey)
   deriving anyclass (NFData)
 
-data Meta a = Meta ID a (Maybe Value)
+data Meta a = Meta !ID a (Maybe Value)
   deriving stock (Generic, Eq, Ord, Show, Read, Data, Functor)
   deriving (FromJSON, ToJSON) via PrimerJSON (Meta a)
   deriving anyclass (NFData)


### PR DESCRIPTION
This one-character change massively reduces our memory usage (measured by maximum residency) on some workloads.  When running the testsuite with `--hedgehog-tests 0` (to get reproducible results) we see a (roughly) 15% drop in maximum residency (as measured by `+RTS -s`), and with the following patch to run a much bigger version of `EvalFull.unit_8`, we see a 97% drop, and the total memory in use drops from 1177MB to 58MB! It also has a small beneficial effect on the amount of memory copied during GC, and a negligible effect on both total memory allocated and elapsed runtimes.

```
diff --git a/primer/test/Tests/EvalFull.hs b/primer/test/Tests/EvalFull.hs index c98878049..9292b2870 100644
--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -209,13 +209,13 @@ unit_7 =

 unit_8 :: Assertion
 unit_8 =
-  let n = 10
+  let n = 100 e = mapEven n in do evalFullTest (maxID e) builtinTypes (defMap e) 500 Syn (expr e) >>= \case Left (TimedOut _) -> pure () x -> assertFailure $ show x
-        s <- evalFullTest (maxID e) builtinTypes (defMap e) 1000 Syn (expr e)
+        s <- evalFullTest (maxID e) builtinTypes (defMap e) 100000 Syn (expr e)
         s <~==> Right (expectedResult e)

 -- A worker/wrapper'd map
```