### PR TITLE
test: Primitive functions can exhibit laziness

### DIFF
--- a/primer/src/Primer/Primitives.hs
+++ b/primer/src/Primer/Primitives.hs
@@ -49,6 +49,7 @@ import Primer.Core.DSL (
   int,
   tcon,
  )
+import Primer.Core.Utils (generateIDs)
 import Primer.JSON (CustomJSON (..), PrimerJSON)
 import Primer.Name (Name)
 import Primer.Primitives.PrimDef (PrimDef (..))
@@ -135,6 +136,7 @@ primDefName = \case
   IntNeq -> "Int.≠"
   IntToNat -> "Int.toNat"
   IntFromNat -> "Int.fromNat"
+  PrimConst -> "const"
 
 primDefType :: PrimDef -> Type' () ()
 primDefType = uncurry (flip $ foldr $ TFun ()) . primFunTypes
@@ -161,6 +163,9 @@ primFunTypes = \case
   IntNeq -> ([c tInt, c tInt], c tBool)
   IntToNat -> ([c tInt], c tMaybe `a` c tNat)
   IntFromNat -> ([c tNat], c tInt)
+  -- Arbitrarily limited to `Int` and `Bool` since we our system doesn't allow polymorphic primitives.
+  -- Note that this primitive is only for testing anyway.
+  PrimConst -> ([c tBool, c tNat], c tBool)
   where
     c = TCon ()
     a = TApp ()
@@ -269,6 +274,10 @@ primFunDef def args = case def of
   IntFromNat -> case args of
     [exprToNat -> Just n] ->
       Right $ int $ fromIntegral n
+    _ -> err
+  PrimConst -> case args of
+    [x, _] ->
+      Right $ generateIDs x
     _ -> err
   where
     exprToNat = \case

--- a/primer/src/Primer/Primitives/PrimDef.hs
+++ b/primer/src/Primer/Primitives/PrimDef.hs
@@ -34,6 +34,8 @@ data PrimDef
   | IntNeq
   | IntToNat
   | IntFromNat
+  | -- | Only for testing
+    PrimConst
   deriving stock (Eq, Show, Read, Enum, Bounded, Data, Generic)
   deriving (FromJSON, ToJSON) via PrimerJSON PrimDef
   deriving anyclass (NFData)

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -36,7 +36,7 @@ import Primer.Builtins (
   tNat,
   tPair,
  )
-import Primer.Builtins.DSL (boolAnn, list_, nat)
+import Primer.Builtins.DSL (boolAnn, bool_, list_, nat)
 import Primer.Core
 import Primer.Core.DSL
 import Primer.Core.Utils (
@@ -83,6 +83,7 @@ import Primer.Primitives (
     IntToNat,
     IsSpace,
     NatToHex,
+    PrimConst,
     ToUpper
   ),
   tChar,
@@ -1694,6 +1695,34 @@ unit_prim_ann =
               )
           `app` (char 'a' `ann` tcon tChar)
           <*> char 'A'
+          <*> primDefs
+   in do
+        s <- evalFullTest maxID builtinTypes prims 2 Syn e
+        s <~==> Right r
+
+unit_prim_lazy_1 :: Assertion
+unit_prim_lazy_1 =
+  let ((e, r, prims), maxID) =
+        create
+          $ (,,)
+          <$> pfun PrimConst
+          `app` bool_ True
+          `app` emptyHole
+          <*> bool_ True
+          <*> primDefs
+   in do
+        s <- evalFullTest maxID builtinTypes prims 2 Syn e
+        s <~==> Right r
+
+unit_prim_lazy_2 :: Assertion
+unit_prim_lazy_2 =
+  let ((e, r, prims), maxID) =
+        create
+          $ (,,)
+          <$> pfun PrimConst
+          `app` bool_ True
+          `app` letrec "x" (lvar "x") (tcon tNat) (lvar "x")
+          <*> bool_ True
           <*> primDefs
    in do
         s <- evalFullTest maxID builtinTypes prims 2 Syn e


### PR DESCRIPTION
Closes #1118.

Note that while this test captures the key property (that primitives can be lazy in an argument), we haven't implemented all suggestions in https://github.com/hackworthltd/primer/issues/1118#issuecomment-1689685996, for reasons outlined in the commit message.