### PR TITLE
chore(primer-selda): build for Wasm

### DIFF
--- a/Makefile.wasm32
+++ b/Makefile.wasm32
@@ -15,6 +15,7 @@ test-targets = discover-tests test
 $(test-targets):
 	$(MAKE) -C primer $@
 	$(MAKE) -C primer-api $@
+	$(MAKE) -C primer-selda $@
 
 update:
 	$(CABAL) update

--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,7 @@ if arch(wasm32)
   packages:
     primer
     primer-api
+    primer-selda
     primer-miso
 else
   packages:

--- a/primer-selda/.gitignore
+++ b/primer-selda/.gitignore
@@ -1,0 +1,1 @@
+test/TestsWasm32.hs

--- a/primer-selda/Makefile.wasm32
+++ b/primer-selda/Makefile.wasm32
@@ -1,0 +1,23 @@
+# NOTE:
+#
+# This Makefile assumes you're using the `nix develop .#wasm` shell.
+
+CABAL = wasm32-wasi-cabal
+
+primer-selda-test-path	= $(shell $(CABAL) list-bin -v0 test:primer-selda-test)
+
+build:	discover-tests
+	$(CABAL) build
+
+# test target is special because it requires wasmtime.
+test: 	build
+	wasmtime --dir test::test --dir /tmp::/tmp "$(primer-selda-test-path)"
+
+discover-tests:
+	tasty-discover test/Test.hs _ test/TestsWasm32.hs --tree-display
+
+clean:
+	$(CABAL) clean
+	rm -f test/TestsWasm32.hs
+
+.PHONY: build test discover-tests clean

--- a/primer-selda/primer-selda.cabal
+++ b/primer-selda/primer-selda.cabal
@@ -78,8 +78,6 @@ library primer-selda-testlib
     , uuid-types
 
 test-suite primer-selda-test
-  type:               exitcode-stdio-1.0
-  main-is:            Test.hs
   hs-source-dirs:     test
   other-modules:
     Tests.DeleteSession
@@ -99,11 +97,22 @@ test-suite primer-selda-test
     NoImplicitPrelude
     OverloadedStrings
 
-  ghc-options:
-    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
-    -Wcompat -Widentities -Wredundant-constraints
-    -Wmissing-deriving-strategies -fhide-source-paths -threaded
-    -rtsopts -with-rtsopts=-N
+  if arch(wasm32)
+    type:        exitcode-stdio-1.0
+    main-is:     TestsWasm32.hs
+    ghc-options:
+      -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+      -Wcompat -Widentities -Wredundant-constraints
+      -Wmissing-deriving-strategies -fhide-source-paths
+
+  else
+    type:        exitcode-stdio-1.0
+    main-is:     Test.hs
+    ghc-options:
+      -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+      -Wcompat -Widentities -Wredundant-constraints
+      -Wmissing-deriving-strategies -fhide-source-paths -threaded
+      -rtsopts -with-rtsopts=-N
 
   build-depends:
     , aeson


### PR DESCRIPTION
Note that the `primer-selda` tests build, but fail, because they try to run `primer-sqitch` in a separate process, but `process` throws a runtime exception under Wasm (on purpose):

https://github.com/haskell/process/blob/166971ffd5a750dd0b101f208f2ddc624d8d6997/System/Process.hs#L904

This is completely orthogonal to whichever Sqlite implementation we choose, of course, and nothing to do with Selda. In fact, in theory, Selda supports its own migration system, so we may be able to replace `primer-sqitch` with Selda's own functionality. (That said, I believe Selda's support for migrations is not particularly robust.)

In any case, if we want to use Sqlite in Wasm, this probably means the end of the road for `sqitch`, and moving the database init/migration into native Haskell code.