### PR TITLE
Output separate nodes for variable bindings

### DIFF
--- a/primer-api/src/Primer/API/EdgeFlavor.hs
+++ b/primer-api/src/Primer/API/EdgeFlavor.hs
@@ -29,6 +29,7 @@ data EdgeFlavor
   | FunOut
   | ForallKind
   | Forall
+  | Bind
   deriving stock (Show, Read, Eq, Generic)
   deriving (ToJSON, FromJSON) via PrimerJSON EdgeFlavor
   deriving anyclass (NFData)

--- a/primer-api/src/Primer/API/NodeFlavor.hs
+++ b/primer-api/src/Primer/API/NodeFlavor.hs
@@ -19,19 +19,13 @@ import Primer.JSON (CustomJSON (..), FromJSON, PrimerJSON, ToJSON)
 
 data NodeFlavorTextBody
   = Con
-  | Lam
-  | LAM
-  | Let
-  | LetType
-  | Letrec
-  | PatternBind
   | PatternCon
   | TCon
   | TVar
-  | TForall
-  | TLet
   | GlobalVar
   | LocalVar
+  | VarBind
+  | TVarBind
   deriving stock (Show, Read, Eq, Generic, Enum, Bounded)
   deriving (ToJSON, FromJSON) via PrimerJSON NodeFlavorTextBody
   deriving anyclass (NFData)
@@ -65,6 +59,13 @@ data NodeFlavorNoBody
   | KType
   | KHole
   | KFun
+  | Lam
+  | LAM
+  | Let
+  | LetType
+  | Letrec
+  | TLet
+  | TForall
   deriving stock (Show, Read, Eq, Generic, Enum, Bounded)
   deriving (ToJSON, FromJSON) via PrimerJSON NodeFlavorNoBody
   deriving anyclass (NFData)

