### PR TITLE
Allow deleting an in-use term definition

### DIFF
--- a/primer/src/Primer/Action/Available.hs
+++ b/primer/src/Primer/Action/Available.hs
@@ -98,7 +98,7 @@ import Primer.Def (
   ASTDef (..),
   DefMap,
  )
-import Primer.Def.Utils (globalInUse, typeInUse)
+import Primer.Def.Utils (typeInUse)
 import Primer.JSON (CustomJSON (..), FromJSON, PrimerJSON, ToJSON)
 import Primer.Name (unName)
 import Primer.Primitives (tChar, tInt)
@@ -212,13 +212,10 @@ forDef ::
   GVarName ->
   [Action]
 forDef _ _ NonEditable _ = mempty
-forDef defs l Editable defName =
-  sortByPriority l
-    $ [Input RenameDef, NoInput DuplicateDef]
-    <> mwhen
-      -- ensure the definition is not in use, otherwise the action will not succeed
-      (not $ globalInUse defName $ Map.delete defName defs)
-      [NoInput DeleteDef]
+forDef _ l Editable _ =
+  sortByPriority
+    l
+    [Input RenameDef, NoInput DuplicateDef, NoInput DeleteDef]
 
 forBody ::
   TypeDefMap ->

--- a/primer/src/Primer/Action/ProgError.hs
+++ b/primer/src/Primer/Action/ProgError.hs
@@ -14,7 +14,6 @@ data ProgError
   | NoTypeDefSelected
   | DefNotFound GVarName
   | DefAlreadyExists GVarName
-  | DefInUse GVarName
   | TypeDefIsPrim TyConName
   | TypeDefNotFound TyConName
   | TypeDefAlreadyExists TyConName

--- a/primer/src/Primer/Def/Utils.hs
+++ b/primer/src/Primer/Def/Utils.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 
-module Primer.Def.Utils (nextID, nextIDTypeDef, globalInUse, typeInUse) where
+module Primer.Def.Utils (nextID, nextIDTypeDef, typeInUse) where
 
 import Foreword
 
@@ -9,9 +9,9 @@ import Data.Generics.Uniplate.Operations (universe)
 import Data.Set qualified as Set
 import Optics (anyOf, folded, foldlOf', to, toListOf, (%), _2)
 import Primer.Core (Expr' (..), KindMeta, Type' (..), TypeMeta, typesInExpr)
-import Primer.Core.Meta (GVarName, ID, TyConName)
+import Primer.Core.Meta (ID, TyConName)
 import Primer.Core.Type.Utils (kindIDs)
-import Primer.Core.Utils (exprIDs, freeGlobalVars, typeIDs)
+import Primer.Core.Utils (exprIDs, typeIDs)
 import Primer.Def (ASTDef (..), Def (..), defAST, defType)
 import Primer.TypeDef (ASTTypeDef (..), PrimTypeDef (PrimTypeDef), TypeDef (..), ValCon (..))
 
@@ -39,12 +39,6 @@ nextIDTypeDef (TypeDefAST (ASTTypeDef ps vcs _)) =
 nextIDTypeDef (TypeDefPrim (PrimTypeDef ps _)) =
   succ $ foldlOf' (folded % _2 % kindIDs) max minBound ps
 {-# INLINE nextIDTypeDef #-}
-
-globalInUse :: Foldable f => GVarName -> f Def -> Bool
-globalInUse v =
-  anyOf
-    (folded % #_DefAST % #astDefExpr % to freeGlobalVars)
-    (Set.member v)
 
 -- | Is this type (including any of its constructors) in use in the given definitions?
 typeInUse :: (Foldable f, Foldable g, Data a', Data b') => TyConName -> ASTTypeDef a b -> f (TypeDef a' b') -> g Def -> Bool

--- a/primer/test/Tests/Action/Available.hs
+++ b/primer/test/Tests/Action/Available.hs
@@ -107,7 +107,7 @@ import Primer.Core (
   ID,
   Kind' (..),
   KindMeta,
-  ModuleName (ModuleName, unModuleName),
+  ModuleName (unModuleName),
   Pattern (PatPrim),
   TyConName,
   Type,
@@ -291,24 +291,6 @@ mkTests deps (defName, DefAST def') =
                   , bodyActions
                   , sigActions
                   }
-
--- We should not offer to delete a definition that is in use, as that
--- action cannot possibly succeed
-unit_def_in_use :: Assertion
-unit_def_in_use =
-  let (d, defs) = create' $ do
-        let foo = qualifyName (ModuleName ["M"]) "foo"
-        fooDef <- ASTDef <$> emptyHole <*> tEmptyHole
-        let bar = qualifyName (ModuleName ["M"]) "bar"
-        barDef <- ASTDef <$> gvar foo <*> tEmptyHole
-        let ds = [(foo, DefAST fooDef), (bar, DefAST barDef)]
-        pure (foo, Map.fromList ds)
-   in for_
-        enumerate
-        ( \l ->
-            Available.forDef defs l Editable d
-              @?= [Available.Input Available.RenameDef, Available.NoInput Available.DuplicateDef]
-        )
 
 -- Any offered action will complete successfully,
 -- other than one with a student-specified name that introduces capture.


### PR DESCRIPTION
For consistency with https://github.com/hackworthltd/primer/pull/1153, as anticipated in https://github.com/hackworthltd/primer/issues/1133#issuecomment-1715843100.

The only context in which we still ban edits rather than fixing up use sites is for type definition parameters, as tracked in https://github.com/hackworthltd/primer/issues/402.