### PR TITLE
fix: const primitive directionality

### DIFF
--- a/primer/src/Primer/Primitives.hs
+++ b/primer/src/Primer/Primitives.hs
@@ -45,6 +45,7 @@ import Primer.Core (
   qualifyName,
  )
 import Primer.Core.DSL (
+  ann,
   char,
   int,
   tcon,
@@ -277,7 +278,7 @@ primFunDef def args = case def of
     _ -> err
   PrimConst -> case args of
     [x, _] ->
-      Right $ generateIDs x
+      Right $ generateIDs x `ann` tcon tBool
     _ -> err
   where
     exprToNat = \case

--- a/primer/test/Tests/EvalFull.hs
+++ b/primer/test/Tests/EvalFull.hs
@@ -1709,6 +1709,7 @@ unit_prim_lazy_1 =
           `app` bool_ True
           `app` emptyHole
           <*> bool_ True
+          `ann` tcon tBool
           <*> primDefs
    in do
         s <- evalFullTest maxID builtinTypes prims 2 Syn e
@@ -1723,6 +1724,7 @@ unit_prim_lazy_2 =
           `app` bool_ True
           `app` letrec "x" (lvar "x") (tcon tNat) (lvar "x")
           <*> bool_ True
+          `ann` tcon tBool
           <*> primDefs
    in do
         s <- evalFullTest maxID builtinTypes prims 2 Syn e


### PR DESCRIPTION
Since `const x y` is synthesisable but `x` is checkable, the reduction rule is `const x y ~> x : Bool` (rather than `const x y ~> x`). Note that `const` is restricted to type `Bool -> Int -> Bool`, and that this reduction matches that of obvious analogue where `const` is replaced by the non-primitive `(λx y. x) : Bool -> Int -> Bool`.