### PR TITLE
ci: ensure Nix Buildkite plugin jobs are built on Linux builders

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,7 +12,7 @@ steps:
     plugins:
       - hackworthltd/nix#v1.0.0:
           file: ci.nix
-          agent-tags: queue=nix-build
+          agent-tags: queue=nix-build,os=linux
 
   - wait
 


### PR DESCRIPTION
We now have macOS Buildkite agents in the `nix-build` queue, so that we can cache macOS Nix shells, but we don't want these agents to build jobs generated by the Nix Buildkite plugin, as those need to go through our Linux builders due to the way Nix remote builds and caching work.