### PR TITLE
chore: switch from `uuid` to `uuid-types`

### DIFF
--- a/primer-api/primer-api.cabal
+++ b/primer-api/primer-api.cabal
@@ -149,7 +149,7 @@ test-suite primer-api-test
       , tasty-hunit
       , text
       , transformers
-      , uuid
+      , uuid-types                                        ^>=1.0.5.1
 
 --TODO This currently breaks with haskell.nix, so we manually add it to `flake.nix` instead.
 -- See: https://github.com/input-output-hk/haskell.nix/issues/839

--- a/primer-api/test/Tests/API.hs
+++ b/primer-api/test/Tests/API.hs
@@ -6,7 +6,6 @@ import Data.ByteString.Lazy qualified as BSL
 import Data.Map qualified as M
 import Data.Text qualified as Text
 import Data.Text.Lazy qualified as TL
-import Data.UUID.V4 (nextRandom)
 import Hedgehog hiding (Property, Var, property)
 import Optics ((.~))
 import Primer.API (
@@ -90,6 +89,7 @@ import Primer.Test.Util (
   constructTCon,
   (@?=),
  )
+import Primer.UUIDv4 (nextRandom)
 import Protolude.Unsafe (unsafeFromJust)
 import Tasty (
   Property,

--- a/primer-selda/primer-selda.cabal
+++ b/primer-selda/primer-selda.cabal
@@ -43,7 +43,7 @@ library
     , selda-sqlite    ^>=0.1.7.2
     , text            ^>=2.0
     , time            >=1.11     && <1.13
-    , uuid            ^>=1.3.15
+    , uuid-types      ^>=1.0.5.1
 
 library primer-selda-testlib
   visibility:         public
@@ -75,7 +75,7 @@ library primer-selda-testlib
     , temporary       ^>=1.3
     , time
     , typed-process   ^>=0.2.11
-    , uuid
+    , uuid-types
 
 test-suite primer-selda-test
   type:               exitcode-stdio-1.0
@@ -125,7 +125,7 @@ test-suite primer-selda-test
       , tasty-hunit                                        ^>=0.10.0
       , text
       , time
-      , uuid
+      , uuid-types
 
 --TODO This currently breaks with haskell.nix, so we manually add it to `flake.nix` instead.
 -- See: https://github.com/input-output-hk/haskell.nix/issues/839

--- a/primer-selda/src/Primer/Database/Selda/SQLite.hs
+++ b/primer-selda/src/Primer/Database/Selda/SQLite.hs
@@ -26,7 +26,7 @@ import Data.Aeson qualified as Aeson (
 import Data.ByteString.Lazy as BL hiding (take)
 import Data.Text qualified as Text
 import Data.Time.Clock (UTCTime)
-import Data.UUID (UUID)
+import Data.UUID.Types (UUID)
 import Database.Selda (
   Assignment ((:=)),
   Attr ((:-)),

--- a/primer-selda/testlib/Primer/Database/Selda/Test/Util.hs
+++ b/primer-selda/testlib/Primer/Database/Selda/Test/Util.hs
@@ -25,7 +25,6 @@ import Data.Time (
   diffTimeToPicoseconds,
   picosecondsToDiffTime,
  )
-import Data.UUID.V4 (nextRandom)
 import Database.Selda (
   insert_,
  )
@@ -40,6 +39,7 @@ import Primer.Database.Selda.SQLite (
   runSeldaSQLiteDbT,
   sessions,
  )
+import Primer.UUIDv4 (nextRandom)
 import System.IO.Temp (withSystemTempDirectory)
 import System.Process.Typed (
   proc,

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -67,7 +67,7 @@ library
     , text                       ^>=2.0
     , time                       >=1.11     && <1.13
     , transformers               >=0.5.6.2  && <0.7.0
-    , uuid                       ^>=1.3.15
+    , uuid-types                 ^>=1.0.5.1
     , wai                        ^>=3.2
     , wai-app-static             ^>=3.1
     , wai-cors                   ^>=0.2.7
@@ -212,7 +212,7 @@ test-suite service-test
     , tasty-hunit                                        ^>=0.10.0
     , text
     , time
-    , uuid
+    , uuid-types
 
 --TODO This currently breaks with haskell.nix, so we manually add it to `flake.nix` instead.
 -- See: https://github.com/input-output-hk/haskell.nix/issues/839

--- a/primer-service/test/Tests/OpenAPI.hs
+++ b/primer-service/test/Tests/OpenAPI.hs
@@ -13,7 +13,7 @@ import Data.Time (
   fromGregorian,
   secondsToDiffTime,
  )
-import Data.UUID (UUID, fromWords64)
+import Data.UUID.Types (UUID, fromWords64)
 import Hedgehog (
   Gen,
   MonadGen,

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -54,6 +54,7 @@ library
     Primer.Typecheck
     Primer.TypeDef
     Primer.Unification
+    Primer.UUIDv4
     Primer.Zipper
     Primer.ZipperCxt
 
@@ -106,33 +107,34 @@ library
     -Wmissing-deriving-strategies -fhide-source-paths
 
   build-depends:
-    , aeson                        >=2.0     && <2.2
+    , aeson                        >=2.0      && <2.2
     , assoc                        ^>=1.1
-    , base                         >=4.12    && <4.19
+    , base                         >=4.12     && <4.19
     , base64-bytestring            ^>=1.2.1
-    , containers                   >=0.6.0.1 && <0.7.0
-    , deriving-aeson               >=0.2     && <0.3.0
+    , containers                   >=0.6.0.1  && <0.7.0
+    , deriving-aeson               >=0.2      && <0.3.0
     , diagrams-lib                 ^>=1.4.6
     , diagrams-rasterific          ^>=1.4.2
-    , exceptions                   >=0.10.4  && <0.11.0
-    , extra                        >=1.7.10  && <1.8.0
-    , generic-optics               >=2.0     && <2.3.0
+    , exceptions                   >=0.10.4   && <0.11.0
+    , extra                        >=1.7.10   && <1.8.0
+    , generic-optics               >=2.0      && <2.3.0
     , JuicyPixels                  ^>=3.3.8
-    , list-t                       >=1.0     && <1.1.0
+    , list-t                       >=1.0      && <1.1.0
     , logging-effect               ^>=1.4
     , mmorph                       ^>=1.2.0
-    , mtl                          >=2.2.2   && <2.4.0
-    , optics                       >=0.4     && <0.5.0
-    , prettyprinter                >=1.7.1   && <1.8.0
-    , prettyprinter-ansi-terminal  >=1.1.3   && <1.2.0
-    , protolude                    >=0.3.1   && <0.4.0
-    , stm                          >=2.5     && <2.6.0
-    , stm-containers               >=1.1     && <1.3.0
+    , mtl                          >=2.2.2    && <2.4.0
+    , optics                       >=0.4      && <0.5.0
+    , prettyprinter                >=1.7.1    && <1.8.0
+    , prettyprinter-ansi-terminal  >=1.1.3    && <1.2.0
+    , protolude                    >=0.3.1    && <0.4.0
+    , random                       ^>=1.2.1.1
+    , stm                          >=2.5      && <2.6.0
+    , stm-containers               >=1.1      && <1.3.0
     , text                         ^>=2.0
-    , time                         >=1.11    && <1.13
-    , transformers                 >=0.5.6.2 && <0.7.0
-    , uniplate                     >=1.6     && <1.7.0
-    , uuid                         ^>=1.3.15
+    , time                         >=1.11     && <1.13
+    , transformers                 >=0.5.6.2  && <0.7.0
+    , uniplate                     >=1.6      && <1.7.0
+    , uuid-types                   ^>=1.0.5.1
 
 library primer-hedgehog
   visibility:         public
@@ -296,7 +298,7 @@ test-suite primer-test
       , text
       , transformers
       , uniplate
-      , uuid
+      , uuid-types
 
 --TODO This currently breaks with haskell.nix, so we manually add it to `flake.nix` instead.
 -- See: https://github.com/input-output-hk/haskell.nix/issues/839

--- a/primer/src/Primer/Database.hs
+++ b/primer/src/Primer/Database.hs
@@ -56,9 +56,8 @@ import Data.Time.Clock (
 import Data.Time.Clock qualified as UTC (
   getCurrentTime,
  )
-import Data.UUID (UUID)
-import Data.UUID qualified as UUID (toText)
-import Data.UUID.V4 (nextRandom)
+import Data.UUID.Types (UUID)
+import Data.UUID.Types qualified as UUID (toText)
 import ListT qualified (toList)
 import Optics (
   (.~),
@@ -70,6 +69,7 @@ import Primer.JSON (
   PrimerJSON,
   ToJSON,
  )
+import Primer.UUIDv4 (nextRandom)
 import StmContainers.Map qualified as StmMap
 
 -- | A Primer version.

--- a/primer/src/Primer/UUIDv4.hs
+++ b/primer/src/Primer/UUIDv4.hs
@@ -1,0 +1,14 @@
+module Primer.UUIDv4 (nextRandom) where
+
+import Foreword
+
+import Data.UUID.Types (UUID)
+import System.Random (randomIO)
+
+-- | Generate a pseudo-random 'UUID'.
+--
+-- Note: this effect does __not__ generate cryptographically secure
+-- UUIDs. If you need cryptographically secure 'UUID's, use
+-- the effect of the same name from the @uuid@ package.
+nextRandom :: IO UUID
+nextRandom = randomIO

--- a/primer/test/Tests/NullDb.hs
+++ b/primer/test/Tests/NullDb.hs
@@ -3,7 +3,6 @@ module Tests.NullDb where
 import Foreword
 
 import Data.Text qualified as Text
-import Data.UUID.V4 (nextRandom)
 import Primer.App (
   newApp,
   newEmptyApp,
@@ -31,6 +30,7 @@ import Primer.Test.Util (
   assertException,
   (@?=),
  )
+import Primer.UUIDv4 (nextRandom)
 import Test.Tasty
 import Test.Tasty.HUnit (testCaseSteps)
 


### PR DESCRIPTION
`uuid` drags in `network-info`, which doesn't build on GHC's Wasm target. The only drawback to `uuid-types` for our purposes is that it doesn't include a cryptographically secure generator for UUIDv4, which we've been using up until now (specifically, the `nextRandom` effect).

Therefore, we replace `nextRandom` with our own pseudo-random implementation. Note that our implementation is *not* cryptographically secure, as `entropy` does not build on the Wasm target, either.