### PR TITLE
chore(hackage): bump `index-state`, more strict PvP

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2024-07-13T00:00:00Z
+index-state: 2024-11-02T00:00:00Z
 
 jobs: $ncpus
 
@@ -30,7 +30,7 @@ haddock-quickjump:        True
 haddock-hyperlink-source: True
 haddock-internal:         True
 
-allow-newer: all
+allow-newer: servant-openapi3:base, openapi3:*, selda:*, hedgehog:pretty-show, hedgehog-classes:pretty-show
 
 package *
   ghc-options: -fwrite-ide-info

--- a/cabal.project
+++ b/cabal.project
@@ -101,5 +101,5 @@ if arch(wasm32)
   source-repository-package
     type: git
     location: https://github.com/amesgen/splitmix
-    tag: 83b906c4bcdc2720546f1779a16eb65e8e12ecba
-    --sha256: sha256-sR+Ne56SBzVbPfC7AJeQZn20YDfFwBDpRI873cTm1nU=
+    tag: 5f5b766d97dc735ac228215d240a3bb90bc2ff75
+    --sha256: sha256-OCrEnjmESxtFHoeb4TCrQN//Oyx/7dKwiRr6P1/AqSk=

--- a/flake.nix
+++ b/flake.nix
@@ -442,12 +442,13 @@
                       "fail"
                     ];
 
-                    # These packages don't generate HIE files. See:
+                    # These packages don't/can't generate HIE files. See:
                     # https://github.com/input-output-hk/haskell.nix/issues/1242
                     packages.mtl-compat.writeHieFiles = false;
                     packages.bytestring-builder.writeHieFiles = false;
                     packages.fail.writeHieFiles = false;
                     packages.diagrams.writeHieFiles = false;
+                    packages.happy-lib.writeHieFiles = false;
                   }
                   {
                     #TODO This shouldn't be necessary - see the commented-out `build-tool-depends` in primer.cabal.

--- a/primer-service/primer-service.cabal
+++ b/primer-service/primer-service.cabal
@@ -57,11 +57,11 @@ library
     , primer-api                 ^>=0.7.2
     , refined                    ^>=0.8
     , semirings                  >=0.6      && <0.8
-    , servant                    >=0.18     && <0.20.2
-    , servant-client             >=0.18     && <0.20.2
-    , servant-client-core        >=0.18     && <0.20.2
+    , servant                    >=0.18     && <0.20.3
+    , servant-client             >=0.18     && <0.20.3
+    , servant-client-core        >=0.18     && <0.20.3
     , servant-openapi3           ^>=2.0.1.2
-    , servant-server             >=0.18     && <0.20.2
+    , servant-server             >=0.18     && <0.20.3
     , stm                        ^>=2.5
     , stm-containers             >=1.1      && <1.3.0
     , streaming-commons          ^>=0.2.2.4


### PR DESCRIPTION
Setting `allow-newer: all` is finally catching up to us, so we go back to a more strict policy, and override only what's necessary (mainly due to a few packages not explicitly supporting GHC 9.10 yet).

Also, we bump servant & friends to the latest version.