--- a/primer-api/test/outputs/APITree/Expr
+++ b/primer-api/test/outputs/APITree/Expr
@@ -1,14 +1,6 @@
 Tree
     { nodeId = "10"
-    , body = TextBody
-        ( RecordPair
-            { fst = Let
-            , snd = Name
-                { qualifiedModule = Nothing
-                , baseName = "x"
-                }
-            }
-        )
+    , body = NoBody Let
     , childTrees =
         [ RecordPair
             { fst = LetEqual
@@ -64,15 +56,7 @@ Tree
             { fst = LetIn
             , snd = Tree
                 { nodeId = "14"
-                , body = TextBody
-                    ( RecordPair
-                        { fst = Letrec
-                        , snd = Name
-                            { qualifiedModule = Nothing
-                            , baseName = "y"
-                            }
-                        }
-                    )
+                , body = NoBody Letrec
                 , childTrees =
                     [ RecordPair
                         { fst = LetEqual
@@ -243,29 +227,13 @@ Tree
                                     { fst = AnnTerm
                                     , snd = Tree
                                         { nodeId = "28"
-                                        , body = TextBody
-                                            ( RecordPair
-                                                { fst = Lam
-                                                , snd = Name
-                                                    { qualifiedModule = Nothing
-                                                    , baseName = "i"
-                                                    }
-                                                }
-                                            )
+                                        , body = NoBody Lam
                                         , childTrees =
                                             [ RecordPair
                                                 { fst = Lam
                                                 , snd = Tree
                                                     { nodeId = "29"
-                                                    , body = TextBody
-                                                        ( RecordPair
-                                                            { fst = LAM
-                                                            , snd = Name
-                                                                { qualifiedModule = Nothing
-                                                                , baseName = "β"
-                                                                }
-                                                            }
-                                                        )
+                                                    , body = NoBody LAM
                                                     , childTrees =
                                                         [ RecordPair
                                                             { fst = Lam
@@ -283,15 +251,7 @@ Tree
                                                                                     { fst = AppArg
                                                                                     , snd = Tree
                                                                                         { nodeId = "32"
-                                                                                        , body = TextBody
-                                                                                            ( RecordPair
-                                                                                                { fst = LetType
-                                                                                                , snd = Name
-                                                                                                    { qualifiedModule = Nothing
-                                                                                                    , baseName = "b"
-                                                                                                    }
-                                                                                                }
-                                                                                            )
+                                                                                        , body = NoBody LetType
                                                                                         , childTrees =
                                                                                             [ RecordPair
                                                                                                 { fst = LetEqual
@@ -334,7 +294,25 @@ Tree
                                                                                                     }
                                                                                                 }
                                                                                             ]
-                                                                                        , rightChild = Nothing
+                                                                                        , rightChild = Just
+                                                                                            ( RecordPair
+                                                                                                { fst = Bind
+                                                                                                , snd = Tree
+                                                                                                    { nodeId = "32V"
+                                                                                                    , body = TextBody
+                                                                                                        ( RecordPair
+                                                                                                            { fst = TVarBind
+                                                                                                            , snd = Name
+                                                                                                                { qualifiedModule = Nothing
+                                                                                                                , baseName = "b"
+                                                                                                                }
+                                                                                                            }
+                                                                                                        )
+                                                                                                    , childTrees = []
+                                                                                                    , rightChild = Nothing
+                                                                                                    }
+                                                                                                }
+                                                                                            )
                                                                                         }
                                                                                     }
                                                                                 , RecordPair
@@ -460,7 +438,7 @@ Tree
                                                                                                                             { nodeId = "39"
                                                                                                                             , body = TextBody
                                                                                                                                 ( RecordPair
-                                                                                                                                    { fst = PatternBind
+                                                                                                                                    { fst = VarBind
                                                                                                                                     , snd = Name
                                                                                                                                         { qualifiedModule = Nothing
                                                                                                                                         , baseName = "n"
@@ -644,11 +622,47 @@ Tree
                                                                 }
                                                             }
                                                         ]
-                                                    , rightChild = Nothing
+                                                    , rightChild = Just
+                                                        ( RecordPair
+                                                            { fst = Bind
+                                                            , snd = Tree
+                                                                { nodeId = "29V"
+                                                                , body = TextBody
+                                                                    ( RecordPair
+                                                                        { fst = TVarBind
+                                                                        , snd = Name
+                                                                            { qualifiedModule = Nothing
+                                                                            , baseName = "β"
+                                                                            }
+                                                                        }
+                                                                    )
+                                                                , childTrees = []
+                                                                , rightChild = Nothing
+                                                                }
+                                                            }
+                                                        )
                                                     }
                                                 }
                                             ]
-                                        , rightChild = Nothing
+                                        , rightChild = Just
+                                            ( RecordPair
+                                                { fst = Bind
+                                                , snd = Tree
+                                                    { nodeId = "28V"
+                                                    , body = TextBody
+                                                        ( RecordPair
+                                                            { fst = VarBind
+                                                            , snd = Name
+                                                                { qualifiedModule = Nothing
+                                                                , baseName = "i"
+                                                                }
+                                                            }
+                                                        )
+                                                    , childTrees = []
+                                                    , rightChild = Nothing
+                                                    }
+                                                }
+                                            )
                                         }
                                     }
                                 , RecordPair
@@ -681,15 +695,7 @@ Tree
                                                 { fst = FunOut
                                                 , snd = Tree
                                                     { nodeId = "50"
-                                                    , body = TextBody
-                                                        ( RecordPair
-                                                            { fst = TForall
-                                                            , snd = Name
-                                                                { qualifiedModule = Nothing
-                                                                , baseName = "α"
-                                                                }
-                                                            }
-                                                        )
+                                                    , body = NoBody TForall
                                                     , childTrees =
                                                         [ RecordPair
                                                             { fst = ForallKind
@@ -778,7 +784,25 @@ Tree
                                                                 }
                                                             }
                                                         ]
-                                                    , rightChild = Nothing
+                                                    , rightChild = Just
+                                                        ( RecordPair
+                                                            { fst = Bind
+                                                            , snd = Tree
+                                                                { nodeId = "50V"
+                                                                , body = TextBody
+                                                                    ( RecordPair
+                                                                        { fst = TVarBind
+                                                                        , snd = Name
+                                                                            { qualifiedModule = Nothing
+                                                                            , baseName = "α"
+                                                                            }
+                                                                        }
+                                                                    )
+                                                                , childTrees = []
+                                                                , rightChild = Nothing
+                                                                }
+                                                            }
+                                                        )
                                                     }
                                                 }
                                             ]
@@ -790,9 +814,45 @@ Tree
                             }
                         }
                     ]
-                , rightChild = Nothing
+                , rightChild = Just
+                    ( RecordPair
+                        { fst = Bind
+                        , snd = Tree
+                            { nodeId = "14V"
+                            , body = TextBody
+                                ( RecordPair
+                                    { fst = VarBind
+                                    , snd = Name
+                                        { qualifiedModule = Nothing
+                                        , baseName = "y"
+                                        }
+                                    }
+                                )
+                            , childTrees = []
+                            , rightChild = Nothing
+                            }
+                        }
+                    )
                 }
             }
         ]
-    , rightChild = Nothing
+    , rightChild = Just
+        ( RecordPair
+            { fst = Bind
+            , snd = Tree
+                { nodeId = "10V"
+                , body = TextBody
+                    ( RecordPair
+                        { fst = VarBind
+                        , snd = Name
+                            { qualifiedModule = Nothing
+                            , baseName = "x"
+                            }
+                        }
+                    )
+                , childTrees = []
+                , rightChild = Nothing
+                }
+            }
+        )
     }

--- a/primer-api/test/outputs/APITree/Type
+++ b/primer-api/test/outputs/APITree/Type
@@ -26,15 +26,7 @@ Tree
             { fst = FunOut
             , snd = Tree
                 { nodeId = "2"
-                , body = TextBody
-                    ( RecordPair
-                        { fst = TForall
-                        , snd = Name
-                            { qualifiedModule = Nothing
-                            , baseName = "a"
-                            }
-                        }
-                    )
+                , body = NoBody TForall
                 , childTrees =
                     [ RecordPair
                         { fst = ForallKind
@@ -122,7 +114,25 @@ Tree
                             }
                         }
                     ]
-                , rightChild = Nothing
+                , rightChild = Just
+                    ( RecordPair
+                        { fst = Bind
+                        , snd = Tree
+                            { nodeId = "2V"
+                            , body = TextBody
+                                ( RecordPair
+                                    { fst = TVarBind
+                                    , snd = Name
+                                        { qualifiedModule = Nothing
+                                        , baseName = "a"
+                                        }
+                                    }
+                                )
+                            , childTrees = []
+                            , rightChild = Nothing
+                            }
+                        }
+                    )
                 }
             }
         ]

