### PR TITLE
feat: add `primer-miso`, an attempt to re-implement Primer's UI in Haskell

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -75,10 +75,14 @@
   - {name: Data.Text.init, within: []}
   - {name: Data.Text.last, within: []}
 
-  - {name: minimum, within: []} # Partial
-  - {name: minimumBy, within: []} # Partial
-  - {name: maximum, within: []} # Partial
-  - {name: maximumBy, within: []} # Partial
+  - {name: Data.Foldable.minimum, within: []} # Partial
+  - {name: Data.Foldable.minimumBy, within: []} # Partial
+  - {name: Data.Foldable.maximum, within: []} # Partial
+  - {name: Data.Foldable.maximumBy, within: []} # Partial
+  - {name: Data.List.minimum, within: []} # Partial
+  - {name: Data.List.minimumBy, within: []} # Partial
+  - {name: Data.List.maximum, within: []} # Partial
+  - {name: Data.List.maximumBy, within: []} # Partial
 
   # Same, but for Data.Text
   - {name: Data.Text.maximum, within: []}

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 #
 # This Makefile assumes you're using the `nix develop` shell.
 
-build:	configure
+build:
 	cabal build all
 
-project-targets = configure test bench haddock
+project-targets = test bench haddock
 
 $(project-targets):
 	cabal $@ all

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ package-targets = update-tests
 $(package-targets):
 	$(MAKE) -C primer $@
 	$(MAKE) -C primer-api $@
+	$(MAKE) -C primer-miso $@
 	$(MAKE) -C primer-selda $@
 	$(MAKE) -C primer-service $@
 	$(MAKE) -C primer-benchmark $@

--- a/Makefile.wasm32
+++ b/Makefile.wasm32
@@ -22,7 +22,17 @@ $(test-targets):
 update:
 	$(CABAL) update
 
+frontend:
+	$(MAKE) -C primer-miso frontend
+
+frontend-prod:
+	$(MAKE) -C primer-miso frontend-prod
+
+serve-frontend:
+	$(MAKE) -C primer-miso serve-frontend
+
 clean:
 	$(CABAL) clean
+	$(MAKE) -C primer-miso clean
 
 .PHONY: build configure $(test-targets) update clean

--- a/Makefile.wasm32
+++ b/Makefile.wasm32
@@ -7,11 +7,8 @@ MAKE := $(MAKE) -f Makefile.wasm32
 
 CABAL = wasm32-wasi-cabal
 
-build:	configure discover-tests
+build:	discover-tests
 	$(CABAL) build all
-
-configure:
-	$(CABAL) configure all
 
 test-targets = discover-tests test
 
@@ -35,4 +32,4 @@ clean:
 	$(CABAL) clean
 	$(MAKE) -C primer-miso clean
 
-.PHONY: build configure $(test-targets) update clean
+.PHONY: build $(test-targets) update clean

--- a/cabal.project
+++ b/cabal.project
@@ -6,10 +6,12 @@ if arch(wasm32)
   packages:
     primer
     primer-api
+    primer-miso
 else
   packages:
     primer
     primer-api
+    primer-miso
     primer-selda
     primer-service
     primer-benchmark
@@ -68,6 +70,14 @@ source-repository-package
   tag: 2e3dc54d7de8365b3be84da76f08327dc8b40f61
   subdir: selda selda-sqlite
   --sha256: 0fw336sb03sc54pzmkz6jn989zvbnwnzypb9n0ackprymnvh8mym
+
+-- Until a new Hackage release is made which includes
+-- https://github.com/dmjio/miso/pull/752
+source-repository-package
+  type: git
+  location: https://github.com/dmjio/miso
+  tag: 2b548d48bffb0e8ae28a6cfb886e4afb0d8be37a
+  --sha256: sha256-fzDEa8vKXgxPPB+8NDLmhn2Jw1UDZso7e/klwidCfhM=
 
 -- Wasm workarounds.
 --

--- a/cabal.project
+++ b/cabal.project
@@ -79,6 +79,9 @@ source-repository-package
 -- dependencies*, using Nix while in the Nix development shell.
 
 if arch(wasm32)
+  -- Required for TemplateHaskell support on Wasm targets.
+  shared: True
+
   -- Upstream requires `happy` at build time, which doesn't work on Wasm
   -- targets.
   source-repository-package

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -72,7 +72,7 @@ For interactive development workflows, both with and without Nix, we
 provide some convenient `Makefile` targets from the repository's top
 level directory. For example:
 
-* `make` runs `cabal configure all` followed by `cabal build all`.
+* `make` runs `cabal build all`.
 
 * `make test` runs `cabal test all`.
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -36,3 +36,17 @@ with the following caveats:
    ```sh
    make -f Makefile.wasm32 test
    ```
+
+3. We now have a very preliminary Wasm frontend for Primer. The goal
+   of this frontend is to eventually replace the existing TypeScript
+   frontend, but it's currently missing quite a bit of that
+   implementation's functionality.
+
+   To run the Wasm frontend, use the following command from the
+   special Wasm shell:
+
+   ```sh
+   make -f Makefile.wasm32 serve-frontend
+   ```
+
+   Then visit http://localhost:8000 in your browser.

