### PR TITLE
Improve Miso string performance

### DIFF
--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -586,28 +586,29 @@ viewNodeData position dimensions edges node = case node.opts of
           Clay.width $ Clay.px $ realToClay dimensions.x
           Clay.height $ Clay.px $ realToClay dimensions.y
       ]
-  _ -> div_
-    ( [ class_
-      . mconcat
-      . intersperse " "
-      $ [ "node"
-        , case node.level of
-            Expr -> "expr"
-            Type -> "type"
-            Kind -> "kind"
-        , case node.opts of
-            SyntaxNode{} -> "syntax"
-            _ -> "non-syntax"
-        , case node.opts of
-            SyntaxNode{flavor} -> flavor
-            HoleNode{} -> "hole"
-            PrimNode{} -> "prim"
-            ConNode{} -> "con"
-            VarNode{} -> "var"
-            PatternBoxNode{} -> "pattern-box"
-        ]
-        <> mwhen node.selected ["selected"]
-        <> mwhen (isJust node.clickAction) ["selectable"]
+  _ ->
+    div_
+      ( [ class_
+            . mconcat
+            . intersperse " "
+            $ [ "node"
+              , case node.level of
+                  Expr -> "expr"
+                  Type -> "type"
+                  Kind -> "kind"
+              , case node.opts of
+                  SyntaxNode{} -> "syntax"
+                  _ -> "non-syntax"
+              , case node.opts of
+                  SyntaxNode{flavor} -> flavor
+                  HoleNode{} -> "hole"
+                  PrimNode{} -> "prim"
+                  ConNode{} -> "con"
+                  VarNode{} -> "var"
+                  PatternBoxNode{} -> "pattern-box"
+              ]
+              <> mwhen node.selected ["selected"]
+              <> mwhen (isJust node.clickAction) ["selectable"]
         , style_ $ clayToMiso do
             Clay.position Clay.absolute
             Clay.transform $

--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -586,23 +586,28 @@ viewNodeData position dimensions edges node = case node.opts of
           Clay.width $ Clay.px $ realToClay dimensions.x
           Clay.height $ Clay.px $ realToClay dimensions.y
       ]
-  _ ->
-    div_
-      ( [ class_ "node"
-        , class_ case node.level of
+  _ -> div_
+    ( [ class_
+      . mconcat
+      . intersperse " "
+      $ [ "node"
+        , case node.level of
             Expr -> "expr"
             Type -> "type"
             Kind -> "kind"
-        , class_ case node.opts of
+        , case node.opts of
             SyntaxNode{} -> "syntax"
             _ -> "non-syntax"
-        , class_ case node.opts of
+        , case node.opts of
             SyntaxNode{flavor} -> flavor
             HoleNode{} -> "hole"
             PrimNode{} -> "prim"
             ConNode{} -> "con"
             VarNode{} -> "var"
             PatternBoxNode{} -> "pattern-box"
+        ]
+        <> mwhen node.selected ["selected"]
+        <> mwhen (isJust node.clickAction) ["selectable"]
         , style_ $ clayToMiso do
             Clay.position Clay.absolute
             Clay.transform $
@@ -610,8 +615,7 @@ viewNodeData position dimensions edges node = case node.opts of
                 (Clay.px $ realToClay position.x)
                 (Clay.px $ realToClay position.y)
         ]
-          <> foldMap' (\a -> [onClick a, class_ "selectable"]) node.clickAction
-          <> mwhen node.selected [class_ "selected"]
+          <> foldMap' (pure . onClick) node.clickAction
       )
       $ edges -- Edges come first so that they appear behind contents.
         <> [ div_


### PR DESCRIPTION
I noticed that rendering performance was surprisingly slow with large trees, and that it scaled linearly with the number of `class_` attributes (around 1ms each).

The first commit is really a leftover from a first attempt at solving it. Unfortunately there was no noticeable impact on performance, even with Miso bumped to a version which uses `JSString` on Wasm instead of `Text`. But there's no harm in keeping it around now that the work has been done. It will be required eventually, and would probably become difficult to merge if left on a separate branch.

The second commit actually solves the problem. I'm still investigating exactly why Miso is so slow without this fix.