### PR TITLE
chore: upgrade to GHC 9.10.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -30,17 +30,7 @@ haddock-quickjump:        True
 haddock-hyperlink-source: True
 haddock-internal:         True
 
-allow-newer:
-  , hedgehog-classes:hedgehog
-  , hedgehog-classes:pretty-show
-  , hedgehog:pretty-show
-  , logging-effect:base
-  , refined:base
-  , refined:deepseq
-  , refined:template-haskell
-  , refined:aeson
-  , these-skinny:base
-  , selda:bytestring
+allow-newer: all
 
 package *
   ghc-options: -fwrite-ide-info
@@ -57,6 +47,14 @@ package primer-service
 if arch(wasm32)
   package tasty
     flags: -unix
+
+-- Protolude upstream doesn't support GHC 9.10, and appears to
+-- be dormant.
+source-repository-package
+  type: git
+  location: https://github.com/tomjaguarpaw/protolude
+  tag: 57ffd726d9685a862df8c9773f3eb09de2b89594
+  --sha256: 1z9z887s4f1wv0pv3njyd8h8zgr2ha89jyvaxz3k5k3rk6h2g1cp
 
 -- We need a newer version of Selda than what's been released to
 -- Hackage, plus some GHC 9.6 fixes from a community fork.

--- a/docs/haskell-style-guide.md
+++ b/docs/haskell-style-guide.md
@@ -100,7 +100,7 @@ import Foreword
 * We can't make promises on backward compatibility with GHC releases older than the one we're currently using to develop the project, but we won't break compatibility arbitrarily.
 * We will make a best-effort attempt to test all supported GHC versions in CI.
 * As a general rule, we would like to avoid CPP-style conditional compilation, except as a last resort.
