### PR TITLE
chore: remove GHC 9.6.2 spurious warning workarounds

### DIFF
--- a/primer-api/src/Primer/API.hs
+++ b/primer-api/src/Primer/API.hs
@@ -5,10 +5,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- Temporary workaround for GHC 9.6:
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23143
-{-# OPTIONS -Wno-redundant-constraints #-}
-
 -- | The Primer API.
 --
 -- This module defines the Primer API, which is collection of

--- a/primer-api/test/Tests/Database.hs
+++ b/primer-api/test/Tests/Database.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
--- Temporary workaround for GHC 9.6:
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23143
-{-# OPTIONS -Wno-redundant-constraints #-}
-
 module Tests.Database where
 
 import Foreword

--- a/primer-selda/src/Primer/Database/Selda/SQLite.hs
+++ b/primer-selda/src/Primer/Database/Selda/SQLite.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- Temporary workaround for GHC 9.6:
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23143
-{-# OPTIONS -Wno-redundant-constraints #-}
-
 module Primer.Database.Selda.SQLite (
   -- * The "Database.Selda.SQLite" database adapter.
   MonadSeldaSQLiteDb,

--- a/primer/src/Primer/App.hs
+++ b/primer/src/Primer/App.hs
@@ -6,10 +6,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
--- Temporary workaround for GHC 9.6:
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23143
-{-# OPTIONS -Wno-redundant-constraints #-}
-
 -- This module defines the high level application functions.
 
 module Primer.App (

--- a/primer/src/Primer/Database.hs
+++ b/primer/src/Primer/Database.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLabels #-}
 
--- Temporary workaround for GHC 9.6:
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23143
-{-# OPTIONS -Wno-redundant-constraints #-}
-
 module Primer.Database (
   SessionId,
   -- 'SessionName' is abstract. Do not export its constructors.

--- a/primer/test/Tests/Database.hs
+++ b/primer/test/Tests/Database.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
--- Temporary workaround for GHC 9.6:
--- https://gitlab.haskell.org/ghc/ghc/-/issues/23143
-{-# OPTIONS -Wno-redundant-constraints #-}
-
 module Tests.Database where
 
 import Foreword


### PR DESCRIPTION
We're now on GHC 9.6.3, so these should no longer be necessary on our
build.

Closes https://github.com/hackworthltd/primer/issues/1152

Signed-off-by: Drew Hess <src@drewhess.com>
