### PR TITLE
fix: bump `ghc-wasm` flake to fix `wizer`

### DIFF
--- a/.buildkite/primer-wasm.yaml
+++ b/.buildkite/primer-wasm.yaml
@@ -19,6 +19,7 @@ steps:
       build.pull_request.labels includes "Run Wasm tests"
     command: |
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 frontend-prod
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 test
 
   - label: ":haskell: :macos: Primer Wasm tests"
@@ -27,6 +28,7 @@ steps:
       build.pull_request.labels includes "Run Wasm tests"
     command: |
       nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 update
+      nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 frontend-prod
       nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 test
     agents:
       os: "darwin"
@@ -37,7 +39,7 @@ steps:
       !(build.pull_request.labels includes "Run Wasm tests")
     command: |
       nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
-      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32
+      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 frontend-prod
 
   - label: ":haskell: :macos: Primer Wasm build"
     if: |
@@ -45,6 +47,6 @@ steps:
       !(build.pull_request.labels includes "Run Wasm tests")
     command: |
       nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 update
-      nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32
+      nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 frontend-prod
     agents:
       os: "darwin"

--- a/.buildkite/primer-wasm.yaml
+++ b/.buildkite/primer-wasm.yaml
@@ -26,8 +26,8 @@ steps:
       build.branch =~ /^gh-readonly-queue\// ||
       build.pull_request.labels includes "Run Wasm tests"
     command: |
-      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
-      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 test
+      nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 update
+      nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 test
     agents:
       os: "darwin"
 
@@ -44,7 +44,7 @@ steps:
       build.branch !~ /^gh-readonly-queue\// &&
       !(build.pull_request.labels includes "Run Wasm tests")
     command: |
-      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32 update
-      nix develop .#wasm --print-build-logs --command make -f Makefile.wasm32
+      nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32 update
+      nix develop --no-sandbox .#wasm --print-build-logs --command make -f Makefile.wasm32
     agents:
       os: "darwin"

--- a/flake.lock
+++ b/flake.lock
@@ -241,11 +241,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743018267,
-        "narHash": "sha256-f+egD12IqvYSI1FNB02ETSodqUwn449gapCwTaQhEz0=",
+        "lastModified": 1746131777,
+        "narHash": "sha256-Tktjxb3hXyXcYwT6othEJH2ja45jMI/4N/9Cdju6t2Y=",
         "ref": "refs/heads/master",
-        "rev": "1e2e05f23be5c2280f2f86af2f4a5b548f0db45f",
-        "revCount": 250,
+        "rev": "694c011879c4630dfcbcea52c6c0a06404061a9b",
+        "revCount": 289,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
       },
@@ -702,11 +702,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The version of `wizer` pulled in by this updated `ghc-wasm` flake supports tail calls, which we now need.

(This `ghc-wasm` flake version breaks the Wasm build on macOS, or at least it does on macOS 15.4.1, but we'll just have to deal with the breakage for now, as the need for the updated `wizer` overrides a working macOS build.