### PR TITLE
Add UI for editing type definitions

### DIFF
--- a/primer-miso/frontend/style.css
+++ b/primer-miso/frontend/style.css
@@ -189,6 +189,35 @@ body {
   }
 }
 
+#params,
+#cons {
+  > * {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    > .param-name,
+    .con-name {
+      width: 100%;
+      text-align: center;
+      padding: 0.8rem 0;
+      color: var(--blue-primary);
+      &:hover {
+        color: var(--white-primary);
+        background-color: var(--blue-secondary);
+      }
+      &.selected {
+        color: var(--white-primary);
+        background-color: var(--blue-primary);
+      }
+    }
+    > .con-fields {
+      width: 100%;
+      display: flex;
+      justify-content: space-evenly;
+    }
+  }
+}
+
 .tree {
   padding: 0.625rem;
 }

--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -79,6 +79,11 @@ import Primer.App (
   NodeType (BodyNode, SigNode),
   ProgError (ActionError),
   Selection' (SelectionDef, SelectionTypeDef),
+  TypeDefConsFieldSelection (..),
+  TypeDefConsSelection (..),
+  TypeDefNodeSelection (..),
+  TypeDefParamSelection (..),
+  TypeDefSelection (..),
   appIdCounter,
   appNameCounter,
   appProg,
@@ -86,6 +91,7 @@ import Primer.App (
   newApp,
   progAllDefs,
   progAllTypeDefs,
+  progAllTypeDefsMeta,
   progSelection,
  )
 import Primer.App qualified
@@ -143,17 +149,20 @@ import Primer.Miso.Layout (
  )
 import Primer.Miso.Util (
   ASTDefT (expr, sig),
-  DefSelectionT,
   P2,
+  SelectionT,
   TermMeta',
   assumeDefHasTypeCheckInfo,
   assumeDefSelectionHasTypeCheckInfo,
+  assumeTypeDefHasTypeCheckInfo,
+  assumeTypeDefSelectionHasTypeCheckInfo,
   astDefTtoAstDef,
+  astTypeDefTtoAstTypeDef,
   availableForSelection,
   bindingsInExpr,
   bindingsInType,
   clayToMiso,
-  findASTDef,
+  findASTTypeOrTermDef,
   kindsInType,
   nodeSelectionType,
   optToName,
@@ -161,7 +170,6 @@ import Primer.Miso.Util (
   realToClay,
   runMutationWithNullDb,
   runTC,
-  selectedDefName,
   setSelectionAction,
   showMs,
   startAppWithSavedState,
@@ -169,6 +177,7 @@ import Primer.Miso.Util (
   typeBindingsInExpr,
  )
 import Primer.Name (Name, NameCounter, unName)
+import Primer.TypeDef (ASTTypeDef (..), TypeDef (TypeDefAST), ValCon (..), forgetTypeDefMetadata, typeDefAST, typeDefKind)
 import Primer.Typecheck (SmartHoles (SmartHoles), buildTypingContext, exprTtoExpr, typeTtoType)
 
 start :: JSM ()
@@ -224,7 +233,7 @@ start =
 
 data Model = Model
   { app :: Primer.App.App
-  , readOnlySelection :: Maybe DefSelectionT
+  , readOnlySelection :: Maybe SelectionT
   -- ^ A non-editable def is being viewed (e.g. from an imported module), rather than the selection in `app`.
   , components :: ComponentModels
   }
@@ -270,7 +279,7 @@ data EvalOpts = EvalOpts
 
 data Action
   = NoOp MisoString -- For situations where Miso requires an action, but we don't actually want to do anything.
-  | Select Editable DefSelectionT
+  | Select Editable SelectionT
   | ShowActionOptions (Available.InputAction, Available.Options)
   | ApplyAction (Either Available.NoInputAction (Available.InputAction, Available.Option))
   | CancelActionInput
@@ -299,21 +308,17 @@ updateModel =
     ApplyAction actionAndOpts -> do
       prog <- appProg <$> use #app
       let defs = progAllDefs prog
+          tydefs = progAllTypeDefsMeta prog
       -- TODO handle errors properly, not just `Either MisoString`
       actionResult <- runExceptT do
         sel <- liftEither $ maybeToEither (Left "no selection for action") $ progSelection prog
-        defName <-
-          liftEither
-            . first (const $ Left "unexpected type def selection")
-            . either Right Left
-            $ selectedDefName sel
         (_editable, def) <-
           liftEither
-            . first (Left . ("findASTDef failure in runAction: " <>) . ms)
-            $ findASTDef defs defName
+            . first (Left . ("findASTDef failure in runAction: " <>))
+            $ findASTTypeOrTermDef tydefs defs sel
         liftEither $ first (Right . ActionError) case actionAndOpts of
-          Left action -> toProgActionNoInput (snd <$> defs) (Right def) (getID <$> sel) action
-          Right (action, opt) -> toProgActionInput (Right def) (getID <$> sel) opt action
+          Left action -> toProgActionNoInput (snd <$> defs) def (getID <$> sel) action
+          Right (action, opt) -> toProgActionInput def (getID <$> sel) opt action
       case actionResult of
         Right actions -> runMutation $ Edit actions
         Left e -> scheduleIO_ $ consoleLog $ "running action failed: " <> either identity showMs e
@@ -439,11 +444,20 @@ viewModel Model{..} =
           [id_ "def-panel"]
           let
             viewDef def editable =
-              let s = DefSelection def Nothing
+              let s = SelectionDef $ DefSelection def Nothing
                in button_
                     [ class_ $ mwhen (Just s == maybeDefSel) "selected"
                     , class_ $ mwhen (editable == NonEditable) "read-only"
                     , onClick $ Select editable s
+                    ]
+                    [text $ ms $ globalNamePretty def]
+            viewTypeDef def editable =
+              let s = SelectionTypeDef $ TypeDefSelection def Nothing
+               in button_
+                    [ class_ $ mwhen (Just s == maybeDefSel) "selected"
+                    , class_ $ mwhen (editable == NonEditable) "read-only"
+                    , onClick $ Select editable s
+                    , class_ "type"
                     ]
                     [text $ ms $ globalNamePretty def]
             (editableDefs, nonEditableDefs) =
@@ -452,56 +466,149 @@ viewModel Model{..} =
                 . map fst
                 . Map.mapMaybe (traverse defAST)
                 $ progAllDefs prog
+            (editableTypeDefs, nonEditableTypeDefs) =
+              partition ((== Editable) . snd)
+                . Map.toList
+                . map fst
+                . Map.mapMaybe (traverse typeDefAST)
+                $ progAllTypeDefs prog
            in
             mconcat
-              [ uncurry viewDef <$> editableDefs
+              [ uncurry viewTypeDef <$> editableTypeDefs
+              , uncurry viewDef <$> editableDefs
+              , uncurry viewTypeDef <$> nonEditableTypeDefs
               , uncurry viewDef <$> nonEditableDefs
               ]
       ]
       <> case maybeDefSel of
         Nothing -> [text "no selection"]
-        Just defSel ->
-          [ div_
-              [ id_ "sig"
-              ]
-              [ fst
-                  . viewTree
-                  $ viewTreeType
-                    ( mkMetaSelectable $
-                        DefSelection defSel.def
-                          . Just
-                          . NodeSelection SigNode
-                          . Right
-                    )
-                    def.sig
-              ]
-          , div_
-              [ id_ "body"
-              ]
-              [ fst
-                  . viewTree
-                  $ viewTreeExpr
-                    ( mkMetaSelectable $
-                        DefSelection defSel.def
-                          . Just
-                          . NodeSelection BodyNode
-                    )
-                    def.expr
-              ]
+        Just sel ->
+          [ case selAndDef of
+              Left (sel', ASTTypeDef{astTypeDefParameters}) ->
+                div_ [id_ "params"] $
+                  astTypeDefParameters <&> \(paramName, paramKind) ->
+                    div_
+                      []
+                      [ div_
+                          ( let s =
+                                  SelectionTypeDef
+                                    . TypeDefSelection sel'.def
+                                    . Just
+                                    . TypeDefParamNodeSelection
+                                    $ TypeDefParamSelection paramName Nothing
+                             in [ onClick $ Select editable s
+                                , class_ "param-name"
+                                ]
+                                  <> mwhen (sel == s) [class_ "selected"]
+                          )
+                          [text $ ms $ unName $ unLocalName paramName]
+                      , fst
+                          . viewTree
+                          $ viewTreeKind
+                            ( mkMetaSelectable $
+                                SelectionTypeDef
+                                  . TypeDefSelection sel'.def
+                                  . Just
+                                  . TypeDefParamNodeSelection
+                                  . TypeDefParamSelection paramName
+                                  . Just
+                                  . Right
+                                  . Right
+                            )
+                            paramKind
+                      ]
+              Right (sel', def) ->
+                div_
+                  [ id_ "sig"
+                  ]
+                  [ fst
+                      . viewTree
+                      $ viewTreeType
+                        ( mkMetaSelectable $
+                            SelectionDef
+                              . DefSelection sel'.def
+                              . Just
+                              . NodeSelection SigNode
+                              . Right
+                        )
+                        def.sig
+                  ]
+          , case selAndDef of
+              Left (sel', ASTTypeDef{astTypeDefConstructors}) ->
+                div_ [id_ "cons"] $
+                  astTypeDefConstructors <&> \ValCon{valConName, valConArgs} ->
+                    div_
+                      []
+                      [ div_
+                          ( let s =
+                                  SelectionTypeDef
+                                    . TypeDefSelection sel'.def
+                                    . Just
+                                    . TypeDefConsNodeSelection
+                                    $ TypeDefConsSelection valConName Nothing
+                             in [ onClick $ Select editable s
+                                , class_ "con-name"
+                                ]
+                                  <> mwhen (sel == s) [class_ "selected"]
+                          )
+                          [text $ ms $ unName $ baseName valConName]
+                      , div_ [class_ "con-fields"] $
+                          zip [0 ..] valConArgs <&> \(valConIndex, conArgType) ->
+                            fst
+                              . viewTree
+                              $ viewTreeType
+                                ( mkMetaSelectable $
+                                    SelectionTypeDef
+                                      . TypeDefSelection sel'.def
+                                      . Just
+                                      . TypeDefConsNodeSelection
+                                      . TypeDefConsSelection valConName
+                                      . Just
+                                      . TypeDefConsFieldSelection valConIndex
+                                      . Right
+                                )
+                                conArgType
+                      ]
+              Right (sel', def) ->
+                div_
+                  [ id_ "body"
+                  ]
+                  [ fst
+                      . viewTree
+                      $ viewTreeExpr
+                        ( mkMetaSelectable $
+                            SelectionDef
+                              . DefSelection sel'.def
+                              . Just
+                              . NodeSelection BodyNode
+                        )
+                        def.expr
+                  ]
           , div_
               [ id_ "selection-type"
               ]
-              [ fst $ viewTree case defSel.node of
-                  Nothing -> viewTreeType mkMeta $ forgetTypeMetadata def.sig
-                  Just s -> case nodeSelectionType s of
-                    Left t -> viewTreeType mkMeta t
-                    Right (Left t) -> viewTreeKind mkMeta t
-                    -- TODO this isn't really correct - kinds in Primer don't have kinds
-                    Right (Right ()) -> viewTreeKind mkMeta $ KType ()
+              [ let mkMeta = const (Nothing, Nothing, NoHighlight)
+                    metaToTree = \case
+                      Left t -> viewTreeType mkMeta t
+                      Right (Left t) -> viewTreeKind mkMeta t
+                      -- TODO this isn't really correct - kinds in Primer don't have kinds
+                      Right (Right ()) -> viewTreeKind mkMeta $ KType ()
+                 in case selAndDef of
+                      Right (DefSelection{node}, def) -> fst $ viewTree case node of
+                        Nothing -> viewTreeType mkMeta $ forgetTypeMetadata def.sig
+                        Just s -> metaToTree $ nodeSelectionType s.meta
+                      Left (TypeDefSelection{def = defName, node}, def) -> fst $ viewTree case node of
+                        Nothing -> viewTreeKind mkMeta $ typeDefKind $ forgetTypeDefMetadata $ TypeDefAST def
+                        Just (TypeDefParamNodeSelection (TypeDefParamSelection{kindMeta})) -> case kindMeta of
+                          Nothing -> viewTreeType @() @() mkMeta $ TCon () defName
+                          Just m -> metaToTree $ nodeSelectionType m
+                        Just (TypeDefConsNodeSelection (TypeDefConsSelection{field})) -> case field of
+                          Nothing -> viewTreeType @() @() mkMeta $ TCon () defName
+                          Just m -> metaToTree $ nodeSelectionType m.meta
               ]
           , div_ [id_ "action-panel"] case components.actionPanel.optionsMode of
               Nothing ->
-                availableForSelection tydefs defs level editable def' defSel <&> \action ->
+                availableForSelection tydefs defs level editable def sel <&> \action ->
                   button_
                     [ onClick case action of
                         Available.NoInput a -> ApplyAction $ Left a
@@ -514,8 +621,8 @@ viewModel Model{..} =
                                   defs
                                   (buildTypingContext tydefs defs SmartHoles)
                                   level
-                                  (Right def')
-                                  (SelectionDef $ getID <$> defSel)
+                                  def
+                                  (getID <$> sel)
                                   a
                             )
                     ]
@@ -524,7 +631,7 @@ viewModel Model{..} =
                         Available.Input a -> showMs a
                     ]
                 where
-                  def' = astDefTtoAstDef def
+                  def = bimap (astTypeDefTtoAstTypeDef . snd) (astDefTtoAstDef . snd) selAndDef
                   level = Primer.App.Expert -- TODO don't hardcode
               Just (action, opts) ->
                 ( case opts.free of
@@ -613,17 +720,23 @@ viewModel Model{..} =
                             )
           ]
           where
-            mkMeta = const (Nothing, Nothing, NoHighlight)
             defsWithEditable = progAllDefs prog
-            tydefsWithEditable = progAllTypeDefs prog
+            tydefsWithEditable = second forgetTypeDefMetadata <$> tydefsWithEditableMeta
+            tydefsWithEditableMeta = progAllTypeDefsMeta prog
             defs = snd <$> defsWithEditable
             tydefs = snd <$> tydefsWithEditable
-            (editable, def) = second getDef . fromMaybe (error "selected def not found") $ defsWithEditable !? defSel.def
+            (editable, selAndDef) = case sel of
+              SelectionTypeDef sel'@TypeDefSelection{def = d} ->
+                second (Left . (sel',) . getTypeDef) . fromMaybe (error "selected def not found") $
+                  tydefsWithEditableMeta !? d
+              SelectionDef sel'@DefSelection{def = d} ->
+                second (Right . (sel',) . getDef) . fromMaybe (error "selected def not found") $
+                  defsWithEditable !? d
             mkMetaSelectable mkSel m =
               let s = mkSel m
                in ( Just $ getID m
                   , Just $ Select editable s
-                  , if defSel == s then SimpleHighlight else NoHighlight
+                  , if sel == s then SimpleHighlight else NoHighlight
                   )
   where
     prog = appProg app
@@ -633,9 +746,13 @@ viewModel Model{..} =
       fromMaybe (error "selected def is not fully typechecked")
         . maybe (error "unexpected primitive def") assumeDefHasTypeCheckInfo
         . defAST
+    getTypeDef =
+      fromMaybe (error "selected typedef is not fully typechecked")
+        . maybe (error "unexpected primitive typedef") assumeTypeDefHasTypeCheckInfo
+        . typeDefAST
     getSelection = \case
-      SelectionTypeDef _ -> error "unexpected type def selection"
-      SelectionDef d -> fromMaybe (error "no TC info in selection") $ assumeDefSelectionHasTypeCheckInfo d
+      SelectionTypeDef d -> SelectionTypeDef $ fromMaybe (error "no TC info in selection") $ assumeTypeDefSelectionHasTypeCheckInfo d
+      SelectionDef d -> SelectionDef $ fromMaybe (error "no TC info in selection") $ assumeDefSelectionHasTypeCheckInfo d
 
 -- TODO `isNothing clickAction` implies `highlight == NoHighlight`, and `isNothing id` iff `isNothing clickAction`
 -- we could model this better, but in the long run, we intend to have no unselectable nodes anyway

--- a/primer-miso/src/Primer/Miso/Util.hs
+++ b/primer-miso/src/Primer/Miso/Util.hs
@@ -33,6 +33,7 @@ module Primer.Miso.Util (
   DefSelectionT,
   realToClay,
   availableForSelection,
+  setSelectionAction,
   astDefTtoAstDef,
   optToName,
   stringToOpt,
@@ -83,6 +84,7 @@ import Optics (
  )
 import Optics.State.Operators ((<<%=))
 import Primer.API (APILog, Env (Env), edit, runPrimerM)
+import Primer.Action (ProgAction (MoveToDef), setCursorBody, setCursorSig)
 import Primer.Action.Available (Action)
 import Primer.Action.Available qualified as Available
 import Primer.App (
@@ -334,6 +336,13 @@ availableForSelection tydefs defs level editable def defSel = case defSel.node o
   Just nodeSel -> case nodeSel.nodeType of
     BodyNode -> Available.forBody tydefs level editable (astDefExpr def) (getID nodeSel)
     SigNode -> Available.forSig level editable (astDefType def) (getID nodeSel)
+
+setSelectionAction :: DefSelectionT -> ProgAction
+setSelectionAction sel = case sel.node of
+  Nothing -> MoveToDef sel.def
+  Just sel' -> case sel'.nodeType of
+    BodyNode -> setCursorBody $ getID sel'
+    SigNode -> setCursorSig $ getID sel'
 
 -- this part of the actions API needs a re-think
 -- (it was perhaps too motivated by what was convenient for our old TypeScript frontend):

--- a/primer/src/Primer/Action.hs
+++ b/primer/src/Primer/Action.hs
@@ -25,6 +25,8 @@ module Primer.Action (
   insertSubseqBy,
   setCursorBody,
   setCursorSig,
+  setCursorTypeDefParamKind,
+  setCursorTypeDefConField,
 ) where
 
 import Foreword hiding (mod)
@@ -91,6 +93,7 @@ import Primer.Core (
   Pattern (PatCon, PatPrim),
   PrimCon (PrimChar, PrimInt),
   TmVarRef (..),
+  TyConName,
   TyVarName,
   Type,
   Type' (..),
@@ -1481,3 +1484,7 @@ setCursorBody :: ID -> ProgAction
 setCursorBody id = BodyAction [SetCursor id]
 setCursorSig :: ID -> ProgAction
 setCursorSig id = SigAction [SetCursor id]
+setCursorTypeDefParamKind :: TyConName -> TyVarName -> ID -> ProgAction
+setCursorTypeDefParamKind t v id = ParamKindAction t v [SetCursor id]
+setCursorTypeDefConField :: TyConName -> ValConName -> Int -> ID -> ProgAction
+setCursorTypeDefConField t v i id = ConFieldAction t v i [SetCursor id]

--- a/primer/src/Primer/Action/ProgAction.hs
+++ b/primer/src/Primer/Action/ProgAction.hs
@@ -29,6 +29,12 @@ data ProgAction
     CreateDef ModuleName (Maybe Text)
   | -- | Delete a new definition
     DeleteDef GVarName
+  | -- | Move the cursor to the type definition with the given name
+    MoveToTypeDef TyConName
+  | -- | Move the cursor to the type definition parameter with the given name
+    MoveToTypeDefParam TyConName TyVarName
+  | -- | Move the cursor to the constructor definition with the given name
+    MoveToTypeDefCon TyConName ValConName
   | -- | Add a new type definition
     AddTypeDef TyConName (ASTTypeDef () ())
   | -- | Delete a type definition

--- a/primer/src/Primer/Action/ProgError.hs
+++ b/primer/src/Primer/Action/ProgError.hs
@@ -27,6 +27,7 @@ data ProgError
     -- - clash between parameter and constructor
     TypeDefModifyNameClash Name
   | TypeParamInUse TyConName TyVarName
+  | TypeParamNotFound TyVarName
   | ConNotFound ValConName
   | ConAlreadyExists ValConName
   | -- | We expected to see more arguments to a constructor than actually existed

--- a/primer/src/Primer/App/Base.hs
+++ b/primer/src/Primer/App/Base.hs
@@ -62,7 +62,7 @@ data Level
   deriving (FromJSON, ToJSON) via PrimerJSON Level
 
 data Editable = Editable | NonEditable
-  deriving stock (Bounded, Enum, Show)
+  deriving stock (Eq, Bounded, Enum, Show)
 
 data NodeType = BodyNode | SigNode
   deriving stock (Eq, Show, Read, Bounded, Enum, Generic, Data)


### PR DESCRIPTION
After #1351, ~~which this is based on top of,~~ this is the final major feature for the new frontend. We can now build any program!

UI is again proof-of-concept, but I don't expect to make major changes there for now. In fact, I think that while it's hardly intuitive in its current form (better labels would help for a start, but this is true for much of the current UI), this is the direction we should be heading in. The choice we've made to only show one definition at a time frees us from worrying about showing the whole type definition as connected, which was always a bit weird in the React frontend. So we now get back some of the clarity of the form-based UI we had in our PureScript frontend, but with the ability to actually create arbitrarily-complex type defs (the fully form-based approach was never going to generalise properly, as I argued a lot back in the day).

~~Code needs some fairly minor tidying up, which will be done once #1351 is merged.~~

Two bugs:
- Selecting a kind node in a constructor field type causes the root node to be selected. This must be an issue with the core library, since it's actually present in the old frontend, though I'd never noticed it before now. I am a bit surprised this isn't caught be some property test along the lines of "perform the action to select a node; that node is now selected", but perhaps this is harder to test for than it sounds. I noticed the issue from absent-mindedly clicking around, though it is arguably pretty obscure in practice, since selecting such a node implies that one probably wishes to edit the kind, and therefore is constructing a type definition which involves quantifying over a higher-kinded type variable. Probably the _simplest_ use case for this is defining monad transformers, which I don't think anyone has attempted in Primer. (Triggering this in the old frontend is even more obscure because selection changes aren't sent to the backend, so whatever buggy Haskell code sets the selection isn't triggered until an actual kind edit is performed.)
- Performing actions which require user input (add param, add constructor, or construct forall) can cause the whole app to crash and need a refresh. The console shows `[WASI stdout] A JavaScript exception was thrown! (may not reach Haskell code)` and `[WASI stdout] TypeError: jsaddle_values.get(...) is undefined`. This happens around half the time, in my experience, and I've detected no clear pattern as to when it does. It's really quite an odd bug. The code handling the input form is very simple, with no obvious explanation for how it can be non-deterministic, or why I've never seen the error with non-type definitions. Anyway, I suspect this doesn't stem from the changes in this PR either, and is a library or compiler issue (I can't really find any relevant issues anywhere, but [this](https://github.com/ghcjs/jsaddle/commit/b8e9793455562e3f30f45f9e311443a76ea1dc4f) is the closest). I'd suggest bumping Miso and/or our Wasm GHC to see whether that makes a difference. I haven't seen anything like this on other projects, where I've mostly been using more recent development versions of Miso.

Some examples:
![Screenshot From 2025-06-02 11-24-23](https://github.com/user-attachments/assets/125d2bbc-fd5a-4069-bcfa-393fbee0d48d)
![Screenshot From 2025-06-02 11-25-02](https://github.com/user-attachments/assets/bbc4fce2-b0c5-4506-bd51-a6f1d4c7c01b)
![image](https://github.com/user-attachments/assets/c66777a6-b0f4-4f60-9580-ded909cba2e0)


Note that seeing as we don't actually have buttons for adding definitions yet, I had to add this temporary code in order to get one to play around with:
```diff
diff --git a/primer-miso/src/Primer/Miso.hs b/primer-miso/src/Primer/Miso.hs
index 8ddb47a7..0327f592 100644
--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -230,7 +230,7 @@ start =
             }
       , update = updateModel
       , view = viewModel
-      , subs = []
+      , subs = pure \s -> liftIO $ s $ ApplyProgAction $ AddTypeDef (Primer.qualifyName (Primer.mkSimpleModuleName "Main") "T") $ ASTTypeDef [] [] []
       , events = defaultEvents
       , initialAction = NoOp "start"
       , mountPoint = Nothing
@@ -299,10 +299,12 @@ data Action
   | ToggleFullscreenEval
   | ChooseRedex ID
   | StepBackEval
+  | ApplyProgAction ProgAction

 updateModel :: Action -> Model -> Effect Action Model
 updateModel =
   fromTransition . \case
+    ApplyProgAction action -> runMutation (Edit [action]) >> resetActionPanel
     NoOp _ -> pure ()
     SelectDef d -> do
       #readOnlySelection .= Nothing
```