### PR TITLE
feat!: API gives more details on mismatched types

### DIFF
--- a/primer-api/test/Tests/API.hs
+++ b/primer-api/test/Tests/API.hs
@@ -654,7 +654,12 @@ test_selectioninfo =
           ( Type
               $ Mismatch
                 { got = viewTreeType $ create' $ tcon tNat
-                , expected = viewTreeType $ create' tEmptyHole
+                , -- We require @expected@ to be an empty hole, matching
+                  -- the behaviour of @? True@
+                  -- Arguably we should change both this and the empty hole case to
+                  -- expose that we expect @Bool -> Maybe Nat@, see
+                  -- https://github.com/hackworthltd/primer/issues/81
+                  expected = viewTreeType $ create' tEmptyHole
                 }
           )
 
@@ -687,7 +692,7 @@ test_selectioninfo =
           ( Kind
               $ Mismatch
                 { got = viewTreeKind $ create' $ ktype `kfun` ktype
-                , expected = viewTreeKind $ create' khole
+                , expected = viewTreeKind $ create' ktype
                 }
           )
 
@@ -721,7 +726,11 @@ test_selectioninfo =
           ( Kind
               $ Mismatch
                 { got = viewTreeKind $ create' ktype
-                , expected = viewTreeKind $ create' khole
+                , -- We require @expected@ to be @?@, matching the behaviour of an empty hole.
+                  -- Arguably we should change both this and the empty hole case to
+                  -- expose that we expect @* -> *@, see
+                  -- https://github.com/hackworthltd/primer/issues/81
+                  expected = viewTreeKind $ create' khole
                 }
           )
 

--- a/primer-service/src/Primer/OpenAPI.hs
+++ b/primer-service/src/Primer/OpenAPI.hs
@@ -49,6 +49,7 @@ import Primer.API (
   Module,
   NewSessionReq,
   NodeBody,
+  OkOrMismatch,
   Prog,
   Selection,
   Tree,
@@ -181,6 +182,7 @@ deriving via PrimerJSONNamed "TypeDefConsFieldSelection" (TypeDefConsFieldSelect
 deriving via PrimerJSONNamed "DefSelection" (DefSelection ID) instance ToSchema (DefSelection ID)
 deriving via PrimerJSONNamed "NodeSelection" (NodeSelection ID) instance ToSchema (NodeSelection ID)
 deriving via PrimerJSON NodeType instance ToSchema NodeType
+deriving via PrimerJSON OkOrMismatch instance ToSchema OkOrMismatch
 deriving via PrimerJSON TypeOrKind instance ToSchema TypeOrKind
 deriving via PrimerJSON Level instance ToSchema Level
 deriving via PrimerJSON NewSessionReq instance ToSchema NewSessionReq

--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -30,6 +30,7 @@ import Primer.API (
   Module (Module),
   NewSessionReq (..),
   NodeBody (BoxBody, NoBody, PrimBody, TextBody),
+  OkOrMismatch (Mismatch, Ok),
   Prog (Prog),
   Selection,
   Tree,
@@ -387,4 +388,6 @@ instance Arbitrary CreateTypeDefBody where
 instance Arbitrary NewSessionReq where
   arbitrary = NewSessionReq <$> arbitrary <*> arbitrary
 instance Arbitrary TypeOrKind where
-  arbitrary = hedgehog $ G.choice [Type <$> genTree, Kind <$> genTree]
+  arbitrary = hedgehog $ G.choice [Type <$> genOkMismatch, Kind <$> genOkMismatch]
+    where
+      genOkMismatch = G.choice [Ok <$> genTree, Mismatch <$> genTree <*> genTree]

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -477,6 +477,50 @@
                 ],
                 "type": "string"
             },
+            "OkOrMismatch": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/Tree"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "Ok"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "expected": {
+                                "$ref": "#/components/schemas/Tree"
+                            },
+                            "got": {
+                                "$ref": "#/components/schemas/Tree"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "Mismatch"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "expected",
+                            "got",
+                            "tag"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
             "Option": {
                 "properties": {
                     "context": {
@@ -927,7 +971,7 @@
                     {
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Tree"
+                                "$ref": "#/components/schemas/OkOrMismatch"
                             },
                             "tag": {
                                 "enum": [
@@ -945,7 +989,7 @@
                     {
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Tree"
+                                "$ref": "#/components/schemas/OkOrMismatch"
                             },
                             "tag": {
                                 "enum": [

--- a/primer/src/Primer/Typecheck/Kindcheck.hs
+++ b/primer/src/Primer/Typecheck/Kindcheck.hs
@@ -141,16 +141,16 @@ checkKind k (THole m t) = do
   sh <- asks smartHoles
   (k', t') <- synthKind t
   case (consistentKinds k k', sh) of
-    (_, NoSmartHoles) -> pure $ THole (annotate (KHole ()) m) t'
+    (_, NoSmartHoles) -> pure $ THole (annotate k m) t'
     (True, SmartHoles) -> pure t'
-    (False, SmartHoles) -> pure $ THole (annotate (KHole ()) m) t'
+    (False, SmartHoles) -> pure $ THole (annotate k m) t'
 checkKind k t = do
   sh <- asks smartHoles
   (k', t') <- synthKind t
   case (consistentKinds k k', sh) of
     (True, _) -> pure t'
     (False, NoSmartHoles) -> throwError' $ InconsistentKinds k k'
-    (False, SmartHoles) -> THole <$> meta' (KHole ()) <*> pure t'
+    (False, SmartHoles) -> THole <$> meta' k <*> pure t'
 
 -- | Extend the metadata of an 'Expr' or 'Type'
 -- (usually with a 'TypeCache' or 'Kind')


### PR DESCRIPTION
For non-empty holes (aka "mismatches"), the OpenAPI now gives both the expected and actual types. We also record the checked-at kind of non-empty type holes in the metadata rather than the synthesised one, for consistency with the term level.

BREAKING CHANGE: this changes the OpenAPI schema.