### PR TITLE
feat: build & run `primer-benchmark` for Wasm32 targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ wasm32 = wasm32-build wasm32-build-opt wasm32-configure wasm32-check wasm32-test
 $(wasm32):
 	$(MAKE) -C primer $@
 	$(MAKE) -C primer-api $@
+	$(MAKE) -C primer-benchmark $@
 
 weeder:
 	cabal build all --enable-benchmarks --enable-tests

--- a/primer-benchmark/Makefile
+++ b/primer-benchmark/Makefile
@@ -3,25 +3,50 @@
 # Most commands assume you're running this from the top-level `nix
 # develop` shell.
 
-# Note: no libs or exes to build in this project.
+wasm32-primer-benchmark-test	= $(shell wasm32-wasi-cabal list-bin -v0 test:primer-benchmark-test)
+wasm32-primer-benchmark-test-opt	= $(shell wasm32-wasi-cabal list-bin -O2 -v0 test:primer-benchmark-test)
+
 build:
+	cabal build
+
+wasm32-build:
+	wasm32-wasi-cabal build
+
+wasm32-build-opt:
+	wasm32-wasi-cabal build -O2
 
 configure:
 	cabal configure
 
+wasm32-configure:
+	wasm32-wasi-cabal configure
+
 check:	test
 
-# Note: no tests to run in this project.
+wasm32-check:	wasm32-test
+
 test:
+	cabal test
+
+wasm32-test:
+	wasm32-wasi-cabal build test:primer-benchmark-test
+	wasmtime --dir test::test "$(wasm32-primer-benchmark-test)"
+
+wasm32-test-opt:
+	wasm32-wasi-cabal build -O2 test:primer-benchmark-test
+	wasmtime --dir test::test "$(wasm32-primer-benchmark-test-opt)"
+
+bench:
+	cabal bench
+
+wasm32-bench: wasm32-build-opt
+	wasmtime "$(wasm32-primer-benchmark-test-opt)"
 
 docs:
 	cabal haddock
 
 clean:
 	cabal clean
-
-bench:
-	cabal bench
 
 realclean:
 


### PR DESCRIPTION
Note: there's still quite a bit of work to do on this, because `criterion` and at least one of its dependencies don't work with the Wasm backend target. I'll take a look at [tasty-bench](https://github.com/Bodigrim/tasty-bench), which explicitly states that it supports Wasm in its README.