### PR TITLE
feat(primer-miso): request fullscreen mode when expanding eval window

### DIFF
--- a/primer-miso/src/Primer/Miso.hs
+++ b/primer-miso/src/Primer/Miso.hs
@@ -154,12 +154,14 @@ import Primer.Miso.Util (
   bindingsInExpr,
   bindingsInType,
   clayToMiso,
+  exitFullscreen,
   findASTDef,
   kindsInType,
   nodeSelectionType,
   optToName,
   readMs,
   realToClay,
+  requestFullscreen,
   runMutationWithNullDb,
   runTC,
   selectedDefName,
@@ -333,7 +335,14 @@ updateModel =
     SetEvalOpts f -> do
       #components % #eval % #opts %= f
       setEval
-    ToggleFullscreenEval -> #components % #eval % #fullscreen %= not
+    ToggleFullscreenEval -> do
+      #components % #eval % #fullscreen %= not
+      fs' <- use $ #components % #eval % #fullscreen
+      scheduleIO_ $
+        void
+          if fs'
+            then requestFullscreen
+            else exitFullscreen
   where
     -- TODO the only part of this that should really require `IO` is writing to a database
     -- (currently we use `NullDb` anyway but this will change)

--- a/primer-miso/src/Primer/Miso/Util.hs
+++ b/primer-miso/src/Primer/Miso/Util.hs
@@ -7,6 +7,8 @@
 
 -- | Things which should really be upstreamed rather than living in this project.
 module Primer.Miso.Util (
+  requestFullscreen,
+  exitFullscreen,
   startAppWithSavedState,
   showMs,
   readMs,
@@ -57,6 +59,7 @@ import Data.Map qualified as Map
 import Data.String (String)
 import Data.UUID.Types qualified as UUID
 import GHC.Base (error)
+import Language.Javascript.JSaddle qualified as JS
 import Linear (Additive, R1 (_x), R2 (_y), V2, zero)
 import Linear.Affine (Point (..), unP)
 import Miso (
@@ -133,6 +136,11 @@ import Primer.Name (Name, NameCounter)
 import Primer.TypeDef (TypeDefMap)
 import Primer.Typecheck (ExprT, exprTtoExpr, typeTtoType)
 import StmContainers.Map qualified as StmMap
+
+requestFullscreen :: JSM JS.JSVal
+requestFullscreen = JS.eval ("document.documentElement.requestFullscreen()" :: MisoString)
+exitFullscreen :: JSM JS.JSVal
+exitFullscreen = JS.eval ("document.exitFullscreen()" :: MisoString)
 
 {- Miso -}
 


### PR DESCRIPTION
This is something which I utilised as part of #1350 when testing on mobile. It was handy, for gaining a bit of extra screen space, but it's less of an uncontroversially good idea than those other changes. So I'm just stashing it here as a curiosity to potentially revisit at some point.

- [ ] We should really separate the notions of "eval takes up whole app" and "app is actually fullscreen". Those are conflated here. For the latter we should also handle browser events, i.e. that the user can exit fullscreen without using Primer UI (e.g. `esc` key, in Firefox at least).
- [ ] The JSaddle code isn't very idiomatic, and has no error handling.
- [ ] In an ideal world, this wouldn't be needed at all, and mobile browsers would just have a generic option for this, like pressing f11 on desktop. To my surprise, only Opera Mini appears to have this, and even there it's clunky.