### PR TITLE
fix: make Wasm upstream overrides dependent on `arch(wasm32)`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -45,32 +45,40 @@ source-repository-package
   --sha256: 0q8m8asmb83mpa3j3adlrhc446xif7gv6lql20gv05k33lmbjfhg
 
 -- Wasm workarounds.
+--
+-- We would prefer that these workarounds were not Wasm-dependent;
+-- i.e., that we would use the same version of these dependencies
+-- whether we're building for Wasm or not. However, we *do* make them
+-- Wasm-dependent, because haskell.nix cannot build any of these
+-- source-repository-package dependencies, *nor their reverse
+-- dependencies*, using Nix while in the Nix development shell.
 
--- Upstream requires `happy` at build time, which doesn't work on Wasm
--- targets.
-source-repository-package
-  type: git
-  location: https://github.com/hackworthltd/pretty-show
-  tag: 91d119cb0e3c5f7d866589b25158739580c8fc88
-  --sha256: sha256-mu8Eq0Sg6nCF8C2sXB6ebZcLhz8TVZAbNMiorA7RVc8=
+-- if arch(wasm32)
+--   -- Upstream requires `happy` at build time, which doesn't work on Wasm
+--   -- targets.
+--   source-repository-package
+--     type: git
+--     location: https://github.com/hackworthltd/pretty-show
+--     tag: 91d119cb0e3c5f7d866589b25158739580c8fc88
+--     --sha256: sha256-mu8Eq0Sg6nCF8C2sXB6ebZcLhz8TVZAbNMiorA7RVc8=
 
--- Upstream depends on Posix types unavailable in Wasm.
-source-repository-package
-  type: git
-  location: https://github.com/hackworthltd/semirings
-  tag: 369f696d9d00fe004b16b0de08888fee7a3d08c3
-  --sha256: sha256-kkHCp4Y9IqMXGaDyW5UpsmRjy0ZWZkVSo1nOhpgZUQ0=
+--   -- Upstream depends on Posix types unavailable in Wasm.
+--   source-repository-package
+--     type: git
+--     location: https://github.com/hackworthltd/semirings
+--     tag: 369f696d9d00fe004b16b0de08888fee7a3d08c3
+--     --sha256: sha256-kkHCp4Y9IqMXGaDyW5UpsmRjy0ZWZkVSo1nOhpgZUQ0=
 
--- Upstream uses custom setup, which breaks on Wasm.
-source-repository-package
-  type: git
-  location: https://github.com/cdepillabout/pretty-simple
-  tag: 6fb9b281800ad045925c7344ceb9fd293d86c3b9
-  --sha256: sha256-1gsYj/iznEUCeQ1f5Xk7w54h9FLJSNrIR9V3p4eaRYk=
+--   -- Upstream uses custom setup, which breaks on Wasm.
+--   source-repository-package
+--     type: git
+--     location: https://github.com/cdepillabout/pretty-simple
+--     tag: 6fb9b281800ad045925c7344ceb9fd293d86c3b9
+--     --sha256: sha256-1gsYj/iznEUCeQ1f5Xk7w54h9FLJSNrIR9V3p4eaRYk=
 
--- Upstream doesn't want to support Wasm while it's "experimental."
-source-repository-package
-  type: git
-  location: https://github.com/amesgen/splitmix
-  tag: 83b906c4bcdc2720546f1779a16eb65e8e12ecba
-  --sha256: sha256-sR+Ne56SBzVbPfC7AJeQZn20YDfFwBDpRI873cTm1nU=
+--   -- Upstream doesn't want to support Wasm while it's "experimental."
+--   source-repository-package
+--     type: git
+--     location: https://github.com/amesgen/splitmix
+--     tag: 83b906c4bcdc2720546f1779a16eb65e8e12ecba
+--     --sha256: sha256-sR+Ne56SBzVbPfC7AJeQZn20YDfFwBDpRI873cTm1nU=


### PR DESCRIPTION
This fixes an issue where Nix caching was significantly degraded in the default Nix shell, due to haskell.nix not being able to build `source-repository-package`s using Nix in Nix shells. We'd prefer not to do this, because it means that our Wasm dependencies are ever so slightly different than our native target dependencies, but at the moment the differences should be small enough not to matter.