### PR TITLE
chore: always build `wasm32` targets with `-O2`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,11 @@ packages:
   primer-service
   primer-benchmark
 
-optimization: 0
+if arch(wasm32)
+   package *
+     optimization: 2
+else
+  optimization: 0
 
 allow-newer: hedgehog-classes:hedgehog,hedgehog-classes:pretty-show,hedgehog:pretty-show
 


### PR DESCRIPTION
As Wasm is an execute-only target, it makes sense to always build it
with `-O2`, including deps.

Fixes https://github.com/hackworthltd/primer/issues/1196

Signed-off-by: Drew Hess <src@drewhess.com>
