### PR TITLE
ci: only run Wasm tests once a PR reaches the merge queue

### DIFF
--- a/.buildkite/primer-wasm.yaml
+++ b/.buildkite/primer-wasm.yaml
@@ -1,10 +1,30 @@
+# Note: because they take so much time to run, we only run the Primer
+# Wasm tests when one of these conditions is true:
+#
+# 1. The PR has hit the merge queue.
+# 2. The PR has the "Run Wasm tests" label.
+
 agents:
   queue: "nix-build"
   os: "linux"
 
 steps:
-  - label: ":haskell: :linux: Primer Wasm targets"
+  # Note: only one of these should run during any given build.
+  # Unfortunately, Buildkite doesn't support if-else conditionals, so
+  # this gets a bit tricky.
+
+  - label: ":haskell: :linux: Primer Wasm tests"
+    if: |
+      build.branch =~ /^gh-readonly-queue\// ||
+      build.pull_request.labels includes "Run Wasm tests"
+    command: |
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 test
+
+  - label: ":haskell: :linux: Primer Wasm build"
+    if: |
+      build.branch !~ /^gh-readonly-queue\// &&
+      !(build.pull_request.labels includes "Run Wasm tests")
     command: |
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32
-      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 test


### PR DESCRIPTION
The Wasm tests are very expensive, and our build system isn't smart enough to know when they don't need to be re-run, so for now, we only run the tests once a PR hits the merge queue.