### PR TITLE
Use experimental Miso components support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -71,13 +71,12 @@ source-repository-package
   subdir: selda selda-sqlite
   --sha256: 0fw336sb03sc54pzmkz6jn989zvbnwnzypb9n0ackprymnvh8mym
 
--- Until a new Hackage release is made which includes
--- https://github.com/dmjio/miso/pull/752
+-- Until a new Hackage release is made which includes components
 source-repository-package
   type: git
   location: https://github.com/dmjio/miso
-  tag: 2b548d48bffb0e8ae28a6cfb886e4afb0d8be37a
-  --sha256: sha256-fzDEa8vKXgxPPB+8NDLmhn2Jw1UDZso7e/klwidCfhM=
+  tag: 998a8bbe67e37e2bfbd227acdc6e9fcfc0eb58ce
+  --sha256: YLkCDe/EriS/kix6kiHYfn0HK42iAt/pvhnYe8Y54JQ=
 
 -- Wasm workarounds.
 --

--- a/primer-miso/frontend/style.css
+++ b/primer-miso/frontend/style.css
@@ -65,19 +65,21 @@ body {
   margin: 0;
   font-family: sans;
   height: 100vh;
-}
-
-#miso-root {
-  height: 100%;
-  display: grid;
-  grid-template-columns: 12rem 1fr 2fr;
-  grid-template-rows: 2fr 1fr;
   > * {
-    position: relative;
-    overflow: scroll;
-    border-style: solid;
-    border-width: 1px;
-    border-color: var(--blue-primary);
+    height: 100%;
+    > * {
+      height: 100%;
+      display: grid;
+      grid-template-columns: 12rem 1fr 2fr;
+      grid-template-rows: 2fr 1fr;
+      > * {
+        position: relative;
+        overflow: scroll;
+        border-style: solid;
+        border-width: 1px;
+        border-color: var(--blue-primary);
+      }
+    }
   }
 }
 
@@ -105,7 +107,12 @@ body {
 
 #selection-type {
   grid-column-start: 2;
-  grid-column-end: 4;
+  grid-column-end: 3;
+}
+
+#sub {
+  grid-column-start: 3;
+  grid-row-start: 2;
 }
 
 .tree {

--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -52,6 +52,7 @@ import Miso (
   style_,
   text,
  )
+import Miso.String (MisoString, ms)
 import Optics (lensVL, to, (%), (.~), (^.), (^..), _Just)
 import Optics.State.Operators ((?=))
 import Primer.App (
@@ -160,7 +161,7 @@ data Model = Model
   deriving (ToJSON, FromJSON) via PrimerJSON Model
 
 data Action
-  = NoOp Text -- For situations where Miso requires an action, but we don't actually want to do anything.
+  = NoOp MisoString -- For situations where Miso requires an action, but we don't actually want to do anything.
   | SelectDef GVarName
   | SelectNode NodeSelectionT
   deriving stock (Eq, Show)
@@ -183,7 +184,7 @@ viewModel Model{..} =
               [ class_ $ mwhen (Just def == ((.def) <$> selection)) "selected"
               , onClick $ SelectDef def
               ]
-              [text $ globalNamePretty def]
+              [text $ ms $ globalNamePretty def]
       ]
       <> case selection of
         Nothing -> [text "no selection"]
@@ -228,7 +229,7 @@ data NodeViewData action = NodeViewData
   }
 
 data NodeViewOpts action
-  = SyntaxNode {wide :: Bool, flavor :: Text, text :: Text}
+  = SyntaxNode {wide :: Bool, flavor :: MisoString, text :: MisoString}
   | HoleNode {empty :: Bool}
   | PrimNode PrimCon
   | ConNode {name :: Name, scope :: ModuleName}
@@ -244,7 +245,7 @@ viewNodeData :: P2 Double -> V2 Double -> [View action] -> NodeViewData action -
 viewNodeData position dimensions edges node = case node.opts of
   PrimNode (PrimAnimation animation) ->
     img_
-      [ src_ ("data:img/gif;base64," <> animation)
+      [ src_ ("data:img/gif;base64," <> ms animation)
       , style_ $ clayToMiso do
           Clay.width $ Clay.px $ realToClay dimensions.x
           Clay.height $ Clay.px $ realToClay dimensions.y
@@ -302,11 +303,11 @@ viewNodeData position dimensions edges node = case node.opts of
                       [ text case node.opts of
                           SyntaxNode{text = t} -> t
                           HoleNode{empty = e} -> if e then "?" else "⚠️"
-                          PrimNode pc -> case pc of
+                          PrimNode pc -> ms @Text case pc of
                             PrimChar c' -> show c'
                             PrimInt n -> show n
-                          ConNode{name} -> unName name
-                          VarNode{name} -> unName name
+                          ConNode{name} -> ms $ unName name
+                          VarNode{name} -> ms $ unName name
                       ]
                   ]
            ]

--- a/primer-miso/src/Primer/Miso/Util.hs
+++ b/primer-miso/src/Primer/Miso/Util.hs
@@ -41,6 +41,7 @@ import Control.Monad.Extra (eitherM)
 import Control.Monad.Fresh (MonadFresh (..))
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Map qualified as Map
+import Data.Tuple.Extra (both)
 import Linear (Additive, R1 (_x), R2 (_y), V2, zero)
 import Linear.Affine (Point (..), unP)
 import Miso (
@@ -52,6 +53,7 @@ import Miso (
   startApp,
   (<#),
  )
+import Miso.String (MisoString, ms)
 import Optics (
   AffineTraversal',
   Field1 (_1),
@@ -114,15 +116,15 @@ startAppWithSavedState app = do
 -- note that we silently ignore non-properties, and modifiers on properties
 -- what we really want is for Clay property functions to return something much more precise than `Css`
 -- but this would be a big breaking change, and Clay is really designed primarily for generating stylesheets
-clayToMiso :: Clay.Css -> Map Text Text
+clayToMiso :: Clay.Css -> Map MisoString MisoString
 clayToMiso =
   Map.fromList
     . concatMap \case
       Clay.Property _modifiers (Clay.Key k) (Clay.Value v) -> (,) <$> allPrefixes k <*> allPrefixes v
         where
           allPrefixes = \case
-            Clay.Prefixed ts -> map (uncurry (<>)) ts
-            Clay.Plain t -> pure t
+            Clay.Prefixed ts -> map (uncurry (<>) . both ms) ts
+            Clay.Plain t -> pure $ ms t
       _ -> []
     . Clay.runS
 


### PR DESCRIPTION
See https://github.com/dmjio/miso/pull/766.

This works, until the last commit, where we try to actually add a component, which causes the app to crash with `TypeError: obj.mount is not a function`. The Miso components branch does not yet support Wasm (or `jsaddle-warp`) due to a need for synchronous callbacks, but this is being worked on at this very moment.

If upstream support does appear in the next week or so, then I propose that we use this as the basis for the next stage of frontend development, i.e. we rebase [my WIP actions and eval work](https://github.com/hackworthltd/primer/compare/main...georgefst/frontend-eval) on top of this. Both the actions and eval panels would benefit from being components since they have a natural notion of internal state. I would otherwise have considered fake components as outlined [here](https://github.com/FPtje/miso-component-example), but I'd say we're better off embracing the future. The success of the frontend rewrite so far has been built on using bleeding edge features and working closely with upstream maintainers. I see no reason to stop now!