--- a/primer-service/test/outputs/OpenAPI/openapi.json
+++ b/primer-service/test/outputs/OpenAPI/openapi.json
@@ -131,7 +131,8 @@
                     "FunIn",
                     "FunOut",
                     "ForallKind",
-                    "Forall"
+                    "Forall",
+                    "Bind"
                 ],
                 "type": "string"
             },
@@ -444,7 +445,14 @@
                     "PatternWildcard",
                     "KType",
                     "KHole",
-                    "KFun"
+                    "KFun",
+                    "Lam",
+                    "LAM",
+                    "Let",
+                    "LetType",
+                    "Letrec",
+                    "TLet",
+                    "TForall"
                 ],
                 "type": "string"
             },
@@ -458,19 +466,13 @@
             "NodeFlavorTextBody": {
                 "enum": [
                     "Con",
-                    "Lam",
-                    "LAM",
-                    "Let",
-                    "LetType",
-                    "Letrec",
-                    "PatternBind",
                     "PatternCon",
                     "TCon",
                     "TVar",
-                    "TForall",
-                    "TLet",
                     "GlobalVar",
-                    "LocalVar"
+                    "LocalVar",
+                    "VarBind",
+                    "TVarBind"
                 ],
                 "type": "string"
             },


### PR DESCRIPTION
~~Proof-of-concept. Doing this properly will require having `ID`s for binding nodes. We should probably just fully embrace #75. See also #93.~~ We've decided that we're happy to merge this without having proper IDs.

(frontend companion PR coming soon with fuller explanation)