### PR TITLE
fix: Add `primer-` prefix to service test suite

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -426,7 +426,7 @@
                       (final.haskell-nix.tool ghcVersion "tasty-discover" { })
                       final.primer-sqitch
                     ];
-                    packages.primer-service.components.tests.service-test.build-tools = [
+                    packages.primer-service.components.tests.primer-service-test.build-tools = [
                       (final.haskell-nix.tool ghcVersion "tasty-discover" { })
                       final.primer-sqitch
                     ];
@@ -442,7 +442,7 @@
                     {
                       packages.primer.components.tests.primer-test.testFlags = hide-successes ++ size-cutoff;
                       packages.primer-api.components.tests.primer-api-test.testFlags = hide-successes ++ size-cutoff;
-                      packages.primer-service.components.tests.service-test.testFlags = hide-successes ++ size-cutoff;
+                      packages.primer-service.components.tests.primer-service-test.testFlags = hide-successes ++ size-cutoff;
                       packages.primer-selda.components.tests.primer-selda-test.testFlags = hide-successes;
                       packages.primer-benchmark.components.tests.primer-benchmark-test.testFlags = hide-successes;
                     }

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -165,7 +165,7 @@ executable primer-openapi
     , bytestring
     , primer-service
 
-test-suite service-test
+test-suite primer-service-test
   type:               exitcode-stdio-1.0
   main-is:            Test.hs
   hs-source-dirs:     test


### PR DESCRIPTION
This matches the naming scheme used by all other components in the project.