### PR TITLE
chore: improved Wasm support

### DIFF
--- a/.buildkite/primer-wasm.yaml
+++ b/.buildkite/primer-wasm.yaml
@@ -21,6 +21,16 @@ steps:
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 test
 
+  - label: ":haskell: :macos: Primer Wasm tests"
+    if: |
+      build.branch =~ /^gh-readonly-queue\// ||
+      build.pull_request.labels includes "Run Wasm tests"
+    command: |
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 test
+    agents:
+      os: "darwin"
+
   - label: ":haskell: :linux: Primer Wasm build"
     if: |
       build.branch !~ /^gh-readonly-queue\// &&
@@ -28,3 +38,13 @@ steps:
     command: |
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32
+
+  - label: ":haskell: :macos: Primer Wasm build"
+    if: |
+      build.branch !~ /^gh-readonly-queue\// &&
+      !(build.pull_request.labels includes "Run Wasm tests")
+    command: |
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32
+    agents:
+      os: "darwin"

--- a/cabal.project
+++ b/cabal.project
@@ -15,25 +15,29 @@ else
     primer-benchmark
 
 if arch(wasm32)
-   package *
-     optimization: 2
+  haddock-hoogle:           False
+  haddock-html:             False
+  haddock-quickjump:        False
+  haddock-hyperlink-source: False
+  haddock-internal:         False
+  package *
+    optimization: 2
+    ghc-options: -fno-external-interpreter
 else
   optimization: 0
+  haddock-hoogle:           True
+  haddock-html:             True
+  haddock-quickjump:        True
+  haddock-hyperlink-source: True
+  haddock-internal:         True
+  package *
+    ghc-options: -fwrite-ide-info
 
 benchmarks: True
 
 tests: True
 
-haddock-hoogle:           True
-haddock-html:             True
-haddock-quickjump:        True
-haddock-hyperlink-source: True
-haddock-internal:         True
-
-allow-newer: servant-openapi3:base, openapi3:*, selda:*, hedgehog:pretty-show, hedgehog-classes:pretty-show
-
-package *
-  ghc-options: -fwrite-ide-info
+allow-newer: servant-openapi3:base, openapi3:*, selda:*, hedgehog:pretty-show, hedgehog-classes:pretty-show, *:time
 
 package primer
   test-options: "--size-cutoff=32768"

--- a/flake.lock
+++ b/flake.lock
@@ -259,17 +259,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1725254321,
-        "narHash": "sha256-lGBOi5kLXiadh+9erNcr4Ek+gpOe3BPthSvhkFQcdNQ=",
+        "lastModified": 1729816601,
+        "narHash": "sha256-/GrnRM/5f8DdC+8kuGLJijMBsUULZW5QJU3JcJFGJoc=",
         "ref": "refs/heads/master",
-        "rev": "a04cc1a2206d2030326e1d49be9c6a94ee4283a3",
-        "revCount": 183,
+        "rev": "64e6c8942a7805c0b3a2a7b74846ad962d142208",
+        "revCount": 191,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
       },
       "original": {
-        "ref": "refs/heads/master",
-        "rev": "a04cc1a2206d2030326e1d49be9c6a94ee4283a3",
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-    ghc-wasm.url = "git+https://gitlab.haskell.org/ghc/ghc-wasm-meta?ref=refs/heads/master&rev=a04cc1a2206d2030326e1d49be9c6a94ee4283a3";
+    ghc-wasm.url = "git+https://gitlab.haskell.org/ghc/ghc-wasm-meta";
   };
 
   outputs = inputs@ { flake-parts, ... }:
@@ -330,8 +330,6 @@
                 config.treefmt.build.devShell
               ];
             };
-          } // (pkgs.lib.optionalAttrs (system == "x86_64-linux")) {
-            # Unfortunately, this is only available on x86_64-linux.
             wasm = pkgs.mkShell {
               packages = with inputs.ghc-wasm.packages.${system};
                 [


### PR DESCRIPTION
Namely:

* Bump `ghc-wasm` flake to latest, which includes support for Template
Haskell and macOS. Note that we now need to pass
`-fno-external-interpreter` to GHC; this appears to be related to
https://github.com/NixOS/nixpkgs/issues/275304.

* Run the Wasm build on macOS in CI, in addition to Linux.

* Don't bother building Haddocks in the Wasm build.

* Don't use `-fwrite-ide-info` in Wasm build.

* `allow-newer` for `time` package.