### PR TITLE
chore: un-pin ghc-wasm-meta and fix `primer-miso`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -39,7 +39,7 @@ benchmarks: True
 
 tests: True
 
-allow-newer: servant-openapi3:base, openapi3:*, selda:*, hedgehog:pretty-show, hedgehog-classes:pretty-show, *:time
+allow-newer: servant-openapi3:base, openapi3:*, selda:*, hedgehog:pretty-show, hedgehog-classes:pretty-show, *:time, protolude:ghc-prim
 
 package primer
   test-options: "--size-cutoff=32768"
@@ -70,14 +70,6 @@ source-repository-package
   tag: 2e3dc54d7de8365b3be84da76f08327dc8b40f61
   subdir: selda selda-sqlite
   --sha256: 0fw336sb03sc54pzmkz6jn989zvbnwnzypb9n0ackprymnvh8mym
-
--- Until a new Hackage release is made which includes
--- https://github.com/dmjio/miso/pull/752
-source-repository-package
-  type: git
-  location: https://github.com/dmjio/miso
-  tag: 2b548d48bffb0e8ae28a6cfb886e4afb0d8be37a
-  --sha256: sha256-fzDEa8vKXgxPPB+8NDLmhn2Jw1UDZso7e/klwidCfhM=
 
 -- Wasm workarounds.
 --

--- a/flake.lock
+++ b/flake.lock
@@ -241,17 +241,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1736814899,
-        "narHash": "sha256-5ecjTrtyFRjFSSt39aUUfvBAiLmmR0f3IuhhMcI4kXE=",
+        "lastModified": 1743018267,
+        "narHash": "sha256-f+egD12IqvYSI1FNB02ETSodqUwn449gapCwTaQhEz0=",
         "ref": "refs/heads/master",
-        "rev": "a9102d59d00bc87550dda902c8084a74f9742c00",
-        "revCount": 230,
+        "rev": "1e2e05f23be5c2280f2f86af2f4a5b548f0db45f",
+        "revCount": 250,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
       },
       "original": {
-        "ref": "refs/heads/master",
-        "rev": "a9102d59d00bc87550dda902c8084a74f9742c00",
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
       }
@@ -704,11 +702,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736701207,
-        "narHash": "sha256-jG/+MvjVY7SlTakzZ2fJ5dC3V1PrKKrUEOEE30jrOKA=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed4a395ea001367c1f13d34b1e01aa10290f67d6",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-    ghc-wasm.url = "git+https://gitlab.haskell.org/ghc/ghc-wasm-meta?ref=refs/heads/master&rev=a9102d59d00bc87550dda902c8084a74f9742c00";
+    ghc-wasm.url = "git+https://gitlab.haskell.org/ghc/ghc-wasm-meta";
   };
 
   outputs = inputs@ { flake-parts, ... }:

--- a/primer-miso/primer-miso.cabal
+++ b/primer-miso/primer-miso.cabal
@@ -51,7 +51,7 @@ library
     , jsaddle         ^>=0.9.9.2
     , jsaddle-dom     ^>=0.9.9.2
     , linear          ^>=1.23
-    , miso            ^>=1.8.5.0
+    , miso            ^>=1.8.7.0
     , mtl             >=2.2.2    && <2.4.0
     , optics          >=0.4      && <0.5.0
     , primer          ^>=0.7.2
@@ -59,7 +59,7 @@ library
     , uniplate        >=1.6      && <1.7.0
 
   if arch(wasm32)
-    build-depends: jsaddle-wasm ^>=0.0.1.0
+    build-depends: jsaddle-wasm
 
   else
     build-depends:
@@ -93,7 +93,7 @@ executable primer-miso
 
   if arch(wasm32)
     build-depends:
-      , ghc-experimental  ^>=0.1.0.0
+      , ghc-experimental
       , jsaddle-wasm
 
     ghc-options:


### PR DESCRIPTION
Note that this also bumps `primer-miso` to the latest (1.8.7.0). 

We did have to un-pin `experimental` and `jsaddle-wasm` to get this working, however. Hopefully that's temporary until we have proper upstream GHC Wasm releases.