### PR TITLE
chore(nix): bump dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -169,11 +169,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1753121425,
+        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1753121425,
+        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1752452932,
-        "narHash": "sha256-gqB0sEfoJHUj42D2OswbRLqwYUyuXrM52e8wzlFz57Y=",
+        "lastModified": 1753749008,
+        "narHash": "sha256-u1Y3TMgS+eOvZSZP6PZP+ZgAjNglmyMI40DM5sfM4Bg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "86294b3df3d5094f981437018478e37bb24fff7e",
+        "rev": "44a3cfa36baddd4d6c97be3ac3304f3e5751c1d2",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1752452922,
-        "narHash": "sha256-1uobqUVkpqqDXlt+b1TXITgHapw/xggplHvwpSVwpzQ=",
+        "lastModified": 1753748998,
+        "narHash": "sha256-9WDGOgV4EzSJ6CoRojz6G6/7i0CUJmV2JfkVQ+/9NDg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "9fb6712285ad1af31dd2a626cbebbdf0dd2a785e",
+        "rev": "17af65c0d89484e303282b233baf275217caf5ac",
         "type": "github"
       },
       "original": {
@@ -376,11 +376,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1752490838,
-        "narHash": "sha256-7Lk2DXS2FCpb4ghi8+MqeidVHBcC5ivnNBtSjfJIT4Y=",
+        "lastModified": 1753536862,
+        "narHash": "sha256-MA9qFnF2RIxtlX2pXcqJA0ws1jkqGXxTSlmLSs1XLgQ=",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "9b4e2806167ef5e806b70599ca849776c75a4422",
+        "rev": "eea3927d96871fa5ec2088a65e8ace1c94bca394",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1752454316,
-        "narHash": "sha256-TSYAd/ySF/zm+gEnr2xeIlZ/HSpHvc1TYDaQZWyze/0=",
+        "lastModified": 1753750353,
+        "narHash": "sha256-6QMY5hsY/tVuLo+cc0GZOfshFLC4uGzNR3bMAqsVnOA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "19ff56a902b173be9589166d8ea4ccc538b8ca78",
+        "rev": "f7b3cfeb37901101479c34aaf34ce104039eaa4d",
         "type": "github"
       },
       "original": {
@@ -976,11 +976,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1752365727,
-        "narHash": "sha256-ISUg2c+vhozELEZgv4gTpju1HpDsZfqCN2S4IsJ/FJY=",
+        "lastModified": 1753748130,
+        "narHash": "sha256-ctCmxiXsjHSDSsoszjhWXxRvwXVkj3GdDvMuvgesRRs=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "d79f5705ed3d40e6702eef1f3b75676d858e5f1a",
+        "rev": "d47a06c64176504bc8c25a5d622ac64898552c73",
         "type": "github"
       },
       "original": {
@@ -1012,11 +1012,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752055615,
-        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "lastModified": 1753439394,
+        "narHash": "sha256-Bv9h1AJegLI8uAhiJ1sZ4XAndYxhgf38tMgCQwiEpmc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "rev": "2673921c03d6e75fdf4aa93e025772608d1482cf",
         "type": "github"
       },
       "original": {
@@ -1032,11 +1032,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752055615,
-        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "lastModified": 1753772294,
+        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -289,7 +289,7 @@
             };
 
           devShells = {
-            default = primerFlake.devShell // {
+            default = primerFlake.devShells.default // {
               inputsFrom = [
                 config.treefmt.build.devShell
               ];


### PR DESCRIPTION
Note that `primerFlake.devShell` is now `primerFlake.devShells.default`.