### PR TITLE
chore: upgrade Hedgehog to version 1.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,8 @@ packages:
 
 optimization: 0
 
+allow-newer: hedgehog-classes:hedgehog
+
 package *
   ghc-options: -fwrite-ide-info
   benchmarks: True

--- a/primer-api/primer-api.cabal
+++ b/primer-api/primer-api.cabal
@@ -67,7 +67,7 @@ library primer-api-hedgehog
 
   build-depends:
     , base
-    , hedgehog                                          ^>=1.1
+    , hedgehog                                          ^>=1.4
     , primer-api
     , primer:{primer, primer-hedgehog, primer-testlib}
 

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -193,7 +193,7 @@ test-suite service-test
     , aeson-pretty
     , base
     , bytestring
-    , hedgehog                                           ^>=1.1
+    , hedgehog                                           ^>=1.4
     , hedgehog-quickcheck                                ^>=0.1.1
     , hspec                                              ^>=2.10
     , openapi3
@@ -207,7 +207,7 @@ test-suite service-test
     , tasty                                              ^>=1.4.1
     , tasty-discover                                     ^>=5.0
     , tasty-golden                                       ^>=2.3.5
-    , tasty-hedgehog                                     ^>=1.3
+    , tasty-hedgehog                                     ^>=1.4.0.2
     , tasty-hspec                                        ^>=1.2.0.1
     , tasty-hunit                                        ^>=0.10.0
     , text

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -156,13 +156,13 @@ library primer-hedgehog
     , base
     , containers
     , extra
-    , hedgehog        ^>=1.1
+    , hedgehog        ^>=1.4
     , mmorph          ^>=1.2.0
     , mtl
     , primer
     , primer-testlib
     , tasty-discover  ^>=5.0
-    , tasty-hedgehog  ^>=1.3
+    , tasty-hedgehog  ^>=1.4.0.2
 
 library primer-testlib
   visibility:         public
@@ -269,7 +269,7 @@ test-suite primer-test
       , extra
       , filepath
       , hedgehog
-      , hedgehog-classes             ^>=0.2.5.3
+      , hedgehog-classes             ^>=0.2.5.4
       , logging-effect
       , mtl
       , optics

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -354,7 +354,7 @@ tasty_available_actions_accepted = withTests 500 $
                                           KHole m -> [getID m]
                                           KType m -> [getID m]
                                           KFun m k1 k2 -> [getID m] <> allKindIDs k1 <> allKindIDs k2
-                                    id <- Gen.element $ allKindIDs k
+                                    id <- Gen.element @[] $ allKindIDs k
                                     pure
                                       ( "forTypeDefParamKindNode"
                                       ,

--- a/primer/test/Tests/Eval/Utils.hs
+++ b/primer/test/Tests/Eval/Utils.hs
@@ -48,7 +48,7 @@ import Test.Tasty.HUnit (Assertion, (@?=))
 --  * the type of the term
 genDirTm :: PropertyT WT (Dir, Expr, Type' ())
 genDirTm = do
-  dir <- forAllT $ Gen.element [Chk, Syn]
+  dir <- forAllT $ Gen.element @[] [Chk, Syn]
   (t', ty) <- case dir of
     Chk -> do
       ty' <- forAllT $ genWTType $ KType ()

--- a/primer/test/Tests/Questions.hs
+++ b/primer/test/Tests/Questions.hs
@@ -150,7 +150,7 @@ genSTE' =
         Right (ty, True) -> Global (qualifyName m n, ty)
    in evalExprGen 0 $ Gen.list (Range.linear 0 20) $ toSTE' <$> genModuleName <*> genName <*> g
   where
-    genModuleName = ModuleName <$> Gen.element [["M"], ["M1"]]
+    genModuleName = ModuleName <$> Gen.element @[] [["M"], ["M1"]]
 
 genSTE :: Gen ShadowedVarsExpr
 genSTE = deal . nubOrdOn nameSTE' <$> genSTE'


### PR DESCRIPTION
Now that Hedgehog 1.4 has been released with [the fix for replaying tests](https://github.com/hedgehogqa/haskell-hedgehog/pull/489), we can migrate off 1.1. This is a prerequisite for upgrading ghc to 9.6 (#1077).

Note that currently we need to `allow-newer` to get hedgehog-classes to work with hedgehog 1.4; I have opened an upstream PR at https://github.com/hedgehogqa/haskell-hedgehog-classes/pull/52