--- a/flake.nix
+++ b/flake.nix
@@ -333,11 +333,11 @@
             wasm = pkgs.mkShell {
               packages = with inputs.ghc-wasm.packages.${system};
                 [
-                  wasm32-wasi-ghc-9_10
-                  wasm32-wasi-cabal-9_10
-                  wasmtime
+                  all_9_10
 
                   pkgs.gnumake
+                  pkgs.simple-http-server
+                  pkgs.brotli
 
                   # We need to run native `tasty-discover` at compile
                   # time, because we can't do it via `wasmtime`.

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -3,10 +3,10 @@
 # Most commands assume you're running this from the top-level `nix
 # develop` shell.
 
-build:	configure
+build:
 	cabal build
 
-package-targets = configure test haddock clean
+package-targets = test haddock clean
 
 $(package-targets):
 	cabal $@

--- a/primer-api/Makefile.wasm32
+++ b/primer-api/Makefile.wasm32
@@ -6,11 +6,8 @@ CABAL = wasm32-wasi-cabal
 
 primer-api-test-path	= $(shell $(CABAL) list-bin -v0 test:primer-api-test)
 
-build:	configure discover-tests
+build:	discover-tests
 	$(CABAL) build
-
-configure:
-	$(CABAL) configure
 
 # test target is special because it requires wasmtime.
 test: 	build
@@ -23,4 +20,4 @@ clean:
 	$(CABAL) clean
 	rm -f test/TestsWasm32.hs
 
-.PHONY: build configure test discover-tests clean
+.PHONY: build test discover-tests clean

--- a/primer-miso/.gitignore
+++ b/primer-miso/.gitignore
@@ -1,0 +1,2 @@
+dist/
+ghc_wasm_jsffi.js

--- a/primer-miso/COPYING
+++ b/primer-miso/COPYING
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/primer-miso/Makefile
+++ b/primer-miso/Makefile
@@ -1,0 +1,5 @@
+# NOTE:
+#
+# This Makefile assumes you're using the `nix develop` shell.
+
+include ../makefiles/common.mk

--- a/primer-miso/Makefile.wasm32
+++ b/primer-miso/Makefile.wasm32
@@ -1,0 +1,26 @@
+# NOTE:
+#
+# This Makefile assumes you're using the `nix develop .#wasm` shell.
+
+CABAL = wasm32-wasi-cabal
+
+build:	configure
+	$(CABAL) build
+
+frontend: build
+	./build-frontend.sh
+
+frontend-prod: build
+	./build-frontend.sh -Oz
+
+serve-frontend: frontend
+	simple-http-server -i -p 8000 -- dist
+
+configure:
+	$(CABAL) configure
+
+clean:
+	$(CABAL) clean
+	rm -rf dist/
+
+.PHONY: build configure clean

--- a/primer-miso/Makefile.wasm32
+++ b/primer-miso/Makefile.wasm32
@@ -4,7 +4,7 @@
 
 CABAL = wasm32-wasi-cabal
 
-build:	configure
+build:
 	$(CABAL) build
 
 frontend: build
@@ -16,11 +16,8 @@ frontend-prod: build
 serve-frontend: frontend
 	simple-http-server -i -p 8000 -- dist
 
-configure:
-	$(CABAL) configure
-
 clean:
 	$(CABAL) clean
 	rm -rf dist/
 
-.PHONY: build configure clean
+.PHONY: build clean

--- a/primer-miso/build-frontend.sh
+++ b/primer-miso/build-frontend.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Building for dev"
+    dev_mode=true
+else
+    echo "Building for prod"
+    dev_mode=false
+fi
+
+rm -rf dist
+mkdir dist
+cp frontend/*.html dist/
+
+hs_wasm_path=$(wasm32-wasi-cabal list-bin -v0 exe:primer-miso)
+
+ghc_wasm_jsffi="dist/ghc_wasm_jsffi.js"
+
+"$(wasm32-wasi-ghc --print-libdir)"/post-link.mjs \
+                                   --input "$hs_wasm_path" --output "$ghc_wasm_jsffi"
+
+if ! [ -f "$ghc_wasm_jsffi" ] ; then
+    echo "post-link.mjs didn't produce a $ghc_wasm_jsffi file. Make sure you're in the Nix Wasm shell."
+    exit 1
+fi
+
+if $dev_mode; then
+    cp "$hs_wasm_path" dist/bin.wasm
+else
+    wizer --allow-wasi --wasm-bulk-memory true --init-func _initialize -o dist/bin.wasm "$hs_wasm_path"
+    wasm-opt ${1+"$@"} dist/bin.wasm -o dist/bin.wasm
+    wasm-tools strip -o dist/bin.wasm dist/bin.wasm
+    brotli --rm --best dist/bin.wasm -o dist/bin.wasm.br
+    mv dist/bin.wasm.br dist/bin.wasm
+fi
+
+cp frontend/*.js dist

--- a/primer-miso/exe/Main.hs
+++ b/primer-miso/exe/Main.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE CPP #-}
+
+#ifdef wasi_HOST_OS
+
+module MyMain (main) where
+
+import Foreword
+
+--import GHC.Wasm.Prim
+import Language.Javascript.JSaddle.Wasm qualified as JSaddle.Wasm
+import Primer.Miso (start)
+
+foreign export javascript "hs_start" main :: IO ()
+
+main :: IO ()
+main = JSaddle.Wasm.run start
+
+#else
+
+module Main (main) where
+
+import Foreword
+
+import Language.Javascript.JSaddle.Warp
+import Primer.Miso (start)
+
+-- Note that `debug` works with `cabal repl` but not `cabal run`.
+-- The best workflow is to run `ghcid -c "cabal repl primer-miso" -W -T ':main'`.
+main :: IO ()
+main = debug 8000 start
+
+#endif

--- a/primer-miso/exe/Main.hs
+++ b/primer-miso/exe/Main.hs
@@ -6,7 +6,6 @@ module MyMain (main) where
 
 import Foreword
 
---import GHC.Wasm.Prim
 import Language.Javascript.JSaddle.Wasm qualified as JSaddle.Wasm
 import Primer.Miso (start)
 

--- a/primer-miso/exe/Main.hs
+++ b/primer-miso/exe/Main.hs
@@ -20,7 +20,7 @@ module Main (main) where
 
 import Foreword
 
-import Language.Javascript.JSaddle.Warp
+import Language.Javascript.JSaddle.Warp ( debug )
 import Primer.Miso (start)
 
 -- Note that `debug` works with `cabal repl` but not `cabal run`.

--- a/primer-miso/frontend/index.html
+++ b/primer-miso/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Primer</title>
+</head>
+
+<body>
+        <script src="index.js" type="module"></script>
+</body>
+
+</html>

--- a/primer-miso/frontend/index.js
+++ b/primer-miso/frontend/index.js
@@ -1,0 +1,22 @@
+import { WASI, OpenFile, File, ConsoleStdout } from "https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.3.0/dist/index.js";
+import ghc_wasm_jsffi from "./ghc_wasm_jsffi.js";
+
+const args = [];
+const env = [];
+const fds = [
+  new OpenFile(new File([])), // stdin
+  ConsoleStdout.lineBuffered((msg) => console.log(`[WASI stdout] ${msg}`)),
+  ConsoleStdout.lineBuffered((msg) => console.warn(`[WASI stderr] ${msg}`)),
+];
+const options = { debug: false };
+const wasi = new WASI(args, env, fds, options);
+
+const instance_exports = {};
+const { instance } = await WebAssembly.instantiateStreaming(fetch("bin.wasm"), {
+  wasi_snapshot_preview1: wasi.wasiImport,
+  ghc_wasm_jsffi: ghc_wasm_jsffi(instance_exports),
+});
+Object.assign(instance_exports, instance.exports);
+
+wasi.initialize(instance);
+await instance.exports.hs_start();

--- a/primer-miso/primer-miso.cabal
+++ b/primer-miso/primer-miso.cabal
@@ -1,16 +1,21 @@
-cabal-version: 3.0
-name:          primer-miso
-version:       0.8.0.0
-license:       AGPL-3.0-or-later
-license-file:  COPYING
-copyright:     (c) 2024 Hackworth Ltd
-maintainer:    src@hackworthltd.com
-author:        Hackworth Ltd <src@hackworthltd.com>
-stability:     experimental
+cabal-version:      3.0
+name:               primer-miso
+version:            0.8.0.0
+license:            AGPL-3.0-or-later
+license-file:       COPYING
+copyright:          (c) 2024 Hackworth Ltd
+maintainer:         src@hackworthltd.com
+author:             Hackworth Ltd <src@hackworthltd.com>
+stability:          experimental
 synopsis:
   A web frontend for building Primer programs, using the Miso framework
 
-category:      UI
+extra-source-files:
+  build-frontend.sh
+  frontend/**/*.html
+  frontend/**/*.js
+
+category:           UI
 
 library
   exposed-modules:
@@ -100,8 +105,3 @@ executable primer-miso
       , websockets
 
     ghc-options:   -threaded -rtsopts -with-rtsopts=-N
-
-  extra-source-files:
-    build-frontend.sh
-    frontend/**/*.html
-    frontend/**/*.js

--- a/primer-miso/primer-miso.cabal
+++ b/primer-miso/primer-miso.cabal
@@ -1,0 +1,107 @@
+cabal-version: 3.0
+name:          primer-miso
+version:       0.8.0.0
+license:       AGPL-3.0-or-later
+license-file:  COPYING
+copyright:     (c) 2024 Hackworth Ltd
+maintainer:    src@hackworthltd.com
+author:        Hackworth Ltd <src@hackworthltd.com>
+stability:     experimental
+synopsis:
+  A web frontend for building Primer programs, using the Miso framework
+
+category:      UI
+
+library
+  exposed-modules:
+    Primer.Miso
+    Primer.Miso.Colors
+    Primer.Miso.Layout
+    Primer.Miso.Util
+
+  hs-source-dirs:     src
+  default-language:   GHC2021
+  default-extensions:
+    DataKinds
+    DeriveAnyClass
+    DerivingStrategies
+    DerivingVia
+    LambdaCase
+    NoImplicitPrelude
+    OverloadedStrings
+
+  ghc-options:
+    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wcompat -Widentities -Wredundant-constraints
+    -Wmissing-deriving-strategies -fhide-source-paths
+
+  build-depends:
+    , aeson           >=2.0      && <2.3
+    , base            >=4.12     && <4.21
+    , bytestring      >=0.10.8.2 && <0.13
+    , containers      >=0.6.0.1  && <0.7.0
+    , data-default    ^>=0.8.0.0
+    , deriving-aeson  >=0.2      && <0.3.0
+    , extra           >=1.7.10   && <1.8.0
+    , jsaddle         ^>=0.9.9.2
+    , linear          ^>=1.23
+    , miso            ^>=1.8.5.0
+    , mtl             >=2.2.2    && <2.4.0
+    , optics          >=0.4      && <0.5.0
+    , primer          ^>=0.7.2
+    , text            >=2.0      && <2.2
+    , uniplate        >=1.6      && <1.7.0
+
+  if arch(wasm32)
+    build-depends: jsaddle-wasm ^>=0.0.1.0
+
+  else
+    build-depends:
+      , jsaddle-warp  ^>=0.9.9.2
+      , warp          >=3.3       && <3.5
+      , websockets    ^>=0.13.0.0
+
+executable primer-miso
+  main-is:            Main.hs
+  hs-source-dirs:     exe
+  default-language:   GHC2021
+  default-extensions:
+    DataKinds
+    DeriveAnyClass
+    DerivingStrategies
+    DerivingVia
+    LambdaCase
+    NoImplicitPrelude
+    OverloadedStrings
+
+  ghc-options:
+    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wcompat -Widentities -Wredundant-constraints
+    -Wmissing-deriving-strategies -fhide-source-paths
+
+  build-depends:
+    , base
+    , jsaddle
+    , primer
+    , primer-miso
+
+  if arch(wasm32)
+    build-depends:
+      , ghc-experimental  ^>=0.1.0.0
+      , jsaddle-wasm
+
+    ghc-options:
+      -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
+
+  else
+    build-depends:
+      , jsaddle-warp
+      , warp
+      , websockets
+
+    ghc-options:   -threaded -rtsopts -with-rtsopts=-N
+
+  extra-source-files:
+    build-frontend.sh
+    frontend/**/*.html
+    frontend/**/*.js

--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -13,7 +13,7 @@ import Foreword hiding (minimum)
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Data (Data (..))
-import Data.Default (Default (..))
+import Data.Default qualified as Default
 import Data.Generics.Uniplate.Data (children)
 import Data.Map qualified as Map
 import Data.Tree (Tree)
@@ -21,7 +21,7 @@ import Data.Tree qualified as Tree
 import GHC.Base (error)
 import Linear (R1 (_x), V2 (V2))
 import Linear.Affine ((.+^), (.-^))
-import Miso hiding (P)
+import Miso hiding (P, node)
 import Optics hiding (view)
 import Optics.State.Operators ((?=))
 import Primer.App
@@ -164,8 +164,8 @@ viewNode opts extraOuterStyles extraInnerStyles =
                           <> extraInnerStyles
                     ]
                     [ text case opts of
-                        SyntaxNode{text} -> text
-                        HoleNode{empty} -> if empty then "?" else "⚠️"
+                        SyntaxNode{text = t} -> t
+                        HoleNode{empty = e} -> if e then "?" else "⚠️"
                         PrimNode pc -> case pc of
                           PrimChar c' -> show c'
                           PrimInt n -> show n
@@ -179,14 +179,14 @@ viewNode opts extraOuterStyles extraInnerStyles =
                     _ -> bluePrimary
           where
             borderColor = case opts of
-              SyntaxNode{..} -> color
+              SyntaxNode{color} -> color
               HoleNode{} -> redTertiary
               PrimNode{} -> greenPrimary
               ConNode{} -> greenPrimary
               VarNode{} -> blueQuaternary
               PatternBoxNode{} -> yellowPrimary
             backgroundColor = case opts of
-              SyntaxNode{..} -> color
+              SyntaxNode{color} -> color
               PatternBoxNode{} -> yellowPrimary <> "33" -- 1/5 opacity
               _ -> whitePrimary
     }
@@ -350,7 +350,7 @@ viewTreeWithDimensions outerPadding t =
     nodes =
       toNonEmpty $
         symmLayout' @Double
-          ( def
+          ( Default.def
               & (slHSep .~ padding)
               & (slVSep .~ padding)
               & (slWidth .~ \node -> (-(node.dimensions.x / 2), node.dimensions.x / 2))

--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -1,0 +1,366 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Primer.Miso (start) where
+
+import Foreword hiding (minimum)
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Data (Data (..))
+import Data.Default (Default (..))
+import Data.Generics.Uniplate.Data (children)
+import Data.Map qualified as Map
+import Data.Tree (Tree)
+import Data.Tree qualified as Tree
+import GHC.Base (error)
+import Linear (R1 (_x), V2 (V2))
+import Linear.Affine ((.+^), (.-^))
+import Miso hiding (P)
+import Optics hiding (view)
+import Optics.State.Operators ((?=))
+import Primer.App
+import Primer.Core hiding (App)
+import Primer.Core qualified as Primer
+import Primer.Def (Def (..))
+import Primer.JSON (CustomJSON (..), PrimerJSON)
+import Primer.Miso.Colors
+import Primer.Miso.Layout
+import Primer.Miso.Util
+import Primer.Module (Module (moduleDefs, moduleName))
+import Primer.Name (Name, unName)
+
+start :: JSM ()
+start =
+  startAppWithSavedState
+    App
+      { model = Model{def = mapDef, selection = Nothing}
+      , update = updateModel
+      , view = viewModel
+      , subs = []
+      , events = defaultEvents
+      , initialAction = NoOp "start"
+      , mountPoint = Nothing
+      , logLevel = Off
+      }
+  where
+    -- TODO we display a single hardcoded expression, for the sake of demonstration
+    mapDef =
+      either (error . ("Prelude.map failed to typecheck: " <>) . show) identity
+        . tcBasicProg p
+        $ fromMaybe (error "prog doesn't contain Prelude.map") do
+          m <- find ((== mkSimpleModuleName "Prelude") . moduleName) $ progImports p
+          DefAST d <- Map.lookup "map" $ moduleDefs m
+          pure d
+      where
+        (p, _, _) = newProg
+
+data Model = Model
+  { def :: ASTDefT -- We typecheck everything up front so that we can use `ExprT`, guaranteeing existence of metadata.
+  , selection :: Maybe NodeSelectionT -- TODO once we move beyond one-tree prototype, we'll need to generalise this
+  }
+  deriving stock (Eq, Show, Read, Generic)
+  deriving (ToJSON, FromJSON) via PrimerJSON Model
+
+data Action
+  = NoOp Text -- For situations where Miso requires an action, but we don't actually want to do anything.
+  | SelectNode NodeSelectionT
+  deriving stock (Eq, Show)
+
+updateModel :: Action -> Model -> Effect Action Model
+updateModel =
+  fromTransition . \case
+    NoOp _ -> pure ()
+    SelectNode sel -> #selection ?= sel
+
+viewModel :: Model -> View Action
+viewModel Model{..} =
+  div_ [] $
+    [ div_
+        [ style_
+            [ ("display", "grid")
+            , ("grid-template-columns", "1fr 1fr 1fr")
+            , ("justify-items", "center")
+            ]
+        ]
+        [ SelectNode . NodeSelection SigNode <$> viewTree (viewTreeType def.sig)
+        , SelectNode . NodeSelection BodyNode <$> viewTree (viewTreeExpr def.expr)
+        , case selection of
+            Nothing -> "no selection"
+            Just s ->
+              NoOp "clicked non-interactive node" <$ case nodeSelectionType s of
+                Left t -> viewTree $ viewTreeType t
+                Right (Left t) -> viewTree $ viewTreeKind t
+                -- TODO this isn't really correct - kinds in Primer don't have kinds
+                Right (Right ()) -> viewTree $ viewTreeKind $ KType ()
+        ]
+    ]
+
+data NodeViewData
+  = SyntaxNode {wide :: Bool, color :: Text, text :: Text}
+  | HoleNode {empty :: Bool}
+  | PrimNode PrimCon
+  | ConNode {name :: Name, scope :: ModuleName}
+  | VarNode {name :: Name, mscope :: Maybe ModuleName} -- TODO we should be able to re-use the name `scope`: https://github.com/ghc-proposals/ghc-proposals/pull/535#issuecomment-1694388075
+  | PatternBoxNode (forall action. MeasuredView action)
+
+viewNode :: NodeViewData -> Map Text Text -> Map Text Text -> MeasuredView action
+viewNode opts extraOuterStyles extraInnerStyles =
+  MeasuredView
+    { dimensions
+    , view = case opts of
+        PrimNode (PrimAnimation animation) ->
+          img_
+            [ src_ ("data:img/gif;base64," <> animation)
+            , style_ $
+                [ ("width", show dimensions.x <> "px")
+                , ("height", show dimensions.y <> "px")
+                ]
+                  <> extraOuterStyles
+                  <> extraInnerStyles
+            ]
+        _ ->
+          div_
+            [ style_ $
+                [ ("display", "flex")
+                , ("justify-content", "center")
+                , ("align-items", "center")
+                , ("border-style", "solid")
+                , ("box-sizing", "border-box")
+                , ("border-color", borderColor)
+                , ("background-color", backgroundColor)
+                , ("width", show dimensions.x <> "px")
+                , ("height", show dimensions.y <> "px")
+                , ("border-width", ".25rem")
+                ]
+                  <> case opts of
+                    HoleNode{} -> [("font-style", "italic")]
+                    _ -> []
+                  <> extraOuterStyles
+            ]
+            case opts of
+              PatternBoxNode p ->
+                [ div_
+                    [ style_
+                        [ ("position", "absolute")
+                        , ("top", show (boxPadding / 2) <> "px")
+                        ]
+                    ]
+                    [p.view]
+                ]
+              _ ->
+                [ div_
+                    [ style_ $
+                        [ ("overflow", "hidden")
+                        , ("text-overflow", "ellipsis")
+                        , ("white-space", "nowrap")
+                        , ("color", fontColor)
+                        ]
+                          <> extraInnerStyles
+                    ]
+                    [ text case opts of
+                        SyntaxNode{text} -> text
+                        HoleNode{empty} -> if empty then "?" else "⚠️"
+                        PrimNode pc -> case pc of
+                          PrimChar c' -> show c'
+                          PrimInt n -> show n
+                        ConNode{name} -> unName name
+                        VarNode{name} -> unName name
+                    ]
+                ]
+                where
+                  fontColor = case opts of
+                    SyntaxNode{} -> whitePrimary
+                    _ -> bluePrimary
+          where
+            borderColor = case opts of
+              SyntaxNode{..} -> color
+              HoleNode{} -> redTertiary
+              PrimNode{} -> greenPrimary
+              ConNode{} -> greenPrimary
+              VarNode{} -> blueQuaternary
+              PatternBoxNode{} -> yellowPrimary
+            backgroundColor = case opts of
+              SyntaxNode{..} -> color
+              PatternBoxNode{} -> yellowPrimary <> "33" -- 1/5 opacity
+              _ -> whitePrimary
+    }
+  where
+    boxPadding = 55
+    basicDims = V2 80 35
+    dimensions = case opts of
+      PatternBoxNode p -> p.dimensions + pure boxPadding
+      SyntaxNode{wide = False} -> basicDims & lensVL _x .~ basicDims.y
+      _ -> basicDims
+
+viewTreeExpr ::
+  (Data a, Data b, Data c) =>
+  Expr' a b c ->
+  Tree.Tree (MeasuredView (TermMeta' a b c))
+viewTreeExpr e =
+  Tree.Node
+    ( over #view (div_ [onClick $ Left $ e ^. _exprMetaLens] . pure) $
+        viewNode nodeView rounded []
+    )
+    childViews
+  where
+    rounded = [("border-radius", "1.5rem")] -- Curved nodes to indicate value-level expressions.
+    nodeView = case e of
+      Hole{} -> HoleNode{empty = False}
+      EmptyHole{} -> HoleNode{empty = False}
+      Ann{} -> SyntaxNode False blackPrimary ":"
+      Primer.App{} -> SyntaxNode False blueTertiary "←"
+      APP{} -> SyntaxNode False blueTertiary "←"
+      Con _ c _ -> ConNode{name = baseName c, scope = qualifiedModule c}
+      Lam{} -> SyntaxNode False bluePrimary "λ"
+      LAM{} -> SyntaxNode False blueSecondary "Λ"
+      Var _ (GlobalVarRef v) -> VarNode{name = baseName v, mscope = Just $ qualifiedModule v}
+      Var _ (LocalVarRef v) -> VarNode{name = unLocalName v, mscope = Nothing}
+      Let{} -> SyntaxNode False blueQuaternary "let"
+      LetType{} -> SyntaxNode False blueQuaternary "let type"
+      Letrec{} -> SyntaxNode False blueQuaternary "let rec"
+      PrimCon _ c -> PrimNode c
+      Case{} -> SyntaxNode True yellowPrimary "match"
+    childViews = case e of
+      Case _ scrut branches fb ->
+        mconcat
+          [ [viewTreeExpr scrut]
+          , branches <&> \(CaseBranch p bindings r) ->
+              Tree.Node
+                ( viewNode
+                    ( PatternBoxNode
+                        ( viewTreeWithDimensions False
+                            $ Tree.Node case p of
+                              PatCon c -> viewNode ConNode{name = baseName c, scope = qualifiedModule c} rounded []
+                              PatPrim c -> viewNode (PrimNode c) rounded []
+                            $ bindings
+                              <&> \(Bind _ v) ->
+                                Tree.Node (viewNode VarNode{name = unLocalName v, mscope = Nothing} rounded []) []
+                        )
+                    )
+                    rounded
+                    []
+                )
+                [viewTreeExpr r]
+          , case fb of
+              CaseExhaustive -> []
+              CaseFallback r -> [Tree.Node (viewNode (SyntaxNode False yellowPrimary "_") [] []) [viewTreeExpr r]]
+          ]
+      _ ->
+        mconcat
+          [ map (viewTreeBinding []) (e ^.. typeBindingsInExpr)
+          , map (viewTreeBinding rounded) (e ^.. bindingsInExpr)
+          , map viewTreeType (e ^.. typesInExpr)
+          , map viewTreeExpr (children e)
+          ]
+        where
+          viewTreeBinding as name = Tree.Node (viewNode VarNode{name = unLocalName name, mscope = Nothing} as []) []
+
+viewTreeType ::
+  (Data b, Data c) =>
+  Type' b c ->
+  (Tree.Tree (MeasuredView (TermMeta' a b c)))
+viewTreeType t =
+  Tree.Node
+    ( over #view (div_ [onClick $ Right $ Left $ t ^. _typeMetaLens] . pure) $
+        viewNode nodeView [] []
+    )
+    childViews
+  where
+    nodeView = case t of
+      TEmptyHole{} -> HoleNode{empty = True}
+      THole{} -> HoleNode{empty = True}
+      TCon _ c -> ConNode{name = baseName c, scope = qualifiedModule c}
+      TFun{} -> SyntaxNode False bluePrimary "→"
+      TVar _ v -> VarNode{name = unLocalName v, mscope = Nothing}
+      TApp{} -> SyntaxNode False blueTertiary "←"
+      TForall{} -> SyntaxNode False blueSecondary "∀"
+      TLet{} -> SyntaxNode False blueQuaternary "let"
+    childViews =
+      map
+        (\name -> Tree.Node (viewNode VarNode{name, mscope = Nothing} [] []) [])
+        (t ^.. bindingsInType % to unLocalName)
+        <> map viewTreeKind (t ^.. kindsInType)
+        <> map viewTreeType (children t)
+
+viewTreeKind :: (Data c) => Kind' c -> Tree.Tree (MeasuredView (TermMeta' a b c))
+viewTreeKind k =
+  Tree.Node
+    ( over #view (div_ [onClick $ Right $ Right $ k ^. _kindMetaLens] . pure) $
+        viewNode
+          nodeView
+          -- Rotate to indicate kind.
+          -- We then scale by (1 + 1/√2)/2 so that dimensions used for layout are a good approximation.
+          [("transform", "rotate(45deg) scale(0.854)")]
+          -- Rotate the content back to it's correct orientation.
+          [("transform", "rotate(-45deg)")]
+    )
+    childViews
+  where
+    nodeView = case k of
+      KHole{} -> HoleNode{empty = True}
+      KType{} -> SyntaxNode False greenPrimary "*"
+      KFun{} -> SyntaxNode False bluePrimary "→"
+    childViews = map viewTreeKind (children k)
+
+viewTree :: Tree (MeasuredView action) -> View action
+viewTree = (.view) . viewTreeWithDimensions True
+
+viewTreeWithDimensions ::
+  -- | Apply the same padding we use between nodes to the entire tree.
+  -- Should be `False` for nested trees.
+  Bool ->
+  Tree (MeasuredView action) ->
+  MeasuredView action
+viewTreeWithDimensions outerPadding t =
+  MeasuredView
+    { dimensions = bottomRight - topLeft
+    , view =
+        div_ (mwhen outerPadding [style_ [("padding", show (padding / 2) <> "px")]])
+          $ map
+            ( \(node, p) ->
+                let offset = p .-^ node.dimensions / 2
+                 in div_
+                      [ style_
+                          [ ("position", "absolute")
+                          ,
+                            ( "transform"
+                            , "translate("
+                                <> show offset.x
+                                <> "px,"
+                                <> show offset.y
+                                <> "px)"
+                            )
+                          ]
+                      ]
+                      [node.view]
+            )
+          $ toList nodes
+    }
+  where
+    mins = map (\(v, p) -> p .-^ v.dimensions / 2) nodes
+    topLeft = V2 (minimum $ map (.x) mins) (minimum $ map (.y) mins)
+    maxs = map (\(v, p) -> p .+^ v.dimensions / 2) nodes
+    bottomRight = V2 (maximum $ map (.x) maxs) (maximum $ map (.y) maxs)
+    nodes =
+      toNonEmpty $
+        symmLayout' @Double
+          ( def
+              & (slHSep .~ padding)
+              & (slVSep .~ padding)
+              & (slWidth .~ \node -> (-(node.dimensions.x / 2), node.dimensions.x / 2))
+              & (slHeight .~ \node -> (-(node.dimensions.y / 2), node.dimensions.y / 2))
+          )
+          t
+    padding = 20
+
+data MeasuredView action = MeasuredView
+  { view :: View action
+  , dimensions :: V2 Double
+  }
+  deriving stock (Generic)

--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -20,17 +20,108 @@ import Data.Tree qualified as Tree
 import GHC.Base (error)
 import Linear (Metric (norm), R1 (_x), V2 (V2), unangle)
 import Linear.Affine ((.+^), (.-.), (.-^))
-import Miso hiding (P, node)
-import Optics hiding (view)
+import Miso (
+  App (
+    App,
+    events,
+    initialAction,
+    logLevel,
+    model,
+    mountPoint,
+    subs,
+    update,
+    view
+  ),
+  Effect,
+  JSM,
+  LogLevel (Off),
+  View,
+  defaultEvents,
+  div_,
+  fromTransition,
+  img_,
+  onClick,
+  src_,
+  style_,
+  text,
+ )
+import Optics (lensVL, over, to, (%), (.~), (^.), (^..))
 import Optics.State.Operators ((?=))
-import Primer.App
-import Primer.Core hiding (App)
+import Primer.App (
+  NodeSelection (NodeSelection),
+  NodeType (BodyNode, SigNode),
+  Prog (progImports),
+  newProg,
+ )
+import Primer.Core (
+  Bind' (Bind),
+  CaseBranch' (CaseBranch),
+  CaseFallback' (CaseExhaustive, CaseFallback),
+  Expr' (
+    APP,
+    Ann,
+    Case,
+    Con,
+    EmptyHole,
+    Hole,
+    LAM,
+    Lam,
+    Let,
+    LetType,
+    Letrec,
+    PrimCon,
+    Var
+  ),
+  GlobalName (baseName, qualifiedModule),
+  Kind' (..),
+  LocalName (unLocalName),
+  ModuleName,
+  Pattern (PatCon, PatPrim),
+  PrimCon (..),
+  TmVarRef (GlobalVarRef, LocalVarRef),
+  Type' (..),
+  mkSimpleModuleName,
+  typesInExpr,
+  _exprMetaLens,
+  _kindMetaLens,
+  _typeMetaLens,
+ )
 import Primer.Core qualified as Primer
 import Primer.Def (Def (..))
 import Primer.JSON (CustomJSON (..), PrimerJSON)
-import Primer.Miso.Colors
-import Primer.Miso.Layout
-import Primer.Miso.Util
+import Primer.Miso.Colors (
+  blackPrimary,
+  bluePrimary,
+  blueQuaternary,
+  blueSecondary,
+  blueTertiary,
+  greenPrimary,
+  greySecondary,
+  redTertiary,
+  whitePrimary,
+  yellowPrimary,
+  yellowTertiary,
+ )
+import Primer.Miso.Layout (
+  P2,
+  slHSep,
+  slHeight,
+  slVSep,
+  slWidth,
+  symmLayout',
+ )
+import Primer.Miso.Util (
+  ASTDefT (expr, sig),
+  NodeSelectionT,
+  TermMeta',
+  bindingsInExpr,
+  bindingsInType,
+  kindsInType,
+  nodeSelectionType,
+  startAppWithSavedState,
+  tcBasicProg,
+  typeBindingsInExpr,
+ )
 import Primer.Module (Module (moduleDefs, moduleName))
 import Primer.Name (Name, unName)
 

--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -4,12 +4,11 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
 module Primer.Miso (start) where
 
-import Foreword hiding (minimum)
+import Foreword
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Data (Data (..))
@@ -80,7 +79,8 @@ updateModel =
 
 viewModel :: Model -> View Action
 viewModel Model{..} =
-  div_ [] $
+  div_
+    []
     [ div_
         [ style_
             [ ("display", "grid")
@@ -264,7 +264,7 @@ viewTreeExpr e =
 viewTreeType ::
   (Data b, Data c) =>
   Type' b c ->
-  (Tree.Tree (MeasuredView (TermMeta' a b c)))
+  Tree.Tree (MeasuredView (TermMeta' a b c))
 viewTreeType t =
   Tree.Node
     ( over #view (div_ [onClick $ Right $ Left $ t ^. _typeMetaLens] . pure) $

--- a/primer-miso/src/Primer/Miso/Colors.hs
+++ b/primer-miso/src/Primer/Miso/Colors.hs
@@ -1,0 +1,66 @@
+module Primer.Miso.Colors where
+
+import Miso.String (MisoString)
+
+whitePrimary :: MisoString
+whitePrimary = "#ffffff"
+
+blackPrimary :: MisoString
+blackPrimary = "#000000"
+
+bluePrimary :: MisoString
+bluePrimary = "#34375d"
+
+blueSecondary :: MisoString
+blueSecondary = "#4b5097"
+
+bluePrimaryHover :: MisoString
+bluePrimaryHover = "#46486f"
+
+blueSecondaryHover :: MisoString
+blueSecondaryHover = "#2b3679"
+
+blueTertiary :: MisoString
+blueTertiary = "#2c6a85"
+
+blueQuaternary :: MisoString
+blueQuaternary = "#64b0c8"
+
+greyPrimary :: MisoString
+greyPrimary = "#f7f7f7"
+
+greySecondary :: MisoString
+greySecondary = "#6b7280"
+
+greyTertiary :: MisoString
+greyTertiary = "#4b5563"
+
+greyQuaternary :: MisoString
+greyQuaternary = "#d4d4d4"
+
+greyPrimaryHover :: MisoString
+greyPrimaryHover = "#e2e2e2"
+
+redPrimary :: MisoString
+redPrimary = "#a52326"
+
+redSecondary :: MisoString
+redSecondary = "#f1685e"
+
+redPrimaryHover :: MisoString
+redPrimaryHover = "#c7433f"
+
+redSecondaryHover :: MisoString
+redSecondaryHover = "#bf3c38"
+
+redTertiary :: MisoString
+redTertiary = "#cd3764"
+
+greenPrimary :: MisoString
+greenPrimary = "#62e2b4"
+
+yellowPrimary :: MisoString
+yellowPrimary = "#ffb961"
+
+yellowSecondary :: MisoString
+yellowSecondary = "#e5a34f"

--- a/primer-miso/src/Primer/Miso/Colors.hs
+++ b/primer-miso/src/Primer/Miso/Colors.hs
@@ -1,4 +1,27 @@
-module Primer.Miso.Colors where
+module Primer.Miso.Colors (
+  whitePrimary,
+  blackPrimary,
+  bluePrimary,
+  blueSecondary,
+  bluePrimaryHover,
+  blueSecondaryHover,
+  blueTertiary,
+  blueQuaternary,
+  greyPrimary,
+  greySecondary,
+  greyTertiary,
+  greyQuaternary,
+  greyPrimaryHover,
+  redPrimary,
+  redSecondary,
+  redPrimaryHover,
+  redSecondaryHover,
+  redTertiary,
+  greenPrimary,
+  yellowPrimary,
+  yellowSecondary,
+)
+where
 
 import Miso.String (MisoString)
 

--- a/primer-miso/src/Primer/Miso/Colors.hs
+++ b/primer-miso/src/Primer/Miso/Colors.hs
@@ -20,6 +20,7 @@ module Primer.Miso.Colors (
   greenPrimary,
   yellowPrimary,
   yellowSecondary,
+  yellowTertiary,
 )
 where
 
@@ -87,3 +88,6 @@ yellowPrimary = "#ffb961"
 
 yellowSecondary :: MisoString
 yellowSecondary = "#e5a34f"
+
+yellowTertiary :: MisoString
+yellowTertiary = "#fff1df"

--- a/primer-miso/src/Primer/Miso/Layout.hs
+++ b/primer-miso/src/Primer/Miso/Layout.hs
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 We can't use `diagrams-contrib` since it pulls in `diagrams-lib`, which in turn uses `fsnotify`,
 which uses `unix-compat`, which contains some C code that fails to compile to Wasm.
+See https://github.com/diagrams/diagrams-lib/issues/370.
 It potentially makes sense to avoid such a huge dependency tree anyway.
 Besides, this is all a temporary solution in lieu of a better layout algorithm,
 such as a Haskell implementation of Tidy.

--- a/primer-miso/src/Primer/Miso/Layout.hs
+++ b/primer-miso/src/Primer/Miso/Layout.hs
@@ -74,13 +74,13 @@ import Foreword hiding (second)
 
 import Control.Arrow (second, (&&&), (***))
 
-import Data.Default
-import Data.Tree
+import Data.Default (Default (..))
+import Data.Tree (Tree (Node, rootLabel))
 
-import Linear
-import Linear.Affine
+import Linear (V2 (V2), (*^))
+import Linear.Affine (Affine ((.+^)), Point (P), origin)
 
-import Optics hiding (Empty)
+import Optics (makeLenses, (^.))
 import Primer.Miso.Util (P2, unitX, unit_Y)
 
 ------------------------------------------------------------

--- a/primer-miso/src/Primer/Miso/Layout.hs
+++ b/primer-miso/src/Primer/Miso/Layout.hs
@@ -33,11 +33,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-We can't use `diagrams-contrib` since it pulls in `diagrams-lib`, which in turn uses `fsnotify`, which uses `unix-compat`, which contains some C code that fails to build. It potentially makes sense to avoid such a huge dependency tree anyway. Besides, this is all a temporary solution in lieu of a better layout algorithm, such as a Haskell implementation of Tidy.
+We can't use `diagrams-contrib` since it pulls in `diagrams-lib`, which in turn uses `fsnotify`,
+which uses `unix-compat`, which contains some C code that fails to compile to Wasm.
+It potentially makes sense to avoid such a huge dependency tree anyway.
+Besides, this is all a temporary solution in lieu of a better layout algorithm,
+such as a Haskell implementation of Tidy.
 
 Differences from upstream:
 - Remove everything but the simple symmetric layout algorithm.
-- Vendor some further required definitions from the `diagrams` family. These are all in one block at the very top of the module body.
 - Add `NoLexicalNegation` to override this package's default, in order to avoid a syntax error in `unRelativize`.
 - Use `optics` instead of `lens`.
 - Make some adjustments so that y-coordinates are always non-negative, with the root being at zero.

--- a/primer-miso/src/Primer/Miso/Layout.hs
+++ b/primer-miso/src/Primer/Miso/Layout.hs
@@ -1,0 +1,275 @@
+{- Vendored from: https://hackage.haskell.org/package/diagrams-contrib-1.4.5.1/docs/Diagrams-TwoD-Layout-Tree.html
+
+The license follows:
+
+Copyright (c) 2011-2015, Brent Yorgey
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Various nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+We can't use `diagrams-contrib` since it pulls in `diagrams-lib`, which in turn uses `fsnotify`, which uses `unix-compat`, which contains some C code that fails to build. It potentially makes sense to avoid such a huge dependency tree anyway. Besides, this is all a temporary solution in lieu of a better layout algorithm, such as a Haskell implementation of Tidy.
+
+Differences from upstream:
+- Remove everything but the simple symmetric layout algorithm.
+- Vendor some further required definitions from the `diagrams` family. These are all in one block at the very top of the module body.
+- Add `NoLexicalNegation` to override this package's default, in order to avoid a syntax error in `unRelativize`.
+- Use `optics` instead of `lens`.
+- Make some adjustments so that y-coordinates are always non-negative, with the root being at zero.
+-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoLexicalNegation #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+
+module Primer.Miso.Layout (
+  -- * Layout algorithms
+
+  -- ** Symmetric layout
+  -- $symmetric
+  symmLayout,
+  symmLayout',
+  SymmLayoutOpts (..),
+  slHSep,
+  slVSep,
+  slWidth,
+  slHeight,
+  P2,
+) where
+
+import Foreword hiding (second)
+
+import Control.Arrow (second, (&&&), (***))
+
+import Data.Default
+import Data.Foldable (maximum)
+import Data.Tree
+
+import Linear
+import Linear.Affine
+
+import Optics hiding (Empty)
+import Primer.Miso.Util (P2, unitX, unit_Y)
+
+------------------------------------------------------------
+--  Binary trees
+------------------------------------------------------------
+
+-- $BTree
+-- There is a standard type of rose trees ('Tree') defined in the
+-- @containers@ package, but there is no standard type for binary
+-- trees, so we define one here.  Note, if you want to draw binary
+-- trees with data of type @a@ at the leaves, you can use something
+-- like @BTree (Maybe a)@ with @Nothing@ at internal nodes;
+-- 'renderTree' lets you specify how to draw each node.
+
+------------------------------------------------------------
+--  Layout algorithms
+------------------------------------------------------------
+
+--------------------------------------------------
+-- "Symmetric" layout of rose trees.
+
+-- $symmetric
+-- \"Symmetric\" layout of rose trees, based on the algorithm described in:
+--
+-- Andrew J. Kennedy. /Drawing Trees/, J Func. Prog. 6 (3): 527-534,
+-- May 1996.
+--
+-- Trees laid out using this algorithm satisfy:
+--
+--   1. Nodes at a given level are always separated by at least a
+--   given minimum distance.
+--
+--   2. Parent nodes are centered with respect to their immediate
+--   offspring (though /not/ necessarily with respect to the entire
+--   subtrees under them).
+--
+--   3. Layout commutes with mirroring: that is, the layout of a given
+--   tree is the mirror image of the layout of the tree's mirror
+--   image.  Put another way, there is no inherent left or right bias.
+--
+--   4. Identical subtrees are always rendered identically.  Put
+--   another way, the layout of any subtree is independent of the rest
+--   of the tree.
+--
+--   5. The layouts are as narrow as possible while satisfying all the
+--   above constraints.
+
+-- | A tree with /relative/ positioning information.  The @n@
+--   at each node is the horizontal /offset/ from its parent.
+type Rel t n a = t (a, n)
+
+-- | Shift a RelTree horizontally.
+moveTree :: Num n => n -> Rel Tree n a -> Rel Tree n a
+moveTree x' (Node (a, x) ts) = Node (a, x + x') ts
+
+-- | An /extent/ is a list of pairs, recording the leftmost and
+--   rightmost (absolute) horizontal positions of a tree at each
+--   depth.
+newtype Extent n = Extent {getExtent :: [(n, n)]}
+
+extent :: ([(n, n)] -> [(n, n)]) -> Extent n -> Extent n
+extent f = Extent . f . getExtent
+
+consExtent :: (n, n) -> Extent n -> Extent n
+consExtent = extent . (:)
+
+-- | Shift an extent horizontally.
+moveExtent :: Num n => n -> Extent n -> Extent n
+moveExtent x = (extent . map) ((+ x) *** (+ x))
+
+-- | Reflect an extent about the vertical axis.
+flipExtent :: Num n => Extent n -> Extent n
+flipExtent = (extent . map) (\(p, q) -> (-q, -p))
+
+-- | Merge two non-overlapping extents.
+mergeExtents :: Extent n -> Extent n -> Extent n
+mergeExtents (Extent e1) (Extent e2) = Extent $ mergeExtents' e1 e2
+  where
+    mergeExtents' [] qs = qs
+    mergeExtents' ps [] = ps
+    mergeExtents' ((p, _) : ps) ((_, q) : qs) = (p, q) : mergeExtents' ps qs
+
+instance Semigroup (Extent n) where
+  (<>) = mergeExtents
+
+instance Monoid (Extent n) where
+  mempty = Extent []
+  mappend = (<>)
+
+-- | Determine the amount to shift in order to \"fit\" two extents
+--   next to one another.  The first argument is the separation to
+--   leave between them.
+fit :: (Num n, Ord n) => n -> Extent n -> Extent n -> n
+fit hSep (Extent ps) (Extent qs) = maximum (0 : zipWith (\(_, p) (q, _) -> p - q + hSep) ps qs)
+
+-- | Fit a list of subtree extents together using a left-biased
+--   algorithm.  Compute a list of positions (relative to the leftmost
+--   subtree which is considered to have position 0).
+fitListL :: (Num n, Ord n) => n -> [Extent n] -> [n]
+fitListL hSep = snd . mapAccumL fitOne mempty
+  where
+    fitOne acc e =
+      let x = fit hSep acc e
+       in (acc <> moveExtent x e, x)
+
+-- | Fit a list of subtree extents together with a right bias.
+fitListR :: (Num n, Ord n) => n -> [Extent n] -> [n]
+fitListR hSep = reverse . map negate . fitListL hSep . map flipExtent . reverse
+
+-- | Compute a symmetric fitting by averaging the results of left- and
+--   right-biased fitting.
+fitList :: (Fractional n, Ord n) => n -> [Extent n] -> [n]
+fitList hSep = uncurry (zipWith mean) . (fitListL hSep &&& fitListR hSep)
+  where
+    mean x y = (x + y) / 2
+
+-- | Options for controlling the symmetric tree layout algorithm.
+data SymmLayoutOpts n a
+  = SLOpts
+  { _slHSep :: n
+  -- ^ Minimum horizontal
+  --   separation between sibling
+  --   nodes.  The default is 1.
+  , _slVSep :: n
+  -- ^ Vertical separation
+  --   between adjacent levels of
+  --   the tree.  The default is 1.
+  , _slWidth :: a -> (n, n)
+  -- ^ A function for measuring the horizontal extent (a pair
+  --   of x-coordinates) of an item in the tree.  The default
+  --   is @const (0,0)@, that is, the nodes are considered as
+  --   taking up no space, so the centers of the nodes will
+  --   be separated according to the @slHSep@ and @slVSep@.
+  --   However, this can be useful, /e.g./ if you have a tree
+  --   of diagrams of irregular size and want to make sure no
+  --   diagrams overlap.  In that case you could use
+  --   @fromMaybe (0,0) . extentX@.
+  , _slHeight :: a -> (n, n)
+  -- ^ A function for measuring the vertical extent of an
+  --   item in the tree.  The default is @const (0,0)@.  See
+  --   the documentation for 'slWidth' for more information.
+  }
+
+makeLenses ''SymmLayoutOpts
+
+instance Num n => Default (SymmLayoutOpts n a) where
+  def =
+    SLOpts
+      { _slHSep = 1
+      , _slVSep = 1
+      , _slWidth = const (0, 0)
+      , _slHeight = const (0, 0)
+      }
+
+-- | Actual recursive tree layout algorithm, which returns a tree
+--   layout as well as an extent.
+symmLayoutR :: (Fractional n, Ord n) => SymmLayoutOpts n a -> Tree a -> (Rel Tree n a, Extent n)
+symmLayoutR opts (Node a ts) = (rt, ext)
+  where
+    (trees, extents) = unzip (map (symmLayoutR opts) ts)
+    positions = fitList (opts ^. slHSep) extents
+    pTrees = zipWith moveTree positions trees
+    pExtents = zipWith moveExtent positions extents
+    ext = (opts ^. slWidth) a `consExtent` mconcat pExtents
+    rt = Node (a, 0) pTrees
+
+-- | Run the symmetric rose tree layout algorithm on a given tree,
+--   resulting in the same tree annotated with node positions.
+symmLayout' :: (Fractional n, Ord n) => SymmLayoutOpts n a -> Tree a -> Tree (a, P2 n)
+symmLayout' opts t0 =
+  let t = unRelativize opts origin $ fst $ symmLayoutR opts t0
+      rootHeight = snd $ fst (rootLabel t) & opts ^. slHeight
+   in second (\(P (V2 x y)) -> P $ V2 x (rootHeight - y)) <$> t
+
+-- | Run the symmetric rose tree layout algorithm on a given tree
+--   using default options, resulting in the same tree annotated with
+--   node positions.
+symmLayout :: (Fractional n, Ord n) => Tree a -> Tree (a, P2 n)
+symmLayout = symmLayout' def
+
+-- | Given a fixed location for the root, turn a tree with
+--   \"relative\" positioning into one with absolute locations
+--   associated to all the nodes.
+unRelativize ::
+  (Num n, Ord n) =>
+  SymmLayoutOpts n a -> P2 n -> Rel Tree n a -> Tree (a, P2 n)
+unRelativize opts curPt (Node (a, hOffs) ts) =
+  Node (a, rootPt) (map (unRelativize opts (rootPt .+^ (vOffs *^ unit_Y))) ts)
+  where
+    rootPt = curPt .+^ (hOffs *^ unitX)
+    vOffs =
+      -fst ((opts ^. slHeight) a)
+        + (maximum . map (snd . (opts ^. slHeight) . fst . rootLabel) $ ts)
+        + (opts ^. slVSep)

--- a/primer-miso/src/Primer/Miso/Util.hs
+++ b/primer-miso/src/Primer/Miso/Util.hs
@@ -36,11 +36,38 @@ import Control.Monad.Fresh (MonadFresh (..))
 import Data.Aeson (FromJSON, ToJSON)
 import Linear (Additive, R1 (_x), R2 (_y), V2, zero)
 import Linear.Affine (Point (..), unP)
-import Miso
-import Optics
+import Miso (
+  App (initialAction, model, subs, update, view),
+  JSM,
+  getLocalStorage,
+  mapSub,
+  setLocalStorage,
+  startApp,
+  (<#),
+ )
+import Optics (
+  AffineTraversal',
+  Field1 (_1),
+  Field2 (_2),
+  atraversalVL,
+  lensVL,
+  (.~),
+  (^.),
+ )
 import Optics.State.Operators ((<<%=))
-import Primer.App
-import Primer.Core
+import Primer.App (NodeSelection (meta), Prog, progCxt)
+import Primer.Core (
+  Expr' (LAM, Lam, Let, LetType, Letrec),
+  ID,
+  Kind' (KType),
+  LVarName,
+  Meta,
+  TyVarName,
+  Type' (TEmptyHole, TForall, THole, TLet),
+  TypeCache (..),
+  TypeCacheBoth (TCBoth, tcChkedAt, tcSynthed),
+  _type,
+ )
 import Primer.Core.Utils (forgetTypeMetadata)
 import Primer.Def (ASTDef (..), astDefExpr)
 import Primer.JSON (CustomJSON (..), PrimerJSON)

--- a/primer-miso/src/Primer/Miso/Util.hs
+++ b/primer-miso/src/Primer/Miso/Util.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Things which should really be upstreamed rather than living in this project.
+module Primer.Miso.Util where
+
+import Foreword hiding (zero)
+
+import Control.Monad.Extra (eitherM)
+import Control.Monad.Fresh (MonadFresh (..))
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Foldable1 qualified
+import Linear (Additive, R1 (_x), R2 (_y), V2, zero)
+import Linear.Affine (Point (..), unP)
+import Miso
+import Optics
+import Optics.State.Operators ((<<%=))
+import Primer.App
+import Primer.Core
+import Primer.Core.Utils (forgetTypeMetadata)
+import Primer.Def (ASTDef (..), astDefExpr)
+import Primer.JSON (CustomJSON (..), PrimerJSON)
+import Primer.Name (NameCounter)
+import Primer.Typecheck (ExprT, TypeError, check, checkKind)
+
+{- Miso -}
+
+-- https://github.com/dmjio/miso/issues/749
+startAppWithSavedState :: forall model action. (Eq model, FromJSON model, ToJSON model) => Miso.App model action -> JSM ()
+startAppWithSavedState app = do
+  savedModel <-
+    eitherM (\e -> liftIO $ putStrLn ("saved state not loaded: " <> e) >> pure Nothing) (pure . Just) $
+      getLocalStorage storageKey
+  startApp
+    app
+      { model = fromMaybe app.model savedModel
+      , update = \case
+          Nothing -> pure
+          Just a -> \m -> do
+            m' <- first Just $ app.update a m
+            m' <# do
+              setLocalStorage storageKey m'
+              pure Nothing
+      , subs = mapSub Just <$> app.subs
+      , view = fmap Just . app.view
+      , initialAction = Just app.initialAction
+      }
+  where
+    storageKey = "miso-app-state"
+
+{- Linear -}
+
+-- defined in `diagrams` but no clear reason why they aren't in `linear` itself
+type P2 = Point V2
+unitX :: (R1 v, Additive v, Num n) => v n
+unitX = zero & lensVL _x .~ 1
+unit_X :: (R1 v, Additive v, Num n) => v n
+unit_X = zero & lensVL _x .~ (-1)
+unitY :: (R2 v, Additive v, Num n) => v n
+unitY = zero & lensVL _y .~ 1
+unit_Y :: (R2 v, Additive v, Num n) => v n
+unit_Y = zero & lensVL _y .~ (-1)
+
+-- this style would be simplest but isn't possible due to the implementation of `OverloadedRecordDot`:
+-- instance R1 t => HasField "x" (t a) a where
+--     getField = flip (^.) $ lensVL _x
+-- this might be too ad-hoc to get accepted upstream:
+instance HasField "x" (V2 a) a where
+  getField = (^. lensVL _x)
+instance (HasField "x" (f a) a) => HasField "x" (Point f a) a where
+  getField = getField @"x" . unP
+instance HasField "y" (V2 a) a where
+  getField = (^. lensVL _y)
+instance (HasField "y" (f a) a) => HasField "y" (Point f a) a where
+  getField = getField @"y" . unP
+
+{- Foreword -}
+
+-- replace unsafe `minimum`
+type Foldable1 = Data.Foldable1.Foldable1
+minimum :: (Foldable1 t) => t Double -> Double
+minimum = Data.Foldable1.minimum
+maximum :: (Foldable1 t) => t Double -> Double
+maximum = Data.Foldable1.maximum
+toNonEmpty :: (Foldable1 t) => t a -> NonEmpty a
+toNonEmpty = Data.Foldable1.toNonEmpty
+
+{- Primer -}
+
+-- `tcWholeProg` throws away information by not returning a prog containing `ExprT`s
+-- we use `check` since, for whatever reason, `synth` deletes the case branches in `map`
+tcBasicProg :: Prog -> ASTDef -> Either TypeError ASTDefT
+tcBasicProg p ASTDef{..} =
+  runTC
+    . flip (runReaderT @_ @(M TypeError)) (progCxt p)
+    $ ASTDefT
+      <$> (check (forgetTypeMetadata astDefType) astDefExpr)
+      <*> (checkKind (KType ()) astDefType)
+
+-- TODO this is all basically copied from unexposed parts of Primer library - find a way to expose
+newtype M e a = M {unM :: StateT (ID, NameCounter) (Except e) a}
+  deriving newtype (Functor, Applicative, Monad, MonadError e)
+instance MonadFresh ID (M e) where
+  fresh = M $ _1 <<%= succ
+instance MonadFresh NameCounter (M e) where
+  fresh = M $ _2 <<%= succ
+runTC :: M e a -> Either e a
+runTC = runExcept . flip evalStateT (0, toEnum 0) . (.unM)
+
+-- analogous with `ExprT`/`TypeT`
+-- type KindT = Kind' KindMetaT
+-- type SelectionT = Selection' (Either ExprMetaT (Either TypeMetaT KindMetaT))
+type TypeT = Type' TypeMetaT KindMetaT -- TODO actually exists in Primer lib but is hidden
+type TermMeta' a b c = Either a (Either b c) -- TODO make this a proper sum type
+type NodeSelectionT = NodeSelection (TermMeta' ExprMetaT TypeMetaT KindMetaT)
+type ExprMetaT = Meta TypeCache
+type TypeMetaT = Meta (Kind' ())
+type KindMetaT = Meta ()
+data ASTDefT = ASTDefT {expr :: ExprT, sig :: TypeT} -- TODO parameterise `ASTDef` etc.?
+  deriving stock (Eq, Show, Read, Generic)
+  deriving (ToJSON, FromJSON) via PrimerJSON ASTDefT
+
+-- analogous to `typesInExpr`
+kindsInType :: AffineTraversal' (Type' a b) (Kind' b)
+kindsInType = atraversalVL $ \point f -> \case
+  TForall m a k t -> flip (TForall m a) t <$> f k
+  e -> point e
+
+-- TODO if we had first-class bindings, we could probably implement all of these generically
+bindingsInExpr :: AffineTraversal' (Expr' a b c) LVarName
+bindingsInExpr = atraversalVL $ \point f -> \case
+  Lam m v e -> f v <&> \v' -> Lam m v' e
+  Let m v e1 e2 -> f v <&> \v' -> Let m v' e1 e2
+  Letrec m v e1 t e2 -> f v <&> \v' -> Letrec m v' e1 t e2
+  e -> point e
+typeBindingsInExpr :: AffineTraversal' (Expr' a b c) TyVarName
+typeBindingsInExpr = atraversalVL $ \point f -> \case
+  LAM m v e -> f v <&> \v' -> LAM m v' e
+  LetType m v t e -> f v <&> \v' -> LetType m v' t e
+  e -> point e
+bindingsInType :: AffineTraversal' (Type' a b) TyVarName
+bindingsInType = atraversalVL $ \point f -> \case
+  TForall m v k t -> f v <&> \v' -> TForall m v' k t
+  TLet m v t1 t2 -> f v <&> \v' -> TLet m v' t1 t2
+  e -> point e
+
+-- TODO generalise to full selections and DRY with `getSelectionTypeOrKind` from `primer-api`
+nodeSelectionType :: NodeSelectionT -> Either (Type' () ()) (Either (Kind' ()) ())
+nodeSelectionType =
+  bimap
+    (getAPIType . (^. _type))
+    (bimap (^. _type) (^. _type))
+    . (.meta)
+  where
+    -- copied directly from innards of `getSelectionTypeOrKind`
+    getAPIType :: TypeCache -> Type' () ()
+    getAPIType = \case
+      TCSynthed t -> t
+      TCChkedAt t -> t
+      TCEmb (TCBoth{tcSynthed, tcChkedAt})
+        -- If this node is an embedding, we have a choice of two types to report.
+        -- We choose the one that is not a hole;
+        | isHole tcSynthed -> tcChkedAt
+        | isHole tcChkedAt -> tcSynthed
+        -- if neither is a hole (in which case the two are consistent), we choose the synthed type
+        | otherwise -> tcSynthed
+      where
+        isHole :: Type' a b -> Bool
+        isHole = \case
+          THole{} -> True
+          TEmptyHole{} -> True
+          _ -> False

--- a/primer-miso/src/Primer/Miso/Util.hs
+++ b/primer-miso/src/Primer/Miso/Util.hs
@@ -75,6 +75,7 @@ startAppWithSavedState app = do
 {- Linear -}
 
 -- defined in `diagrams` but no clear reason why they aren't in `linear` itself
+-- https://github.com/ekmett/linear/issues/180
 type P2 = Point V2
 unitX :: (R1 v, Additive v, Num n) => v n
 unitX = zero & lensVL _x .~ 1
@@ -85,6 +86,7 @@ unitY = zero & lensVL _y .~ 1
 unit_Y :: (R2 v, Additive v, Num n) => v n
 unit_Y = zero & lensVL _y .~ (-1)
 
+-- https://github.com/ekmett/linear/issues/181
 -- this style would be simplest but isn't possible due to the implementation of `OverloadedRecordDot`:
 -- instance R1 t => HasField "x" (t a) a where
 --     getField = flip (^.) $ lensVL _x

--- a/primer/Makefile.wasm32
+++ b/primer/Makefile.wasm32
@@ -6,11 +6,8 @@ CABAL = wasm32-wasi-cabal
 
 primer-test-path	= $(shell $(CABAL) list-bin -v0 test:primer-test)
 
-build:	configure discover-tests
+build:	discover-tests
 	$(CABAL) build
-
-configure:
-	$(CABAL) configure
 
 # test target is special because it requires wasmtime.
 test: 	build
@@ -23,4 +20,4 @@ clean:
 	$(CABAL) clean
 	rm -f test/TestsWasm32.hs
 
-.PHONY: build configure test discover-tests clean
+.PHONY: build test discover-tests clean

--- a/primer/src/Foreword.hs
+++ b/primer/src/Foreword.hs
@@ -15,6 +15,7 @@ module Foreword (
   module Unsafe,
   module Catch,
   module Foldable,
+  module Foldable1,
   module TypeEquality,
 
   -- * Helper functions
@@ -73,11 +74,15 @@ import Protolude hiding (
   gcast,
   handle,
   handleJust,
+  head,
   ignore,
   lenientDecode,
   mask,
   mask_,
   maximum,
+  maximumBy,
+  minimum,
+  minimumBy,
   moduleName,
   onException,
   orElse,
@@ -102,6 +107,7 @@ import Protolude qualified as P
 import Protolude.Unsafe as Unsafe (unsafeHead)
 
 import Data.Foldable as Foldable (foldMap')
+import Data.Foldable1 as Foldable1
 import Data.Type.Equality as TypeEquality (type (~))
 
 -- We want @exceptions@ rather than @base@'s equivalents.


### PR DESCRIPTION
This PR is a proof-of-concept re-implementation of our TypeScript- & React-based Primer frontend application in Haskell, using [Miso](https://haskell-miso.org) and GHC's Wasm backend. The goal of this PR is the following:

* Render an arbitrary Primer term definition (we've chosen polymorphic `map` here) as a tree, completely in the browser, with no backend service required.
* Upon selecting an arbitrary subexpression of the definition, render the subexpression's type as a tree alongside the definition's tree.
* Use as little JavaScript/TypeScript as possible.
* Make a best-effort attempt to mimic the CSS styling of the TypeScript/React implementation. (Notably, we have not yet implemented the "tidy trees" algorithm, nor have we made any attempt to render pattern matches left-to-right as the TypeScript/React implementation does.)

The experience has been very positive, so we plan to follow this work up with one or more additional PRs that will add basic editing, support for multiple definitions, and program evaluation. Assuming that additional work is as successful as this initial PR has been, we will likely deprecate the TypeScript/React frontend and replace it with a pure Haskell version.

Note that this PR is based on @georgefst's original work in https://github.com/georgefst/ghc-wasm-miso-examples/tree/primer.

Also note that the code contains a number of `TODO` comments. Normally we don't permit such comments without a link to a relevant GitHub issue, so that we don't lose track of work that remains to be done. However, in the case of this particular PR, we'll relax this rule, as it's not yet clear exactly how to resolve these `TODO`s, or even whether they'll remain relevant as we implement the full editing API into `primer-miso` in subsequent work.
