### PR TITLE
chore: add `gnutar` to the Docker container

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -518,6 +518,11 @@
                   coreutils
                   lsof
                   procps
+
+                  # Required for `kubectl cp`, which is potentially
+                  # useful for getting databases into and out of the
+                  # pod.
+                  gnutar
                 ]);
 
                 config =


### PR DESCRIPTION
This is required for `kubectl cp`, which is potentially useful for getting databases into and out of the pod.