-* We expect the 1.0 release of the project to have a minimum requirement of at least [GHC `9.6.1`](https://www.haskell.org/ghc/download_ghc_9_6_1.html), as we want to take advantage of that version's support for [JavaScript](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/javascript.html) and [WebAssembly](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/wasm.html?highlight=wasm) targets.
+* We expect the 1.0 release of the project to have a minimum requirement of at least [GHC `9.10.1`](https://www.haskell.org/ghc/download_ghc_9_6_1.html), as we want to take advantage of that version's support for [JavaScript](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/javascript.html) and [WebAssembly](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/wasm.html?highlight=wasm) targets.
 * We do not plan to support Haskell implementations other than GHC.
 
 ## Spelling & grammar

--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1720831680,
-        "narHash": "sha256-UjB/p1ro3ctJ16bHD6AdFyHB2UEq9LNxmAV85vEYGo8=",
+        "lastModified": 1721263615,
+        "narHash": "sha256-J/VaA4xWMpp43HptVP2tpfLwIYCg+OrBova4Uh5R8C8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e5db979085a3dc3226c0b3596ba9bc9046dbe7a8",
+        "rev": "beaee455c56dee413b33f89f6ebd0520ff435295",
         "type": "github"
       },
       "original": {
@@ -414,11 +414,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1720831842,
-        "narHash": "sha256-Glz/h5UF4/IASu5IAOmGbLf+hQ1dT/aFW3h8jLMMm5w=",
+        "lastModified": 1721263838,
+        "narHash": "sha256-ZFcyUXcxU9k5tkv/t5deuQ8PRY0Q0/uk8MLHUb2eXEs=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "96d6b3852707eddd262238ddc38fe4e91a8fa169",
+        "rev": "7bcd019c70e1929d733ed0bf5349c747ce0ee66a",
         "type": "github"
       },
       "original": {
@@ -1091,11 +1091,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1720830292,
-        "narHash": "sha256-TcEsmzMdubSTbEw6cdbL3N+0F/CFfWwHoyKbO5J21Zw=",
+        "lastModified": 1721262189,
+        "narHash": "sha256-FhQK+UGKGBJCyLo8NBhU65QKm5loHS/APUKno/9jO/U=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "70d21dadbc0057a1858f294975315aeee0b22cc0",
+        "rev": "a55d366b4ab71687ce60d428a775a4ecc824a658",
         "type": "github"
       },
       "original": {
@@ -1162,11 +1162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720818892,
-        "narHash": "sha256-f52x9srIcqQm1Df3T+xYR5P6VfdnDFa2vkkcLhlTp6U=",
+        "lastModified": 1721059077,
+        "narHash": "sha256-gCICMMX7VMSKKt99giDDtRLkHJ0cwSgBtDijJAqTlto=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5b002f8a53ed04c1a4177e7b00809d57bd2c696f",
+        "rev": "0fb28f237f83295b4dd05e342f333b447c097398",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
         in
         builtins.trace "Nix Primer version is ${v}" "git-${v}";
 
-      ghcVersion = "ghc982";
+      ghcVersion = "ghc9101";
 
       # We must keep the weeder version in sync with the version of
       # GHC we're using.
@@ -62,7 +62,7 @@
         inputs.self.overlays.default
       ];
 
-      # cabal-fmt needs an override for GHC 9.8.1.
+      # cabal-fmt needs an override for GHC > 9.8.1.
       cabal-fmt-override = {
         version = "latest";
         cabalProject = ''
@@ -299,22 +299,30 @@
               ];
 
               haskellNixTools = pkgs.haskell-nix.tools ghcVersion {
-                hlint = "latest";
+                # Disabled for GHC 9.10.
+                # https://github.com/ndmitchell/hlint/pull/1594
+                #hlint = "latest";
                 fourmolu = fourmoluVersion;
-                cabal-fmt = cabal-fmt-override;
+
+                # Disabled for GHC 9.10.
+                # https://github.com/input-output-hk/haskell.nix/issues/2205
+                #cabal-fmt = cabal-fmt-override;
               };
             in
             {
               projectRootFile = "flake.nix";
 
-              programs.hlint = {
-                enable = true;
-                package = haskellNixTools.hlint;
-              };
-              programs.cabal-fmt = {
-                enable = true;
-                package = haskellNixTools.cabal-fmt;
-              };
+              # Disabled for GHC 9.10.
+              # programs.hlint = {
+              #   enable = true;
+              #   package = haskellNixTools.hlint;
+              # };
+
+              # Disabled for GHC 9.10.
+              # programs.cabal-fmt = {
+              #   enable = true;
+              #   package = haskellNixTools.cabal-fmt;
+              # };
               programs.fourmolu = {
                 enable = true;
                 package = haskellNixTools.fourmolu;
@@ -322,7 +330,9 @@
               programs.nixpkgs-fmt.enable = true;
               programs.shellcheck.enable = true;
 
-              settings.formatter.hlint.excludes = haskellExcludes;
+              # Disabled for GHC 9.10.
+              #settings.formatter.hlint.excludes = haskellExcludes;
+
               settings.formatter.fourmolu.excludes = haskellExcludes;
             };
 
@@ -337,8 +347,8 @@
             wasm = pkgs.mkShell {
               packages = with inputs.ghc-wasm.packages.${system};
                 [
-                  wasm32-wasi-ghc-9_8
-                  wasm32-wasi-cabal-9_8
+                  wasm32-wasi-ghc-9_10
+                  wasm32-wasi-cabal-9_10
                   wasmtime
 
                   pkgs.gnumake
@@ -481,14 +491,17 @@
                     implicit-hie = "latest";
 
                     cabal = "latest";
-                    hlint = "latest";
+
+                    # Disabled for GHC 9.10.
+                    #hlint = "latest";
 
                     # Disabled, as it doesn't currently build with Nix.
                     #weeder = weederVersion;
 
                     fourmolu = fourmoluVersion;
 
-                    cabal-fmt = cabal-fmt-override;
+                    # Disabled for GHC 9.10.
+                    #cabal-fmt = cabal-fmt-override;
 
                     #TODO Explicitly requiring tasty-discover shouldn't be necessary - see the commented-out `build-tool-depends` in primer.cabal.
                     tasty-discover = "latest";

--- a/primer-api/primer-api.cabal
+++ b/primer-api/primer-api.cabal
@@ -34,7 +34,7 @@ library
     -Wmissing-deriving-strategies -fhide-source-paths
 
   build-depends:
-    , base            >=4.12    && <4.20
+    , base            >=4.12    && <4.21
     , containers      >=0.6.0.1 && <0.7.0
     , deriving-aeson  >=0.2     && <0.3.0
     , extra           >=1.7.10  && <1.8.0

--- a/primer-benchmark/primer-benchmark.cabal
+++ b/primer-benchmark/primer-benchmark.cabal
@@ -41,7 +41,7 @@ library
   exposed-modules: Benchmarks
   build-depends:
     , aeson                  >=2.0      && <2.3
-    , base                   >=4.12     && <4.20
+    , base                   >=4.12     && <4.21
     , containers             >=0.6.0.1  && <0.7.0
     , criterion              ^>=1.6.0.0
     , deepseq                ^>=1.5

--- a/primer-selda/primer-selda.cabal
+++ b/primer-selda/primer-selda.cabal
@@ -33,7 +33,7 @@ library
 
   build-depends:
     , aeson           >=2.0      && <2.3
-    , base            >=4.12     && <4.20
+    , base            >=4.12     && <4.21
     , bytestring      >=0.10.8.2 && <0.13
     , containers      >=0.6.0.1  && <0.7.0
     , logging-effect  ^>=1.4

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -40,7 +40,7 @@ library
 
   build-depends:
     , aeson                      >=2.0      && <2.3
-    , base                       >=4.12     && <4.20
+    , base                       >=4.12     && <4.21
     , containers                 >=0.6.0.1  && <0.8
     , deriving-aeson             >=0.2      && <0.3.0
     , exceptions                 >=0.10.4   && <0.11.0

--- a/primer/primer.cabal
+++ b/primer/primer.cabal
@@ -110,7 +110,7 @@ library
   build-depends:
     , aeson                        >=2.0      && <2.3
     , assoc                        ^>=1.1
-    , base                         >=4.12     && <4.20
+    , base                         >=4.12     && <4.21
     , base64-bytestring            ^>=1.2.1
     , containers                   >=0.6.0.1  && <0.7.0
     , deriving-aeson               >=0.2      && <0.3.0


### PR DESCRIPTION
Note that Protolude upstream doesn't support GHC 9.10, so we use a (hopefully temporary) fork.